### PR TITLE
fix(auth): event readiness — Dynamic sign-out + OTP rate-limit copy

### DIFF
--- a/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/lesson-client.tsx
+++ b/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/lesson-client.tsx
@@ -728,6 +728,9 @@ export function LessonPageClient({
         <div className="flex min-w-0 flex-1 items-center gap-2 sm:gap-3">
           <Link
             href={`${linkBase}/${courseSlug}`}
+            // Below sm the text label is display:none, which drops it from the
+            // a11y tree — the aria-label keeps the link named on phones.
+            aria-label={tCommon("back")}
             className="inline-flex shrink-0 items-center gap-1.5 font-display text-sm font-semibold text-text-3 transition-colors hover:text-text"
           >
             <ArrowLeft size={16} weight="bold" />

--- a/apps/web/src/components/auth/dynamic-auth-handler.tsx
+++ b/apps/web/src/components/auth/dynamic-auth-handler.tsx
@@ -22,11 +22,13 @@ import { toMessageSigner } from "@/lib/dynamic/siws";
  *
  * Three jobs, in the order they occur:
  *
- * 1. **Device registration.** Completing the emailed link is not optional —
- *    Dynamic requires device registration for every headless integration, and
- *    a user who is mid-registration is blocked until the redirect is consumed.
- *    It runs first, and on every mount, because the learner arrives back on an
- *    arbitrary page with the token in the URL.
+ * 1. **Device registration.** OPTIONAL — off by default and only active when
+ *    the dashboard toggle enables it (per Dynamic's docs; an earlier reading
+ *    here claimed it was required). When it IS on, a returning learner on a
+ *    new device is blocked until the emailed link's redirect is consumed, so
+ *    the consumer runs first, on every mount — the learner arrives back on an
+ *    arbitrary page with the token in the URL. With the toggle off this
+ *    effect never matches and is inert.
  * 2. **Embedded wallet creation.** Unlike the legacy SDK's modal, the headless
  *    SDK does NOT create a wallet on sign-in; the account exists with no wallet
  *    until asked. Skipping this is why a learner would authenticate and then

--- a/apps/web/src/components/auth/dynamic-email-sign-in.tsx
+++ b/apps/web/src/components/auth/dynamic-email-sign-in.tsx
@@ -12,6 +12,19 @@ import {
 import { Button } from "@/components/ui/button";
 import { trackEvent } from "@/lib/analytics";
 
+/**
+ * Dynamic's OTP endpoints are rate-limited PER IP (10 req/min) — one venue
+ * NAT at an in-person event trips it long before any individual does. The SDK
+ * surfaces it inconsistently (status code or message), so detect broadly and
+ * show copy that says "wait a minute", not "wrong code".
+ */
+function isRateLimitError(err: unknown): boolean {
+  const status = (err as { status?: number; statusCode?: number }) ?? {};
+  if (status.status === 429 || status.statusCode === 429) return true;
+  const message = err instanceof Error ? err.message : String(err);
+  return /\b429\b|rate.?limit|too many/i.test(message);
+}
+
 const INPUT_CLASS =
   "h-12 w-full rounded-md border border-border bg-subtle px-3 text-sm text-text placeholder:text-text-3 focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary disabled:opacity-50";
 
@@ -137,7 +150,9 @@ export function DynamicEmailSignIn({ disabled }: { disabled: boolean }) {
             // in a state we didn't predict, and this console line is the only
             // way to tell those apart in the field.
             console.error("[DynamicEmailSignIn] verifyOTP failed:", err);
-            setError(t("otpInvalid"));
+            setError(
+              t(isRateLimitError(err) ? "otpRateLimited" : "otpInvalid")
+            );
           }
         }}
       >
@@ -205,7 +220,9 @@ export function DynamicEmailSignIn({ disabled }: { disabled: boolean }) {
           await sendEmailOTP({ email });
         } catch (err) {
           console.error("[DynamicEmailSignIn] sendEmailOTP failed:", err);
-          setError(t("emailSignInFailed"));
+          setError(
+            t(isRateLimitError(err) ? "otpRateLimited" : "emailSignInFailed")
+          );
         }
       }}
     >

