### PR TITLE
fix(auth): don't start MPC keygen during the social-return handshake

### DIFF
--- a/apps/web/src/components/auth/__tests__/dynamic-auth-handler-social-return.test.tsx
+++ b/apps/web/src/components/auth/__tests__/dynamic-auth-handler-social-return.test.tsx
@@ -16,6 +16,8 @@ import messages from "@/messages/en.json";
 
 const {
   detectSocialRedirectUrl,
+  createWaasWalletAccounts,
+  getChainsMissingWaasWalletAccounts,
   completeSocialRedirect,
   clearSocialRedirectParams,
   bridgeDynamicSession,
@@ -32,6 +34,8 @@ const {
   getUser: vi.fn(),
   runWalletSiws: vi.fn(),
   reload: vi.fn(),
+  createWaasWalletAccounts: vi.fn(),
+  getChainsMissingWaasWalletAccounts: vi.fn(),
 }));
 
 vi.mock("@dynamic-labs-sdk/client", () => ({
@@ -44,11 +48,11 @@ vi.mock("@dynamic-labs-sdk/client", () => ({
   getDeviceRegistrationTokenFromUrl: vi.fn(),
 }));
 vi.mock("@dynamic-labs-sdk/client/waas", () => ({
-  createWaasWalletAccounts: vi.fn(),
-  getChainsMissingWaasWalletAccounts: vi.fn().mockReturnValue([]),
+  createWaasWalletAccounts,
+  getChainsMissingWaasWalletAccounts,
 }));
 vi.mock("@dynamic-labs-sdk/react-hooks", () => ({
-  useUser: () => ({ data: undefined }),
+  useUser: () => ({ data: { userId: "dynamic-user-1" } }),
   useGetWalletAccounts: () => ({
     data: [{ chain: "SOL", address: "So1anaAddre55" }],
   }),
@@ -78,6 +82,8 @@ beforeEach(() => {
   vi.clearAllMocks();
   getUser.mockResolvedValue({ data: { user: null } });
   runWalletSiws.mockResolvedValue({ ok: true });
+  createWaasWalletAccounts.mockResolvedValue(undefined);
+  getChainsMissingWaasWalletAccounts.mockReturnValue(["SOL"]);
   Object.defineProperty(window, "location", {
     value: { ...window.location, reload },
     writable: true,
@@ -106,9 +112,12 @@ describe("DynamicAuthHandler — social redirect return (job 0)", () => {
     await renderFreshHandler();
 
     await waitFor(() => expect(bridgeDynamicSession).toHaveBeenCalled());
-    // Give job 3 every chance to sneak in behind the pending bridge.
+    // Give jobs 2 and 3 every chance to sneak in behind the pending bridge.
     await new Promise((resolve) => setTimeout(resolve, 50));
     expect(runWalletSiws).not.toHaveBeenCalled();
+    // The MPC keygen must not start either — the success path's hard reload
+    // would kill it mid-flight, stranding the learner with no wallet.
+    expect(createWaasWalletAccounts).not.toHaveBeenCalled();
   });
 
   it("releases job 3 on a plain page load so the SIWS bridge still runs", async () => {
@@ -117,6 +126,7 @@ describe("DynamicAuthHandler — social redirect return (job 0)", () => {
     await renderFreshHandler();
 
     await waitFor(() => expect(runWalletSiws).toHaveBeenCalled());
+    await waitFor(() => expect(createWaasWalletAccounts).toHaveBeenCalled());
     expect(completeSocialRedirect).not.toHaveBeenCalled();
     expect(bridgeDynamicSession).not.toHaveBeenCalled();
   });

--- a/apps/web/src/components/auth/dynamic-auth-handler.tsx
+++ b/apps/web/src/components/auth/dynamic-auth-handler.tsx
@@ -188,6 +188,13 @@ export function DynamicAuthHandler() {
 
   // 2. Create the embedded Solana wallet once the learner is authenticated.
   useEffect(() => {
+    // Not during a social return: the Dynamic session lands mid-handshake, so
+    // this effect would start the multi-round MPC keygen exactly when job 0's
+    // success path is about to hard-reload — killing the keygen in flight and
+    // leaving the learner with no wallet (observed live at the event,
+    // 2026-08-13: sign-in fine, wallet missing). Post-reload the guard clears
+    // in milliseconds and the keygen runs with nothing racing it.
+    if (bridgingSocial) return;
     if (!user || creatingWallet.current) return;
 
     const missing = getChainsMissingWaasWalletAccounts();
@@ -203,7 +210,10 @@ export function DynamicAuthHandler() {
         // again, which remounts this handler.
       }
     })();
-  }, [user]);
+    // `bridgingSocial` is in the deps for the same reason it is in job 3's:
+    // the guard clearing must itself re-run this effect, or a `user` that
+    // hydrated while the guard was held would never get its wallet created.
+  }, [user, bridgingSocial]);
 
   // 3. Bridge the wallet to a Supabase account.
   useEffect(() => {


### PR DESCRIPTION
Live at the event: some Google sign-ups land with no wallet. Job 2 starts the multi-round MPC keygen as soon as the Dynamic session exists — mid-handshake — and the bridge success path's hard reload kills it in flight. Gate job 2 on the same bridgingSocial guard as job 3 (with the guard state in the deps so its release re-runs the effect); post-reload the keygen runs uninterrupted. StrictMode test extended: keygen must not start behind a pending bridge, and must run on a plain load.