### PR TITLE
feat(auth): drop the email-OTP entry from the sign-in modal

### DIFF
--- a/apps/web/src/components/auth/auth-modal.tsx
+++ b/apps/web/src/components/auth/auth-modal.tsx
@@ -19,7 +19,6 @@ import { createClient } from "@/lib/supabase/client";
 import { buildOAuthRedirect } from "@/lib/auth/oauth-redirect";
 import { trackEvent } from "@/lib/analytics";
 import { isDynamicEnabled } from "@/lib/dynamic/config";
-import { DynamicEmailSignIn } from "@/components/auth/dynamic-email-sign-in";
 import { DynamicGoogleSignIn } from "@/components/auth/dynamic-google-sign-in";
 
 interface AuthModalProps {
@@ -65,7 +64,7 @@ export function AuthModal({
   // throws `MissingProviderError` when no provider is mounted, so calling one
   // here would crash sign-in in any build without an environment id. Hooks
   // cannot be conditional, so the gate is a component boundary instead:
-  // DynamicEmailSignIn owns the hooks and mounts only when Dynamic is enabled.
+  // DynamicGoogleSignIn owns the hooks and mounts only when Dynamic is enabled.
   const dynamicEnabled = isDynamicEnabled();
   const { setVisible } = useWalletModal();
 
@@ -165,10 +164,6 @@ export function AuthModal({
           </DialogDescription>
         </DialogHeader>
         <div className="mt-6 space-y-3">
-          {/* First: the only option that asks nothing of a learner with no
-              wallet. Hidden entirely when no environment id is configured. */}
-          {dynamicEnabled && <DynamicEmailSignIn disabled={loading !== null} />}
-
           <Button
             variant="outline"
             className="h-12 w-full gap-3 text-sm font-medium"


### PR DESCRIPTION
Keeps wallet + Google + GitHub. Google-through-Dynamic covers the no-wallet path and lands in the right account; email-OTP creates a wallet-shaped account that forks from a later Google login (the hazard behind today's manual merge). DynamicEmailSignIn stays in-tree — only the modal entry goes. Verified in the preview: modal shows wallet / OR / Google / GitHub.