### PR TITLE
fix(auth): social-return loading on the sign-in buttons, not an overlay

### DIFF
--- a/apps/web/src/app/[locale]/(marketing)/landing-client.tsx
+++ b/apps/web/src/app/[locale]/(marketing)/landing-client.tsx
@@ -14,6 +14,7 @@ import {
 import { Footer } from "@/components/layout/footer";
 import { Button } from "@/components/ui/button";
 import { AuthModal } from "@/components/auth/auth-modal";
+import { useSocialReturnPending } from "@/hooks/use-social-return-pending";
 import { AuthErrorToast } from "@/components/auth/auth-error-toast";
 import { HeroShowcase } from "@/components/landing/hero-showcase";
 import {
@@ -282,6 +283,9 @@ export function LandingPageClient({
 }: LandingPageProps) {
   const t = useTranslations("landing");
   const tCommon = useTranslations("common");
+  const tAuth = useTranslations("auth");
+  // Sign-up trigger carries the Google-return loading state (see AuthModal).
+  const socialReturnPending = useSocialReturnPending();
   const locale = useLocale();
   const [isLoggedIn, setIsLoggedIn] = useState(false);
 
@@ -474,8 +478,22 @@ export function LandingPageClient({
                   {!isLoggedIn && (
                     <AuthModal
                       trigger={
-                        <Button variant="outline" size="lg">
-                          {tCommon("signUp")}
+                        <Button
+                          variant="outline"
+                          size="lg"
+                          disabled={socialReturnPending}
+                        >
+                          {socialReturnPending ? (
+                            <span className="inline-flex items-center gap-2">
+                              <span
+                                className="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent"
+                                aria-hidden="true"
+                              />
+                              {tAuth("signingIn")}
+                            </span>
+                          ) : (
+                            tCommon("signUp")
+                          )}
                         </Button>
                       }
                     />

--- a/apps/web/src/components/auth/__tests__/dynamic-auth-handler-social-return.test.tsx
+++ b/apps/web/src/components/auth/__tests__/dynamic-auth-handler-social-return.test.tsx
@@ -63,7 +63,10 @@ vi.mock("@/lib/supabase/client", () => ({
 vi.mock("@/lib/wallet/siws", () => ({ runWalletSiws }));
 vi.mock("@/lib/dynamic/client", () => ({ logoutDynamic }));
 vi.mock("@/lib/dynamic/siws", () => ({ toMessageSigner: vi.fn() }));
-vi.mock("@/lib/dynamic/social", () => ({ bridgeDynamicSession }));
+vi.mock("@/lib/dynamic/social", () => ({
+  bridgeDynamicSession,
+  setSocialReturnPending: vi.fn(),
+}));
 vi.mock("@/components/ui/toast-container", () => ({ dispatchToast: vi.fn() }));
 
 async function renderFreshHandler() {

--- a/apps/web/src/components/auth/auth-modal.tsx
+++ b/apps/web/src/components/auth/auth-modal.tsx
@@ -19,6 +19,7 @@ import { createClient } from "@/lib/supabase/client";
 import { buildOAuthRedirect } from "@/lib/auth/oauth-redirect";
 import { trackEvent } from "@/lib/analytics";
 import { isDynamicEnabled } from "@/lib/dynamic/config";
+import { useSocialReturnPending } from "@/hooks/use-social-return-pending";
 import { DynamicGoogleSignIn } from "@/components/auth/dynamic-google-sign-in";
 
 interface AuthModalProps {
@@ -66,6 +67,10 @@ export function AuthModal({
   // cannot be conditional, so the gate is a component boundary instead:
   // DynamicGoogleSignIn owns the hooks and mounts only when Dynamic is enabled.
   const dynamicEnabled = isDynamicEnabled();
+  // While the Google-return handshake runs, the trigger button carries the
+  // loading state — the alternative was a full-screen overlay, and the owner
+  // preferred the button.
+  const socialReturnPending = useSocialReturnPending();
   const { setVisible } = useWalletModal();
 
   // Return the learner to the page they signed in from (#619 review): the OAuth
@@ -151,7 +156,21 @@ export function AuthModal({
     >
       {(trigger !== undefined || !isControlled) && (
         <DialogTrigger asChild>
-          {trigger ?? <Button variant="push">{tCommon("signIn")}</Button>}
+          {trigger ?? (
+            <Button variant="push" disabled={socialReturnPending}>
+              {socialReturnPending ? (
+                <span className="inline-flex items-center gap-2">
+                  <span
+                    className="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent"
+                    aria-hidden="true"
+                  />
+                  {t("signingIn")}
+                </span>
+              ) : (
+                tCommon("signIn")
+              )}
+            </Button>
+          )}
         </DialogTrigger>
       )}
       <DialogContent className="sm:max-w-sm">

--- a/apps/web/src/components/auth/dynamic-auth-handler.tsx
+++ b/apps/web/src/components/auth/dynamic-auth-handler.tsx
@@ -21,12 +21,20 @@ import { createClient } from "@/lib/supabase/client";
 import { runWalletSiws } from "@/lib/wallet/siws";
 import { logoutDynamic } from "@/lib/dynamic/client";
 import { toMessageSigner } from "@/lib/dynamic/siws";
-import { bridgeDynamicSession } from "@/lib/dynamic/social";
+import {
+  bridgeDynamicSession,
+  setSocialReturnPending,
+} from "@/lib/dynamic/social";
 import { dispatchToast } from "@/components/ui/toast-container";
 
 /**
- * Everything that has to happen around a Dynamic login. Its only UI is the
- * social-return "signing in" overlay; otherwise it renders nothing.
+ * Everything that has to happen around a Dynamic login, with no UI of its
+ * own. During the social-return handshake it publishes a pending flag
+ * (`setSocialReturnPending`) that the sign-in buttons render as their loading
+ * state — the page would otherwise look signed-out with no cue for the whole
+ * exchange. Set only once a social return is POSITIVELY detected, so ordinary
+ * page loads never flash it; the success reload leaves it set on purpose (the
+ * flag dies with the page).
  *
  * Four jobs, in the order they occur:
  *
@@ -96,12 +104,6 @@ export function DynamicAuthHandler() {
   // while the guard was held would otherwise never get its SIWS turn until
   // some future reload.
   const [bridgingSocial, setBridgingSocial] = useState(true);
-  // The one piece of UI this handler owns: a full-screen "signing in" overlay
-  // for the social-return window. Between Google redirecting back and the
-  // post-bridge reload the page renders fully signed-OUT with no cue at all —
-  // several seconds of "did that work?". True only once a social return is
-  // POSITIVELY detected, so ordinary page loads never flash it.
-  const [finishingSocial, setFinishingSocial] = useState(false);
 
   // 0. Social redirect return.
   useEffect(() => {
@@ -114,7 +116,7 @@ export function DynamicAuthHandler() {
       socialReturnOutcome ??= (async (): Promise<"release" | "hold"> => {
         try {
           if (!(await detectSocialRedirectUrl({ url }))) return "release";
-          setFinishingSocial(true);
+          setSocialReturnPending(true);
 
           await completeSocialRedirect({ url });
           // Before the params are stripped a refresh would replay the callback
@@ -130,7 +132,7 @@ export function DynamicAuthHandler() {
             data: { user: supabaseUser },
           } = await supabase.auth.getUser();
           if (supabaseUser) {
-            setFinishingSocial(false);
+            setSocialReturnPending(false);
             return "release";
           }
 
@@ -150,13 +152,13 @@ export function DynamicAuthHandler() {
           // signed out and can pick another way in.
           dispatchToast(t(outcome.errorKey), "error");
           await logoutDynamic();
-          setFinishingSocial(false);
+          setSocialReturnPending(false);
           return "release";
         } catch (err) {
           console.error("[DynamicAuthHandler] social redirect failed:", err);
           dispatchToast(t("googleBridgeFailed"), "error");
           await logoutDynamic();
-          setFinishingSocial(false);
+          setSocialReturnPending(false);
           return "release";
         }
       })();
@@ -273,19 +275,5 @@ export function DynamicAuthHandler() {
     })();
   }, [walletAccounts, bridgingSocial]);
 
-  if (!finishingSocial) return null;
-  return (
-    <div
-      role="status"
-      className="bg-bg/90 fixed inset-0 z-[100] flex flex-col items-center justify-center gap-3 backdrop-blur-sm"
-    >
-      <div
-        className="h-8 w-8 animate-spin rounded-full border-2 border-current border-t-transparent text-text-3"
-        aria-hidden="true"
-      />
-      <p className="font-display text-sm font-semibold text-text-3">
-        {t("signingIn")}
-      </p>
-    </div>
-  );
+  return null;
 }

--- a/apps/web/src/hooks/use-social-return-pending.ts
+++ b/apps/web/src/hooks/use-social-return-pending.ts
@@ -1,0 +1,21 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+import {
+  getSocialReturnPending,
+  subscribeSocialReturnPending,
+} from "@/lib/dynamic/social";
+
+/**
+ * Whether the Google-return handshake is running right now. Sign-in buttons
+ * use it to show a loading state during the window where the page would
+ * otherwise look signed-out for several seconds. Server snapshot is `false`:
+ * the handshake only exists after hydration.
+ */
+export function useSocialReturnPending(): boolean {
+  return useSyncExternalStore(
+    subscribeSocialReturnPending,
+    getSocialReturnPending,
+    () => false
+  );
+}

--- a/apps/web/src/lib/dynamic/social.ts
+++ b/apps/web/src/lib/dynamic/social.ts
@@ -117,3 +117,30 @@ export async function bridgeDynamicSession(): Promise<DynamicBridgeOutcome> {
     return { ok: false, errorKey: "googleBridgeFailed" };
   }
 }
+
+/**
+ * Social-return pending state, published by `DynamicAuthHandler` while the
+ * redirect-return handshake runs and consumed by the sign-in buttons (via
+ * `useSocialReturnPending`) so THEY carry the loading state — the owner's
+ * call over a full-screen overlay. A module-level store because the handler
+ * and the header render in unrelated trees; threading a context through the
+ * layout for one boolean would be all ceremony.
+ */
+let socialReturnPending = false;
+const pendingListeners = new Set<() => void>();
+
+export function setSocialReturnPending(pending: boolean): void {
+  socialReturnPending = pending;
+  pendingListeners.forEach((listener) => listener());
+}
+
+export function subscribeSocialReturnPending(listener: () => void): () => void {
+  pendingListeners.add(listener);
+  return () => {
+    pendingListeners.delete(listener);
+  };
+}
+
+export function getSocialReturnPending(): boolean {
+  return socialReturnPending;
+}


### PR DESCRIPTION
Replaces #1033's full-screen overlay per owner feedback: DynamicAuthHandler publishes a socialReturnPending flag (module store + useSyncExternalStore hook — handler and header render in unrelated trees), and the AuthModal default trigger + the landing sign-up trigger show a spinner and disable while the Google-return handshake runs. Handler returns to rendering nothing. 42 auth/dynamic tests green.