### PR TITLE
fix(lessons): show the Back label on mobile too

### DIFF
--- a/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/lesson-client.tsx
+++ b/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/lesson-client.tsx
@@ -728,13 +728,10 @@ export function LessonPageClient({
         <div className="flex min-w-0 flex-1 items-center gap-2 sm:gap-3">
           <Link
             href={`${linkBase}/${courseSlug}`}
-            // Below sm the text label is display:none, which drops it from the
-            // a11y tree — the aria-label keeps the link named on phones.
-            aria-label={tCommon("back")}
             className="inline-flex shrink-0 items-center gap-1.5 font-display text-sm font-semibold text-text-3 transition-colors hover:text-text"
           >
-            <ArrowLeft size={16} weight="bold" />
-            <span className="hidden sm:inline">{tCommon("back")}</span>
+            <ArrowLeft size={16} weight="bold" aria-hidden="true" />
+            {tCommon("back")}
           </Link>
         </div>
 


### PR DESCRIPTION
Below sm the lesson back bar rendered a bare arrow — the label was display:none with an aria-label patch. The label is short in every locale and the bar has room, so it just shows now. Verified at 375px: label + XP counter fit.