### PR TITLE
feat(auth): Continue with Google through Dynamic

### DIFF
--- a/apps/web/src/app/api/auth/dynamic/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/dynamic/__tests__/route.test.ts
@@ -87,14 +87,21 @@ let privateKey: CryptoKey;
 let ps256PrivateKey: CryptoKey;
 const fetchMock = vi.fn();
 
-/** The credential Dynamic emits for a completed Google sign-in. */
+/**
+ * The credential Dynamic emits for a completed Google sign-in, as observed in
+ * a LIVE sandbox token (2026-08-13): no `email` field — the address arrives
+ * only in `oauth_emails` (single element) and `oauth_username`. The SDK model
+ * claims `email` can be present; tests for that shape pass it explicitly.
+ */
 function googleCredential(overrides: Record<string, unknown> = {}) {
   return {
     id: GOOGLE_CREDENTIAL_ID,
     format: "oauth",
     oauth_provider: "google",
     oauth_account_id: "google-account-1",
-    email: EXISTING_EMAIL,
+    oauth_username: EXISTING_EMAIL,
+    oauth_display_name: "Existing User",
+    oauth_emails: [EXISTING_EMAIL],
     signInEnabled: true,
     ...overrides,
   };
@@ -486,10 +493,10 @@ describe("POST /api/auth/dynamic — email extraction", () => {
     expect(generateLink).not.toHaveBeenCalled();
   });
 
-  it("refuses an oauth credential carrying no email", async () => {
+  it("refuses an oauth credential carrying no email anywhere", async () => {
     const token = await signDynamicJwt({
       claims: {
-        verified_credentials: [googleCredential({ email: undefined })],
+        verified_credentials: [googleCredential({ oauth_emails: undefined })],
       },
     });
 
@@ -498,6 +505,24 @@ describe("POST /api/auth/dynamic — email extraction", () => {
     expect(res.status).toBe(403);
     await expect(res.json()).resolves.toEqual({
       error: "noVerifiedOauthEmail",
+    });
+  });
+
+  it("still accepts the SDK-model shape where the credential carries `email` itself", async () => {
+    const token = await signDynamicJwt({
+      claims: {
+        verified_credentials: [
+          googleCredential({ email: EXISTING_EMAIL, oauth_emails: undefined }),
+        ],
+      },
+    });
+
+    const res = await POST(dynamicRequest({ dynamicJwt: token }));
+
+    expect(res.status).toBe(200);
+    expect(generateLink).toHaveBeenCalledWith({
+      type: "magiclink",
+      email: EXISTING_EMAIL,
     });
   });
 
@@ -532,15 +557,37 @@ describe("POST /api/auth/dynamic — email extraction", () => {
     expect(generateLink).not.toHaveBeenCalled();
   });
 
-  it("ignores oauth_emails — only the credential's own email counts", async () => {
+  it("never matches on a github credential's oauth_emails", async () => {
     // GitHub lists addresses a user added but never verified. Matching on one
-    // would hand over whichever account that address belongs to.
+    // would hand over whichever account that address belongs to — the
+    // oauth_emails fallback is scoped to google, where the list can only hold
+    // the account's verified primary.
     const token = await signDynamicJwt({
       claims: {
         verified_credentials: [
           googleCredential({
-            email: undefined,
+            oauth_provider: "github",
             oauth_emails: ["victim@gmail.com"],
+          }),
+        ],
+      },
+    });
+
+    const res = await POST(dynamicRequest({ dynamicJwt: token }));
+
+    expect(res.status).toBe(403);
+    expect(generateLink).not.toHaveBeenCalled();
+  });
+
+  it("refuses a google oauth_emails list with more than one address", async () => {
+    // Exactly-one is the invariant Google's OAuth surface guarantees; a
+    // multi-element list means the shape assumption no longer holds, and
+    // guessing which entry is verified is how takeovers happen.
+    const token = await signDynamicJwt({
+      claims: {
+        verified_credentials: [
+          googleCredential({
+            oauth_emails: [EXISTING_EMAIL, "second@gmail.com"],
           }),
         ],
       },

--- a/apps/web/src/app/api/auth/dynamic/route.ts
+++ b/apps/web/src/app/api/auth/dynamic/route.ts
@@ -136,6 +136,7 @@ interface DynamicVerifiedCredential {
   format?: unknown;
   email?: unknown;
   oauth_provider?: unknown;
+  oauth_emails?: unknown;
   signInEnabled?: unknown;
 }
 
@@ -218,26 +219,44 @@ function isRecord(value: unknown): value is Record<string, unknown> {
  *   only meaningful when Dynamic actually sets it.
  * - a non-empty `email` string.
  *
- * The credential's `oauth_emails` array is NOT consulted, and that is a
- * deliberate v1 restriction. It is documented as "list of email addresses from
- * the OAuth provider" — for GitHub that list includes addresses the user added
- * but never verified, so an attacker could add a victim's address to their own
- * GitHub account and have this route hand them the victim's Superteam account.
- * The single `email` field is the address Dynamic settled on for the
- * credential, so it is the only one used.
+ * The email is taken from the credential's own `email` field when present. In
+ * practice Dynamic's LIVE google credential carries no `email` at all (the SDK
+ * model says it can; a real token from this environment says it doesn't) — the
+ * address arrives only in `oauth_emails` and `oauth_username`. So, for GOOGLE
+ * ONLY, a single-element `oauth_emails` is accepted as a fallback: Google's
+ * OAuth surface exposes exactly the account's verified primary address and
+ * nothing else, which is what makes that list trustworthy there.
+ *
+ * The same fallback is deliberately NOT extended to GitHub. GitHub's email
+ * list can include addresses the user added but never verified, so an attacker
+ * could add a victim's address to their own GitHub account and have this route
+ * hand them the victim's Superteam account. A github credential must carry the
+ * `email` field itself; extending the fallback to a new provider is a per-
+ * provider trust decision, not a refactor.
  */
 function matchableEmail(credential: unknown): string | null {
   if (!isRecord(credential)) return null;
-  const { format, oauth_provider, signInEnabled, email } =
+  const { format, oauth_provider, signInEnabled, email, oauth_emails } =
     credential as DynamicVerifiedCredential;
 
   if (format !== "oauth") return null;
   if (typeof oauth_provider !== "string") return null;
   if (!ALLOWED_OAUTH_PROVIDERS.has(oauth_provider)) return null;
   if (signInEnabled === false) return null;
-  if (typeof email !== "string") return null;
 
-  const normalized = normalizeEmail(email);
+  let candidate: string | null = typeof email === "string" ? email : null;
+  if (
+    candidate === null &&
+    oauth_provider === "google" &&
+    Array.isArray(oauth_emails) &&
+    oauth_emails.length === 1 &&
+    typeof oauth_emails[0] === "string"
+  ) {
+    candidate = oauth_emails[0];
+  }
+  if (candidate === null) return null;
+
+  const normalized = normalizeEmail(candidate);
   return normalized === "" ? null : normalized;
 }
 

--- a/apps/web/src/components/auth/__tests__/auth-modal-no-dynamic-provider.test.tsx
+++ b/apps/web/src/components/auth/__tests__/auth-modal-no-dynamic-provider.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 /* eslint-disable import/order -- vi.mock factories are hoisted above imports. */
 import { describe, it, expect, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import { NextIntlClientProvider } from "next-intl";
 import messages from "@/messages/en.json";
 
@@ -29,10 +29,11 @@ import messages from "@/messages/en.json";
 vi.mock("@solana/wallet-adapter-react-ui", () => ({
   useWalletModal: () => ({ setVisible: vi.fn() }),
 }));
+const { signInWithOAuth } = vi.hoisted(() => ({
+  signInWithOAuth: vi.fn().mockResolvedValue({ error: null }),
+}));
 vi.mock("@/lib/supabase/client", () => ({
-  createClient: vi.fn(() => ({
-    auth: { signInWithOAuth: vi.fn().mockResolvedValue({ error: null }) },
-  })),
+  createClient: vi.fn(() => ({ auth: { signInWithOAuth } })),
 }));
 vi.mock("@/lib/analytics", () => ({ trackEvent: vi.fn() }));
 
@@ -64,5 +65,16 @@ describe("AuthModal with Dynamic disabled and no provider mounted", () => {
     expect(
       screen.queryByText(messages.auth.continueWithEmail)
     ).not.toBeInTheDocument();
+
+    // Google falls back to Supabase OAuth. This is the kill switch: unsetting
+    // the environment id must restore the pre-Dynamic button, and the button
+    // that renders here calls Supabase, not Dynamic — the Dynamic variant
+    // would have thrown `MissingProviderError` in this unmocked render.
+    fireEvent.click(
+      screen.getByRole("button", { name: messages.auth.signInWithGoogle })
+    );
+    expect(signInWithOAuth).toHaveBeenCalledWith(
+      expect.objectContaining({ provider: "google" })
+    );
   });
 });

--- a/apps/web/src/components/auth/__tests__/dynamic-auth-handler-social-return.test.tsx
+++ b/apps/web/src/components/auth/__tests__/dynamic-auth-handler-social-return.test.tsx
@@ -1,0 +1,123 @@
+// @vitest-environment jsdom
+/* eslint-disable import/order -- vi.mock factories are hoisted above imports. */
+import { StrictMode } from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, waitFor } from "@testing-library/react";
+import { NextIntlClientProvider } from "next-intl";
+import messages from "@/messages/en.json";
+
+/**
+ * Job 0's once-per-page-load contract, exercised the only way that matters:
+ * under StrictMode, whose dev double-effect is exactly the duplicate
+ * invocation that once replayed the spent OAuth code in the live E2E. The
+ * handler keeps its handshake promise at MODULE scope, so each test imports a
+ * fresh module registry.
+ */
+
+const {
+  detectSocialRedirectUrl,
+  completeSocialRedirect,
+  clearSocialRedirectParams,
+  bridgeDynamicSession,
+  logoutDynamic,
+  getUser,
+  runWalletSiws,
+  reload,
+} = vi.hoisted(() => ({
+  detectSocialRedirectUrl: vi.fn(),
+  completeSocialRedirect: vi.fn().mockResolvedValue(undefined),
+  clearSocialRedirectParams: vi.fn(),
+  bridgeDynamicSession: vi.fn(),
+  logoutDynamic: vi.fn().mockResolvedValue(undefined),
+  getUser: vi.fn(),
+  runWalletSiws: vi.fn(),
+  reload: vi.fn(),
+}));
+
+vi.mock("@dynamic-labs-sdk/client", () => ({
+  signMessage: vi.fn(),
+  clearSocialRedirectParams,
+  completeDeviceRegistration: vi.fn(),
+  completeSocialRedirect,
+  detectDeviceRegistrationRedirect: vi.fn().mockReturnValue(false),
+  detectSocialRedirectUrl,
+  getDeviceRegistrationTokenFromUrl: vi.fn(),
+}));
+vi.mock("@dynamic-labs-sdk/client/waas", () => ({
+  createWaasWalletAccounts: vi.fn(),
+  getChainsMissingWaasWalletAccounts: vi.fn().mockReturnValue([]),
+}));
+vi.mock("@dynamic-labs-sdk/react-hooks", () => ({
+  useUser: () => ({ data: undefined }),
+  useGetWalletAccounts: () => ({
+    data: [{ chain: "SOL", address: "So1anaAddre55" }],
+  }),
+}));
+vi.mock("@/lib/supabase/client", () => ({
+  createClient: () => ({ auth: { getUser } }),
+}));
+vi.mock("@/lib/wallet/siws", () => ({ runWalletSiws }));
+vi.mock("@/lib/dynamic/client", () => ({ logoutDynamic }));
+vi.mock("@/lib/dynamic/siws", () => ({ toMessageSigner: vi.fn() }));
+vi.mock("@/lib/dynamic/social", () => ({ bridgeDynamicSession }));
+vi.mock("@/components/ui/toast-container", () => ({ dispatchToast: vi.fn() }));
+
+async function renderFreshHandler() {
+  vi.resetModules();
+  const { DynamicAuthHandler } = await import("../dynamic-auth-handler");
+  return render(
+    <StrictMode>
+      <NextIntlClientProvider locale="en" messages={messages}>
+        <DynamicAuthHandler />
+      </NextIntlClientProvider>
+    </StrictMode>
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getUser.mockResolvedValue({ data: { user: null } });
+  runWalletSiws.mockResolvedValue({ ok: true });
+  Object.defineProperty(window, "location", {
+    value: { ...window.location, reload },
+    writable: true,
+  });
+});
+
+describe("DynamicAuthHandler — social redirect return (job 0)", () => {
+  it("runs the handshake exactly once under StrictMode's double effect", async () => {
+    detectSocialRedirectUrl.mockResolvedValue(true);
+    bridgeDynamicSession.mockResolvedValue({ ok: true });
+
+    await renderFreshHandler();
+
+    await waitFor(() => expect(reload).toHaveBeenCalled());
+    expect(completeSocialRedirect).toHaveBeenCalledTimes(1);
+    expect(bridgeDynamicSession).toHaveBeenCalledTimes(1);
+    expect(clearSocialRedirectParams).toHaveBeenCalledTimes(1);
+  });
+
+  it("holds job 3 off for the whole return — no SIWS while the bridge is pending or after success", async () => {
+    detectSocialRedirectUrl.mockResolvedValue(true);
+    // A never-settling bridge = the in-flight window the duplicate invocation
+    // once released the guard during.
+    bridgeDynamicSession.mockReturnValue(new Promise(() => {}));
+
+    await renderFreshHandler();
+
+    await waitFor(() => expect(bridgeDynamicSession).toHaveBeenCalled());
+    // Give job 3 every chance to sneak in behind the pending bridge.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(runWalletSiws).not.toHaveBeenCalled();
+  });
+
+  it("releases job 3 on a plain page load so the SIWS bridge still runs", async () => {
+    detectSocialRedirectUrl.mockResolvedValue(false);
+
+    await renderFreshHandler();
+
+    await waitFor(() => expect(runWalletSiws).toHaveBeenCalled());
+    expect(completeSocialRedirect).not.toHaveBeenCalled();
+    expect(bridgeDynamicSession).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/auth/__tests__/dynamic-google-sign-in.test.tsx
+++ b/apps/web/src/components/auth/__tests__/dynamic-google-sign-in.test.tsx
@@ -1,0 +1,89 @@
+// @vitest-environment jsdom
+/* eslint-disable import/order -- vi.mock factories are hoisted above imports. */
+import type { ReactElement } from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { NextIntlClientProvider } from "next-intl";
+import messages from "@/messages/en.json";
+
+/**
+ * Sibling of the email form's stale-session suite, and the same failure with a
+ * different shape: `processSocialCallback` branches on `client.user`, so with a
+ * leftover Dynamic session the Google click becomes a credential LINK on that
+ * account rather than a sign-in.
+ */
+
+const { logoutMock, redirectMock, userState } = vi.hoisted(() => ({
+  logoutMock: vi.fn().mockResolvedValue(undefined),
+  redirectMock: vi.fn().mockResolvedValue(undefined),
+  userState: { current: undefined as { userId: string } | undefined },
+}));
+
+vi.mock("@dynamic-labs-sdk/client", () => ({
+  logout: logoutMock,
+  signInWithSocialRedirect: redirectMock,
+}));
+vi.mock("@dynamic-labs-sdk/react-hooks", () => ({
+  useUser: () => ({ data: userState.current }),
+}));
+vi.mock("@/lib/analytics", () => ({ trackEvent: vi.fn() }));
+
+import { DynamicGoogleSignIn } from "../dynamic-google-sign-in";
+
+function renderWithIntl(ui: ReactElement) {
+  return render(
+    <NextIntlClientProvider locale="en" messages={messages}>
+      {ui}
+    </NextIntlClientProvider>
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  userState.current = undefined;
+});
+
+describe("DynamicGoogleSignIn", () => {
+  it("starts the redirect flow back to the current page", async () => {
+    renderWithIntl(<DynamicGoogleSignIn disabled={false} />);
+    fireEvent.click(
+      screen.getByRole("button", { name: messages.auth.signInWithGoogle })
+    );
+
+    await waitFor(() =>
+      expect(redirectMock).toHaveBeenCalledWith({
+        provider: "google",
+        redirectUrl: window.location.href,
+      })
+    );
+    expect(logoutMock).not.toHaveBeenCalled();
+  });
+
+  it("clears a leftover Dynamic session BEFORE redirecting", async () => {
+    userState.current = { userId: "stale-user" };
+
+    renderWithIntl(<DynamicGoogleSignIn disabled={false} />);
+    fireEvent.click(
+      screen.getByRole("button", { name: messages.auth.signInWithGoogle })
+    );
+
+    await waitFor(() => expect(redirectMock).toHaveBeenCalled());
+    const [logoutOrder] = logoutMock.mock.invocationCallOrder;
+    const [redirectOrder] = redirectMock.mock.invocationCallOrder;
+    expect(logoutOrder as number).toBeLessThan(redirectOrder as number);
+  });
+
+  it("surfaces a translated error when the redirect cannot start", async () => {
+    redirectMock.mockRejectedValueOnce(new Error("no project settings"));
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    renderWithIntl(<DynamicGoogleSignIn disabled={false} />);
+    fireEvent.click(
+      screen.getByRole("button", { name: messages.auth.signInWithGoogle })
+    );
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      messages.auth.googleSignInFailed
+    );
+  });
+});

--- a/apps/web/src/components/auth/auth-modal.tsx
+++ b/apps/web/src/components/auth/auth-modal.tsx
@@ -20,6 +20,7 @@ import { buildOAuthRedirect } from "@/lib/auth/oauth-redirect";
 import { trackEvent } from "@/lib/analytics";
 import { isDynamicEnabled } from "@/lib/dynamic/config";
 import { DynamicEmailSignIn } from "@/components/auth/dynamic-email-sign-in";
+import { DynamicGoogleSignIn } from "@/components/auth/dynamic-google-sign-in";
 
 interface AuthModalProps {
   trigger?: React.ReactNode;
@@ -191,19 +192,27 @@ export function AuthModal({
             </div>
           </div>
 
-          <Button
-            variant="outline"
-            className="h-12 w-full gap-3 text-sm font-medium"
-            onClick={handleConnectGoogle}
-            disabled={loading !== null}
-          >
-            {loading === "google" ? (
-              <div className="h-5 w-5 animate-spin rounded-full border-2 border-current border-t-transparent" />
-            ) : (
-              <GoogleLogo className="h-5 w-5 shrink-0" />
-            )}
-            {loading === "google" ? t("connecting") : t("signInWithGoogle")}
-          </Button>
+          {/* Google goes through Dynamic when it is configured, so the learner
+              also walks away with an embedded wallet; the Supabase OAuth
+              button below is the fallback AND the kill switch — unsetting the
+              environment id restores it untouched. */}
+          {dynamicEnabled ? (
+            <DynamicGoogleSignIn disabled={loading !== null} />
+          ) : (
+            <Button
+              variant="outline"
+              className="h-12 w-full gap-3 text-sm font-medium"
+              onClick={handleConnectGoogle}
+              disabled={loading !== null}
+            >
+              {loading === "google" ? (
+                <div className="h-5 w-5 animate-spin rounded-full border-2 border-current border-t-transparent" />
+              ) : (
+                <GoogleLogo className="h-5 w-5 shrink-0" />
+              )}
+              {loading === "google" ? t("connecting") : t("signInWithGoogle")}
+            </Button>
+          )}
 
           <Button
             variant="outline"

--- a/apps/web/src/components/auth/dynamic-auth-handler.tsx
+++ b/apps/web/src/components/auth/dynamic-auth-handler.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useTranslations } from "next-intl";
 import {
   signMessage,
@@ -66,23 +66,25 @@ export function DynamicAuthHandler() {
   const handledAddress = useRef<string | null>(null);
   const creatingWallet = useRef(false);
   // Held for the whole social return, including the JWT bridge. Job 3 must not
-  // start while it is set: with no Supabase session visible yet it would take
+  // start while it is held: with no Supabase session visible yet it would take
   // the "sign in with this wallet" branch and mint a SECOND, wallet-shaped
   // account — the exact fork /api/auth/dynamic exists to prevent.
-  const bridgingSocial = useRef(false);
+  //
+  // State, not a ref: initializing to `true` claims the guard from the very
+  // first render (before job 0's async detection can yield), and releasing it
+  // re-runs job 3 — a ref flip would not, so a wallet account that arrived
+  // while the guard was held would otherwise never get its SIWS turn until
+  // some future reload.
+  const [bridgingSocial, setBridgingSocial] = useState(true);
 
   // 0. Social redirect return.
   useEffect(() => {
     const url = new URL(window.location.href);
-    // Claimed synchronously, before the async detection can yield: job 3 runs
-    // on this same first pass, and a wallet account arriving in the gap would
-    // slip past the guard.
-    bridgingSocial.current = true;
 
     void (async () => {
       try {
         if (!(await detectSocialRedirectUrl({ url }))) {
-          bridgingSocial.current = false;
+          setBridgingSocial(false);
           return;
         }
 
@@ -100,7 +102,7 @@ export function DynamicAuthHandler() {
         } = await supabase.auth.getUser();
         if (supabaseUser) {
           // Job 3 links the fresh embedded wallet to that account instead.
-          bridgingSocial.current = false;
+          setBridgingSocial(false);
           return;
         }
 
@@ -120,12 +122,12 @@ export function DynamicAuthHandler() {
         // signed out and can pick another way in.
         dispatchToast(t(outcome.errorKey), "error");
         await logoutDynamic();
-        bridgingSocial.current = false;
+        setBridgingSocial(false);
       } catch (err) {
         console.error("[DynamicAuthHandler] social redirect failed:", err);
         dispatchToast(t("googleBridgeFailed"), "error");
         await logoutDynamic();
-        bridgingSocial.current = false;
+        setBridgingSocial(false);
       }
     })();
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -172,7 +174,7 @@ export function DynamicAuthHandler() {
 
   // 3. Bridge the wallet to a Supabase account.
   useEffect(() => {
-    if (bridgingSocial.current) return;
+    if (bridgingSocial) return;
 
     // A local predicate rather than the SDK's `isSolanaWalletAccount`: the
     // pnpm graph holds two client instances (differing peer sets), so the
@@ -226,7 +228,7 @@ export function DynamicAuthHandler() {
         handledAddress.current = null;
       }
     })();
-  }, [walletAccounts]);
+  }, [walletAccounts, bridgingSocial]);
 
   return null;
 }

--- a/apps/web/src/components/auth/dynamic-auth-handler.tsx
+++ b/apps/web/src/components/auth/dynamic-auth-handler.tsx
@@ -1,10 +1,14 @@
 "use client";
 
 import { useEffect, useRef } from "react";
+import { useTranslations } from "next-intl";
 import {
   signMessage,
+  clearSocialRedirectParams,
   completeDeviceRegistration,
+  completeSocialRedirect,
   detectDeviceRegistrationRedirect,
+  detectSocialRedirectUrl,
   getDeviceRegistrationTokenFromUrl,
 } from "@dynamic-labs-sdk/client";
 import {
@@ -15,13 +19,22 @@ import { useUser, useGetWalletAccounts } from "@dynamic-labs-sdk/react-hooks";
 import type { SolanaWalletAccount } from "@/lib/dynamic/solana";
 import { createClient } from "@/lib/supabase/client";
 import { runWalletSiws } from "@/lib/wallet/siws";
+import { logoutDynamic } from "@/lib/dynamic/client";
 import { toMessageSigner } from "@/lib/dynamic/siws";
+import { bridgeDynamicSession } from "@/lib/dynamic/social";
+import { dispatchToast } from "@/components/ui/toast-container";
 
 /**
  * Everything that has to happen around a Dynamic login, with no UI of its own.
  *
- * Three jobs, in the order they occur:
+ * Four jobs, in the order they occur:
  *
+ * 0. **The social redirect return.** Social sign-in on web is a full-page
+ *    navigation (there is no popup variant — see `lib/dynamic/social.ts`), so
+ *    the button that started it is long gone by the time Google redirects
+ *    back. Finishing the handshake and exchanging the resulting Dynamic JWT
+ *    for a Supabase session has to happen from something mounted on every
+ *    page, which is this.
  * 1. **Device registration.** OPTIONAL — off by default and only active when
  *    the dashboard toggle enables it (per Dynamic's docs; an earlier reading
  *    here claimed it was required). When it IS on, a returning learner on a
@@ -43,6 +56,7 @@ import { toMessageSigner } from "@/lib/dynamic/siws";
  * for wallet-adapter wallets.
  */
 export function DynamicAuthHandler() {
+  const t = useTranslations("auth");
   const { data: user } = useUser();
   const { data: walletAccounts = [] } = useGetWalletAccounts();
 
@@ -51,6 +65,71 @@ export function DynamicAuthHandler() {
   // sign the same nonce twice.
   const handledAddress = useRef<string | null>(null);
   const creatingWallet = useRef(false);
+  // Held for the whole social return, including the JWT bridge. Job 3 must not
+  // start while it is set: with no Supabase session visible yet it would take
+  // the "sign in with this wallet" branch and mint a SECOND, wallet-shaped
+  // account — the exact fork /api/auth/dynamic exists to prevent.
+  const bridgingSocial = useRef(false);
+
+  // 0. Social redirect return.
+  useEffect(() => {
+    const url = new URL(window.location.href);
+    // Claimed synchronously, before the async detection can yield: job 3 runs
+    // on this same first pass, and a wallet account arriving in the gap would
+    // slip past the guard.
+    bridgingSocial.current = true;
+
+    void (async () => {
+      try {
+        if (!(await detectSocialRedirectUrl({ url }))) {
+          bridgingSocial.current = false;
+          return;
+        }
+
+        await completeSocialRedirect({ url });
+        // Before the params are stripped a refresh would replay the callback
+        // code, which Dynamic has already spent.
+        clearSocialRedirectParams();
+
+        // An existing Supabase session means this was a link, not a sign-in;
+        // minting a session here could land the learner in a different
+        // account than the one they are already using.
+        const supabase = createClient();
+        const {
+          data: { user: supabaseUser },
+        } = await supabase.auth.getUser();
+        if (supabaseUser) {
+          // Job 3 links the fresh embedded wallet to that account instead.
+          bridgingSocial.current = false;
+          return;
+        }
+
+        const outcome = await bridgeDynamicSession();
+        if (outcome.ok) {
+          // Same hard reload as the SIWS bridge: the Supabase client in this
+          // tab was built anonymous and only re-reads the cookies on boot.
+          // The guard stays CLAIMED — the reload is not instantaneous and job
+          // 3 must not get a turn in the interval.
+          window.location.reload();
+          return;
+        }
+
+        // Authenticated to Dynamic with no Supabase session is a dead end —
+        // every subsequent page load would retry a bridge that has already
+        // been refused. End the Dynamic session so the learner is plainly
+        // signed out and can pick another way in.
+        dispatchToast(t(outcome.errorKey), "error");
+        await logoutDynamic();
+        bridgingSocial.current = false;
+      } catch (err) {
+        console.error("[DynamicAuthHandler] social redirect failed:", err);
+        dispatchToast(t("googleBridgeFailed"), "error");
+        await logoutDynamic();
+        bridgingSocial.current = false;
+      }
+    })();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // 1. Device registration redirect.
   useEffect(() => {
@@ -93,6 +172,8 @@ export function DynamicAuthHandler() {
 
   // 3. Bridge the wallet to a Supabase account.
   useEffect(() => {
+    if (bridgingSocial.current) return;
+
     // A local predicate rather than the SDK's `isSolanaWalletAccount`: the
     // pnpm graph holds two client instances (differing peer sets), so the
     // SDK guard's parameter type and this hook's account type are nominally

--- a/apps/web/src/components/auth/dynamic-auth-handler.tsx
+++ b/apps/web/src/components/auth/dynamic-auth-handler.tsx
@@ -56,17 +56,23 @@ import { dispatchToast } from "@/components/ui/toast-container";
  * for wallet-adapter wallets.
  */
 /**
- * The social-return handshake may run AT MOST ONCE per page load:
+ * The social-return handshake runs AT MOST ONCE per page load:
  * `completeSocialRedirect` spends a one-time OAuth code, so a second
  * invocation — StrictMode's dev double-effect, or any remount while the
  * callback params are still in the URL — replays a spent code, throws, and
  * the failure path then logs out the session the first invocation just
  * established (observed live: a 200 bridge immediately followed by an aborted
  * duplicate, leaving the learner "not signed in" until a second attempt).
+ *
+ * A PROMISE, not a boolean: "claimed" and "resolved" are different states. A
+ * duplicate that treated claimed-as-resolved would release job 3's guard while
+ * the real handshake is still in flight — the fork race all over again. Every
+ * invocation awaits the SAME promise and applies its settled outcome;
+ * `"hold"` means a reload is imminent and the guard must stay up.
  * Module scope, not a ref: a ref dies with its fiber, and both success
  * (hard reload) and failure (params stripped) end this page load's story.
  */
-let socialReturnConsumed = false;
+let socialReturnOutcome: Promise<"release" | "hold"> | null = null;
 
 export function DynamicAuthHandler() {
   const t = useTranslations("auth");
@@ -95,61 +101,54 @@ export function DynamicAuthHandler() {
     const url = new URL(window.location.href);
 
     void (async () => {
-      // Checked and claimed synchronously (this async body runs sync until its
-      // first await), so a double-invoked effect cannot race past it.
-      if (socialReturnConsumed) {
-        setBridgingSocial(false);
-        return;
-      }
-      socialReturnConsumed = true;
+      // `??=` runs synchronously before this body's first await, so only the
+      // first invocation starts the handshake; StrictMode's duplicate and any
+      // later remount await the same promise instead of re-running it.
+      socialReturnOutcome ??= (async (): Promise<"release" | "hold"> => {
+        try {
+          if (!(await detectSocialRedirectUrl({ url }))) return "release";
 
-      try {
-        if (!(await detectSocialRedirectUrl({ url }))) {
-          setBridgingSocial(false);
-          return;
+          await completeSocialRedirect({ url });
+          // Before the params are stripped a refresh would replay the callback
+          // code, which Dynamic has already spent.
+          clearSocialRedirectParams();
+
+          // An existing Supabase session means this was a link, not a sign-in;
+          // minting a session here could land the learner in a different
+          // account than the one they are already using. Job 3 links the fresh
+          // embedded wallet to that account instead.
+          const supabase = createClient();
+          const {
+            data: { user: supabaseUser },
+          } = await supabase.auth.getUser();
+          if (supabaseUser) return "release";
+
+          const outcome = await bridgeDynamicSession();
+          if (outcome.ok) {
+            // Same hard reload as the SIWS bridge: the Supabase client in this
+            // tab was built anonymous and only re-reads the cookies on boot.
+            // The guard stays up — the reload is not instantaneous and job 3
+            // must not get a turn in the interval.
+            window.location.reload();
+            return "hold";
+          }
+
+          // Authenticated to Dynamic with no Supabase session is a dead end —
+          // every subsequent page load would retry a bridge that has already
+          // been refused. End the Dynamic session so the learner is plainly
+          // signed out and can pick another way in.
+          dispatchToast(t(outcome.errorKey), "error");
+          await logoutDynamic();
+          return "release";
+        } catch (err) {
+          console.error("[DynamicAuthHandler] social redirect failed:", err);
+          dispatchToast(t("googleBridgeFailed"), "error");
+          await logoutDynamic();
+          return "release";
         }
+      })();
 
-        await completeSocialRedirect({ url });
-        // Before the params are stripped a refresh would replay the callback
-        // code, which Dynamic has already spent.
-        clearSocialRedirectParams();
-
-        // An existing Supabase session means this was a link, not a sign-in;
-        // minting a session here could land the learner in a different
-        // account than the one they are already using.
-        const supabase = createClient();
-        const {
-          data: { user: supabaseUser },
-        } = await supabase.auth.getUser();
-        if (supabaseUser) {
-          // Job 3 links the fresh embedded wallet to that account instead.
-          setBridgingSocial(false);
-          return;
-        }
-
-        const outcome = await bridgeDynamicSession();
-        if (outcome.ok) {
-          // Same hard reload as the SIWS bridge: the Supabase client in this
-          // tab was built anonymous and only re-reads the cookies on boot.
-          // The guard stays CLAIMED — the reload is not instantaneous and job
-          // 3 must not get a turn in the interval.
-          window.location.reload();
-          return;
-        }
-
-        // Authenticated to Dynamic with no Supabase session is a dead end —
-        // every subsequent page load would retry a bridge that has already
-        // been refused. End the Dynamic session so the learner is plainly
-        // signed out and can pick another way in.
-        dispatchToast(t(outcome.errorKey), "error");
-        await logoutDynamic();
-        setBridgingSocial(false);
-      } catch (err) {
-        console.error("[DynamicAuthHandler] social redirect failed:", err);
-        dispatchToast(t("googleBridgeFailed"), "error");
-        await logoutDynamic();
-        setBridgingSocial(false);
-      }
+      if ((await socialReturnOutcome) === "release") setBridgingSocial(false);
     })();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/apps/web/src/components/auth/dynamic-auth-handler.tsx
+++ b/apps/web/src/components/auth/dynamic-auth-handler.tsx
@@ -55,6 +55,19 @@ import { dispatchToast } from "@/components/ui/toast-container";
  * Mounted at the layout level alongside `WalletAuthHandler`, which does job 3
  * for wallet-adapter wallets.
  */
+/**
+ * The social-return handshake may run AT MOST ONCE per page load:
+ * `completeSocialRedirect` spends a one-time OAuth code, so a second
+ * invocation — StrictMode's dev double-effect, or any remount while the
+ * callback params are still in the URL — replays a spent code, throws, and
+ * the failure path then logs out the session the first invocation just
+ * established (observed live: a 200 bridge immediately followed by an aborted
+ * duplicate, leaving the learner "not signed in" until a second attempt).
+ * Module scope, not a ref: a ref dies with its fiber, and both success
+ * (hard reload) and failure (params stripped) end this page load's story.
+ */
+let socialReturnConsumed = false;
+
 export function DynamicAuthHandler() {
   const t = useTranslations("auth");
   const { data: user } = useUser();
@@ -82,6 +95,14 @@ export function DynamicAuthHandler() {
     const url = new URL(window.location.href);
 
     void (async () => {
+      // Checked and claimed synchronously (this async body runs sync until its
+      // first await), so a double-invoked effect cannot race past it.
+      if (socialReturnConsumed) {
+        setBridgingSocial(false);
+        return;
+      }
+      socialReturnConsumed = true;
+
       try {
         if (!(await detectSocialRedirectUrl({ url }))) {
           setBridgingSocial(false);

--- a/apps/web/src/components/auth/dynamic-google-sign-in.tsx
+++ b/apps/web/src/components/auth/dynamic-google-sign-in.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { useState } from "react";
+import { useTranslations } from "next-intl";
+import { logout, signInWithSocialRedirect } from "@dynamic-labs-sdk/client";
+import { useUser } from "@dynamic-labs-sdk/react-hooks";
+import { Button } from "@/components/ui/button";
+import { GoogleLogo } from "@/components/icons/google-logo";
+import { trackEvent } from "@/lib/analytics";
+
+/**
+ * "Continue with Google", routed through Dynamic instead of Supabase OAuth.
+ *
+ * Same account either way — `/api/auth/dynamic` matches on the Google-verified
+ * email — but this path also leaves the learner with an embedded Solana wallet,
+ * which the Supabase OAuth path does not.
+ *
+ * The click ends in a full-page navigation to Google, so nothing after
+ * `signInWithSocialRedirect` runs in this component. The return leg is handled
+ * by `DynamicAuthHandler`; there is no popup variant on web (see
+ * `lib/dynamic/social.ts`).
+ *
+ * Split out for the same reason as `DynamicEmailSignIn`: `useUser` throws
+ * `MissingProviderError` outside a `DynamicProvider`, and hooks cannot be
+ * conditional, so the feature gate has to be a component boundary.
+ */
+export function DynamicGoogleSignIn({ disabled }: { disabled: boolean }) {
+  const t = useTranslations("auth");
+  const [starting, setStarting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const { data: dynamicUser } = useUser();
+
+  const handleClick = async () => {
+    setStarting(true);
+    setError(null);
+    trackEvent("auth_method_selected", { method: "dynamic_google" });
+    try {
+      // Same stale-session hazard the email form guards against, with a
+      // different symptom: `processSocialCallback` branches on `client.user`
+      // and calls `oauthVerify` (LINK this Google account to the existing
+      // Dynamic user) instead of `oauthSignIn` when one is present. This
+      // button is strictly sign-in, so a session that predates it is cleared.
+      if (dynamicUser) await logout();
+      await signInWithSocialRedirect({
+        provider: "google",
+        // Back to the page they left. The SDK strips its own params off this
+        // before storing it, and re-adds them on the way back.
+        redirectUrl: window.location.href,
+      });
+    } catch (err) {
+      console.error("[DynamicGoogleSignIn] redirect failed:", err);
+      setError(t("googleSignInFailed"));
+      setStarting(false);
+    }
+  };
+
+  return (
+    <div className="space-y-1.5">
+      <Button
+        variant="outline"
+        className="h-12 w-full gap-3 text-sm font-medium"
+        disabled={disabled || starting}
+        onClick={handleClick}
+      >
+        {starting ? (
+          <div
+            className="h-5 w-5 animate-spin rounded-full border-2 border-current border-t-transparent"
+            aria-hidden="true"
+          />
+        ) : (
+          <GoogleLogo className="h-5 w-5 shrink-0" />
+        )}
+        {starting ? t("connecting") : t("signInWithGoogle")}
+      </Button>
+      {error && (
+        <p className="text-center text-xs text-danger" role="alert">
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/lib/dynamic/__tests__/social.test.ts
+++ b/apps/web/src/lib/dynamic/__tests__/social.test.ts
@@ -1,0 +1,119 @@
+/* eslint-disable import/order -- vi.mock factories are hoisted above imports. */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+/**
+ * The bridge POST is the seam where a server refusal becomes copy a learner
+ * reads, so the mapping is pinned here rather than discovered at an event.
+ *
+ * The token choice is pinned too: `/api/auth/dynamic` matches accounts on
+ * `verified_credentials`, which only the FULL JWT (`legacyToken`) carries —
+ * sending `token` (the minified access JWT) would verify and then 403.
+ */
+
+const { state, clientRef } = vi.hoisted(() => ({
+  state: {
+    current: { legacyToken: "full.jwt" as string | null, token: "minified" },
+  },
+  clientRef: { current: {} as object | null },
+}));
+
+vi.mock("@dynamic-labs-sdk/client/core", () => ({
+  getCore: () => ({ state: { get: () => state.current } }),
+}));
+vi.mock("@/lib/dynamic/client", () => ({
+  getDynamicClient: () => clientRef.current,
+}));
+
+import { bridgeDynamicSession, getDynamicAuthToken } from "../social";
+
+function mockFetch(status: number, body: unknown) {
+  const fetchMock = vi.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(body),
+  });
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+beforeEach(() => {
+  state.current = { legacyToken: "full.jwt", token: "minified" };
+  clientRef.current = {};
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("getDynamicAuthToken", () => {
+  it("returns the full JWT, never the minified access token", () => {
+    expect(getDynamicAuthToken()).toBe("full.jwt");
+  });
+
+  it("returns null when Dynamic is off", () => {
+    clientRef.current = null;
+    expect(getDynamicAuthToken()).toBeNull();
+  });
+
+  it("returns null in cookie-based environments, where no token is readable", () => {
+    state.current = { legacyToken: null, token: "minified" };
+    expect(getDynamicAuthToken()).toBeNull();
+  });
+});
+
+describe("bridgeDynamicSession", () => {
+  it("posts the full JWT and reports success", async () => {
+    const fetchMock = mockFetch(200, { success: true });
+
+    await expect(bridgeDynamicSession()).resolves.toEqual({ ok: true });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/auth/dynamic",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ dynamicJwt: "full.jwt" }),
+      })
+    );
+  });
+
+  it("never calls the route when there is no token", async () => {
+    state.current = { legacyToken: null, token: "minified" };
+    const fetchMock = mockFetch(200, { success: true });
+
+    await expect(bridgeDynamicSession()).resolves.toEqual({
+      ok: false,
+      errorKey: "googleBridgeFailed",
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["noVerifiedOauthEmail", 403, "googleEmailUnmatched"],
+    ["ambiguousVerifiedEmail", 403, "googleEmailUnmatched"],
+    ["accountDeleted", 403, "accountDeleted"],
+    ["rateLimited", 429, "otpRateLimited"],
+    ["invalidToken", 401, "googleBridgeFailed"],
+    ["internalError", 500, "googleBridgeFailed"],
+  ])("maps %s (%d) to %s", async (error, status, errorKey) => {
+    mockFetch(status, { error });
+    await expect(bridgeDynamicSession()).resolves.toEqual({
+      ok: false,
+      errorKey,
+    });
+  });
+
+  it("fails closed on a 200 that does not say success", async () => {
+    mockFetch(200, {});
+    await expect(bridgeDynamicSession()).resolves.toEqual({
+      ok: false,
+      errorKey: "googleBridgeFailed",
+    });
+  });
+
+  it("fails closed when the network drops", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("offline")));
+    await expect(bridgeDynamicSession()).resolves.toEqual({
+      ok: false,
+      errorKey: "googleBridgeFailed",
+    });
+  });
+});

--- a/apps/web/src/lib/dynamic/social.ts
+++ b/apps/web/src/lib/dynamic/social.ts
@@ -1,0 +1,119 @@
+/**
+ * The client half of the Dynamic social bridge: Dynamic session in, Supabase
+ * session out, via `POST /api/auth/dynamic`.
+ *
+ * ## Redirect, not popup
+ *
+ * `signInWithSocialPopUp` is React-Native only — the installed dist's web build
+ * throws `MethodNotImplementedError` unconditionally, and its own docblock says
+ * "On web, use signInWithSocialRedirect + completeSocialRedirect instead". Web
+ * social sign-in is therefore a FULL PAGE navigation
+ * (`createNavigationHandler` sets `window.location.href`), so the click handler
+ * can never await the result. The return leg is picked up by
+ * `DynamicAuthHandler`, which is mounted on every page.
+ *
+ * ## Which token
+ *
+ * Dynamic keeps TWO tokens in client state and they are not interchangeable:
+ *
+ * - `token` — the MINIFIED access JWT (`response.minifiedJwt`). Its model
+ *   (`@dynamic-labs/sdk-api-core` `MinifiedDynamicJwt`) carries only credential
+ *   HASHES, no `verified_credentials` array at all.
+ * - `legacyToken` — the full `DynamicJwt` (`response.jwt`), which is the one
+ *   that carries `verified_credentials` with the provider-verified email.
+ *
+ * `/api/auth/dynamic` matches accounts on exactly that array, so the minified
+ * token would be signature-valid and still 403 with `noVerifiedOauthEmail`.
+ * Only `legacyToken` works, deprecation notice notwithstanding — the route and
+ * the SDK disagree about which token is "current", and the route is the one
+ * that decides what a valid bridge looks like.
+ *
+ * `legacyToken` lives on core state rather than the public `DynamicClient`
+ * (which exposes only `token`), so it is read through the SDK's own supported
+ * escape hatch: `getCore` from the `/core` "Extension Development" entry point.
+ *
+ * Both tokens are `null` when the Dynamic environment is configured for
+ * COOKIE-based auth — the API then returns neither `jwt` nor `minifiedJwt`, and
+ * an httpOnly cookie the browser cannot read holds the session instead. That is
+ * a dashboard setting, not something this code can detect ahead of time, so a
+ * missing token is reported as a normal failure rather than treated as
+ * impossible.
+ */
+
+import { getCore } from "@dynamic-labs-sdk/client/core";
+import { getDynamicClient } from "@/lib/dynamic/client";
+
+/**
+ * Message keys in the `auth` namespace. Returned instead of a rendered string
+ * so this module stays free of React and of the translation context.
+ */
+export type DynamicBridgeErrorKey =
+  | "googleEmailUnmatched"
+  | "accountDeleted"
+  | "otpRateLimited"
+  | "googleBridgeFailed";
+
+export type DynamicBridgeOutcome =
+  | { ok: true }
+  | { ok: false; errorKey: DynamicBridgeErrorKey };
+
+/**
+ * The route's `error` strings, mapped to copy a learner can act on. Anything
+ * unrecognised — including a 500 with no body — falls through to the generic
+ * key, because the alternative is a blank toast.
+ */
+const ERROR_KEYS: Record<string, DynamicBridgeErrorKey> = {
+  noVerifiedOauthEmail: "googleEmailUnmatched",
+  ambiguousVerifiedEmail: "googleEmailUnmatched",
+  accountDeleted: "accountDeleted",
+  rateLimited: "otpRateLimited",
+};
+
+/** The full Dynamic JWT for the current session, or `null`. */
+export function getDynamicAuthToken(): string | null {
+  const client = getDynamicClient();
+  if (!client) return null;
+  try {
+    return getCore(client).state.get().legacyToken;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Exchange the current Dynamic session for a Supabase session.
+ *
+ * Does NOT reload — the caller decides, because it also has to decide what to
+ * tear down first when this fails.
+ */
+export async function bridgeDynamicSession(): Promise<DynamicBridgeOutcome> {
+  const dynamicJwt = getDynamicAuthToken();
+  if (!dynamicJwt) return { ok: false, errorKey: "googleBridgeFailed" };
+
+  try {
+    const response = await fetch("/api/auth/dynamic", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ dynamicJwt }),
+    });
+
+    const body: unknown = await response.json().catch(() => null);
+    const error =
+      typeof body === "object" && body !== null && "error" in body
+        ? (body as { error?: unknown }).error
+        : undefined;
+
+    if (response.ok && (body as { success?: unknown })?.success === true) {
+      return { ok: true };
+    }
+
+    return {
+      ok: false,
+      errorKey:
+        (typeof error === "string" ? ERROR_KEYS[error] : undefined) ??
+        "googleBridgeFailed",
+    };
+  } catch {
+    return { ok: false, errorKey: "googleBridgeFailed" };
+  }
+}

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -103,7 +103,9 @@
     "useDifferentEmail": "Use a different email",
     "verifyCode": "Verify",
     "walletConnected": "Wallet Connected",
-    "otpRateLimited": "Too many sign-ups from this network — wait a minute and try again."
+    "otpRateLimited": "Too many sign-ups from this network — wait a minute and try again.",
+    "googleBridgeFailed": "Signed in with Google, but we couldn't finish connecting your account. Please try again.",
+    "googleEmailUnmatched": "Google didn't share a verified email address, so we can't match your account. Try another sign-in method."
   },
   "landing": {
     "poweredBy": "Powered by",

--- a/apps/web/src/messages/es.json
+++ b/apps/web/src/messages/es.json
@@ -103,7 +103,9 @@
     "useDifferentEmail": "Usar otro correo",
     "verifyCode": "Verificar",
     "walletConnected": "Billetera Conectada",
-    "otpRateLimited": "Demasiados registros desde esta red — espera un minuto e inténtalo de nuevo."
+    "otpRateLimited": "Demasiados registros desde esta red — espera un minuto e inténtalo de nuevo.",
+    "googleBridgeFailed": "Iniciaste sesión con Google, pero no pudimos terminar de conectar tu cuenta. Inténtalo de nuevo.",
+    "googleEmailUnmatched": "Google no compartió un correo verificado, así que no podemos identificar tu cuenta. Usa otro método de inicio de sesión."
   },
   "landing": {
     "poweredBy": "Con el apoyo de",

--- a/apps/web/src/messages/pt-BR.json
+++ b/apps/web/src/messages/pt-BR.json
@@ -103,7 +103,9 @@
     "useDifferentEmail": "Usar outro e-mail",
     "verifyCode": "Verificar",
     "walletConnected": "Carteira Conectada",
-    "otpRateLimited": "Muitos cadastros desta rede — aguarde um minuto e tente novamente."
+    "otpRateLimited": "Muitos cadastros desta rede — aguarde um minuto e tente novamente.",
+    "googleBridgeFailed": "Login com Google feito, mas não foi possível concluir a conexão da sua conta. Tente novamente.",
+    "googleEmailUnmatched": "O Google não forneceu um e-mail verificado, então não conseguimos identificar sua conta. Use outro método de login."
   },
   "landing": {
     "poweredBy": "Com apoio de",


### PR DESCRIPTION
Wires the Google button through Dynamic when the environment id is configured: click → signInWithSocialRedirect (web social sign-in is redirect-only — the popup variant throws on web) → DynamicAuthHandler picks up the return leg, exchanges the Dynamic JWT for a Supabase session via /api/auth/dynamic (#1028), and reloads. The learner lands in their existing email-matched account and walks away with an embedded wallet. With no environment id the Supabase OAuth button renders untouched — that's the kill switch.

Two SDK findings that shaped the implementation: the bridge must send `legacyToken` (the full DynamicJwt with verified_credentials) — the public `token` is the minified JWT, which verifies and then 403s; and a `bridgingSocial` guard holds off the SIWS auto-sign-in during the return leg, which would otherwise mint a second wallet-shaped account before the Supabase cookies land.

**Draft until verified on localhost:3000 with a real Google login** (Vercel previews aren't in Dynamic's CORS allowlist). One thing only that E2E can prove: if the Dynamic environment uses cookie-based auth storage, `legacyToken` is null and the bridge fails closed — the fix is the dashboard's auth-storage toggle, not code.

73 tests across the route + new social/button suites.