--- a/apps/web/src/components/auth/user-menu.tsx
+++ b/apps/web/src/components/auth/user-menu.tsx
@@ -22,6 +22,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { createClient } from "@/lib/supabase/client";
+import { logoutDynamic } from "@/lib/dynamic/client";
 
 interface UserMenuProps {
   username: string;
@@ -49,6 +50,10 @@ export function UserMenu({
         // Wallet may already be disconnected — proceed with sign-out
       }
     }
+    // End the Dynamic session too — without this, promptless MPC signing lets
+    // the layout-level auth handler silently sign the learner back in on the
+    // next page load (see logoutDynamic).
+    await logoutDynamic();
     const supabase = createClient();
     await supabase.auth.signOut();
     window.location.href = `/${locale}`;

--- a/apps/web/src/lib/dynamic/client.ts
+++ b/apps/web/src/lib/dynamic/client.ts
@@ -49,6 +49,7 @@
 import {
   createDynamicClient,
   initializeClient,
+  logout,
   type DynamicClient,
 } from "@dynamic-labs-sdk/client";
 import { addWaasSolanaExtension } from "@dynamic-labs-sdk/solana/waas";
@@ -95,4 +96,24 @@ export function getDynamicClient(): DynamicClient | null {
   }
 
   return client;
+}
+
+/**
+ * Ends the Dynamic session, if there is one. Safe to call unconditionally
+ * from app-level sign-out.
+ *
+ * WHY THIS MUST BE PART OF SIGN-OUT: the Dynamic session survives a Supabase
+ * sign-out on its own, `DynamicAuthHandler` is mounted on every page, and MPC
+ * message-signing needs no user prompt — so a surviving session would silently
+ * re-run the SIWS bridge on the next page load and sign the learner straight
+ * back in. On a shared or borrowed device that makes sign-out meaningless.
+ * Dynamic's docs name `logout()` as the required way to end the session.
+ */
+export async function logoutDynamic(): Promise<void> {
+  if (!getDynamicClient()) return;
+  try {
+    await logout();
+  } catch {
+    // Best-effort: an already-dead session must never block app sign-out.
+  }
 }

--- a/apps/web/src/lib/dynamic/client.ts
+++ b/apps/web/src/lib/dynamic/client.ts
@@ -112,7 +112,14 @@ export function getDynamicClient(): DynamicClient | null {
 export async function logoutDynamic(): Promise<void> {
   if (!getDynamicClient()) return;
   try {
-    await logout();
+    // Race a deadline: on a flaky network a hung logout() would otherwise
+    // stall the whole sign-out (Supabase clear + redirect wait on this).
+    // Losing the race is fine — the redirect that follows reloads the app,
+    // and the next OTP send clears any straggler session anyway.
+    await Promise.race([
+      logout(),
+      new Promise<void>((resolve) => setTimeout(resolve, 2_500)),
+    ]);
   } catch {
     // Best-effort: an already-dead session must never block app sign-out.
   }

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -102,7 +102,8 @@
     "signInWithGoogle": "Sign in with Google",
     "useDifferentEmail": "Use a different email",
     "verifyCode": "Verify",
-    "walletConnected": "Wallet Connected"
+    "walletConnected": "Wallet Connected",
+    "otpRateLimited": "Too many sign-ups from this network — wait a minute and try again."
   },
   "landing": {
     "poweredBy": "Powered by",

--- a/apps/web/src/messages/es.json
+++ b/apps/web/src/messages/es.json
@@ -102,7 +102,8 @@
     "signInWithGoogle": "Iniciar sesión con Google",
     "useDifferentEmail": "Usar otro correo",
     "verifyCode": "Verificar",
-    "walletConnected": "Billetera Conectada"
+    "walletConnected": "Billetera Conectada",
+    "otpRateLimited": "Demasiados registros desde esta red — espera un minuto e inténtalo de nuevo."
   },
   "landing": {
     "poweredBy": "Con el apoyo de",

--- a/apps/web/src/messages/pt-BR.json
+++ b/apps/web/src/messages/pt-BR.json
@@ -102,7 +102,8 @@
     "signInWithGoogle": "Entrar com Google",
     "useDifferentEmail": "Usar outro e-mail",
     "verifyCode": "Verificar",
-    "walletConnected": "Carteira Conectada"
+    "walletConnected": "Carteira Conectada",
+    "otpRateLimited": "Muitos cadastros desta rede — aguarde um minuto e tente novamente."
   },
   "landing": {
     "poweredBy": "Com apoio de",


### PR DESCRIPTION
Two field-critical fixes for today's event plus two riders, all from the 13-08 review of the Dynamic integration.

**Sign-out bug (the real one):** app sign-out killed Supabase and wallet-adapter but never Dynamic. The Dynamic session survives, DynamicAuthHandler mounts on every page, and MPC signing is promptless — so the next page load silently re-signed the learner in. On borrowed/shared devices at an event that makes sign-out meaningless. Fix: `logoutDynamic()` helper (gate-aware, best-effort) called from the sign-out path; Dynamic's docs name `logout()` as the required session end.

**429 copy:** Dynamic's OTP endpoints allow 10 req/min per IP — a venue NAT trips this with a handful of concurrent sign-ups. Rate-limited sends/verifies now say 'too many sign-ups from this network — wait a minute' instead of the wrong-code message.

Riders: aria-label on the mobile lesson Back link (text label is display:none below sm, so the link announced as unnamed), and the device-registration comment corrected (docs: optional and off by default, not required).

Deliberately NOT touched: the speedrun deep-link serving all locales — that's the event configuration working as intended today; the en/es question is a post-event decision.