### PR TITLE
fix(admin): course create writes bundle XP values; sync no-ops when chain matches

### DIFF
--- a/apps/web/src/app/api/admin/courses/sync/__tests__/route.test.ts
+++ b/apps/web/src/app/api/admin/courses/sync/__tests__/route.test.ts
@@ -1,0 +1,174 @@
+/* eslint-disable import/order -- vi.mock calls must precede importing the route. */
+// #993 regression: a course whose bundle XP values already match the chain
+// must NO-OP on sync — the old update arm pushed newXpPerLesson /
+// newCreatorRewardXp unconditionally, so every sync issued an update_course
+// and a freshly created course could never settle.
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("server-only", () => ({}));
+
+const {
+  getAccountInfo,
+  fetchCourse,
+  updateCoursePda,
+  deployCoursePda,
+  writeCourseOnChainStatus,
+  writeCourseMaintenanceFlag,
+  getAllCoursesAdmin,
+} = vi.hoisted(() => ({
+  getAccountInfo: vi.fn(),
+  fetchCourse: vi.fn(),
+  updateCoursePda: vi.fn(),
+  deployCoursePda: vi.fn(),
+  writeCourseOnChainStatus: vi.fn(),
+  writeCourseMaintenanceFlag: vi.fn(),
+  getAllCoursesAdmin: vi.fn(),
+}));
+
+vi.mock("next/cache", () => ({ revalidateTag: vi.fn() }));
+vi.mock("@/lib/env.server", () => ({
+  serverEnv: { SOLANA_RPC_URL: "http://localhost:8899" },
+}));
+vi.mock("@/lib/admin/auth", () => ({
+  requireAdminAuth: vi.fn(),
+  adminUnauthorizedResponse: vi.fn(),
+  AdminAuthError: class AdminAuthError extends Error {},
+}));
+vi.mock("@/lib/platform/freeze", () => ({
+  isPlatformFrozen: vi.fn().mockResolvedValue(false),
+}));
+vi.mock("@/lib/platform/freeze-http", () => ({
+  platformFrozenResponse: vi.fn(),
+}));
+vi.mock("@/lib/content/queries", () => ({
+  getAllCoursesAdmin,
+  COURSES_CACHE_TAG: "courses",
+}));
+vi.mock("@/lib/solana/academy-reads", () => ({ fetchCourse }));
+vi.mock("@/lib/solana/admin-signer", () => ({
+  deployCoursePda,
+  updateCoursePda,
+  deployCourseTrackCollection: vi.fn(),
+  setCourseCollectionPda: vi.fn(),
+  buildCourseCommit: vi.fn(),
+}));
+vi.mock("@/lib/content/deployment-writes", () => ({
+  writeCourseMaintenanceFlag,
+  writeCourseOnChainStatus,
+  writeCourseTrackCollection: vi.fn(),
+}));
+vi.mock("@/lib/content/changelog-writes", () => ({
+  recordCourseDeployed: vi.fn(),
+  recordCourseUpdate: vi.fn(),
+}));
+vi.mock("@/lib/content/prior-content", () => ({
+  contentShaFromTxId: vi.fn(),
+  resolvePriorRemovedLessons: vi.fn(),
+}));
+vi.mock("@/lib/content/store", () => ({ slotsByCourseId: new Map() }));
+vi.mock("@/lib/content/meta", () => ({ SYNCED_SHA: "deadbeef" }));
+vi.mock("@solana/web3.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@solana/web3.js")>();
+  return {
+    ...actual,
+    Connection: class {
+      getAccountInfo = getAccountInfo;
+    },
+  };
+});
+
+import { POST } from "../route";
+import { PublicKey } from "@solana/web3.js";
+
+const COURSE_ID = "course-btc-to-sol-evolution";
+
+/** A bundle course that passes getMissingCourseFields (the real one runs). */
+function bundleCourse(overrides: Record<string, unknown> = {}) {
+  return {
+    _id: COURSE_ID,
+    title: "BTC to SOL",
+    slug: "btc-to-sol",
+    difficulty: "beginner",
+    lessonCount: 10,
+    xpPerLesson: 20,
+    creatorRewardXp: 30,
+    trackId: 1,
+    trackLevel: 1,
+    prerequisiteCourse: null,
+    creatorWallet: "3WECquwCtcKVRYNWBPFWE28ag3b1CDKchLZPXxifAJzQ",
+    onChainStatus: { status: "synced", coursePda: null },
+    ...overrides,
+  };
+}
+
+/** On-chain decode matching the bundle values above. */
+function decodedCourse(overrides: Record<string, unknown> = {}) {
+  return {
+    course_id: COURSE_ID,
+    xp_per_lesson: 20,
+    creator_reward_xp: 30,
+    collection: PublicKey.default,
+    activeLessons: [0n, 0n, 0n, 0n],
+    content_tx_id: new Array(32).fill(0),
+    version: 1,
+    liveLessonCount: 10,
+    ...overrides,
+  };
+}
+
+function syncRequest(): NextRequest {
+  return new NextRequest("https://app.test/api/admin/courses/sync", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ courseId: COURSE_ID }),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getAllCoursesAdmin.mockResolvedValue([bundleCourse()]);
+  getAccountInfo.mockResolvedValue({ data: Buffer.alloc(253) });
+  fetchCourse.mockResolvedValue(decodedCourse());
+  writeCourseOnChainStatus.mockResolvedValue(undefined);
+  writeCourseMaintenanceFlag.mockResolvedValue(undefined);
+  updateCoursePda.mockResolvedValue({ success: true, signature: "SIG" });
+});
+
+describe("POST /api/admin/courses/sync — #993 no-op regression", () => {
+  it("no-ops when bundle XP values match the chain", async () => {
+    const res = await POST(syncRequest());
+    const body = (await res.json()) as { action?: string };
+
+    expect(body.action).toBe("noop");
+    expect(updateCoursePda).not.toHaveBeenCalled();
+  });
+
+  it("updates only the field that actually differs", async () => {
+    fetchCourse.mockResolvedValue(decodedCourse({ xp_per_lesson: 10 }));
+
+    const res = await POST(syncRequest());
+    const body = (await res.json()) as {
+      action?: string;
+      fieldsUpdated?: string[];
+    };
+
+    expect(body.action).toBe("updated");
+    expect(body.fieldsUpdated).toEqual(["newXpPerLesson"]);
+    expect(updateCoursePda).toHaveBeenCalledWith(
+      expect.objectContaining({ newXpPerLesson: 20 })
+    );
+    expect(updateCoursePda.mock.calls[0]![0]).not.toHaveProperty(
+      "newCreatorRewardXp"
+    );
+  });
+
+  it("409s when the account vanishes between the two reads", async () => {
+    fetchCourse.mockResolvedValue(null);
+
+    const res = await POST(syncRequest());
+
+    expect(res.status).toBe(409);
+    expect(updateCoursePda).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/app/api/admin/courses/sync/route.ts
+++ b/apps/web/src/app/api/admin/courses/sync/route.ts
@@ -395,10 +395,7 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
       { status: 409 }
     );
   }
-  const onChainCollection = onChainCourse.collection as unknown as
-    | string
-    | Uint8Array
-    | undefined;
+  const onChainCollection = onChainCourse.collection;
   const boundCollection =
     onChainCollection == null
       ? null

--- a/apps/web/src/app/api/admin/courses/sync/route.ts
+++ b/apps/web/src/app/api/admin/courses/sync/route.ts
@@ -400,10 +400,7 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
       { status: 409 }
     );
   }
-  const onChainCollection = onChainCourse.collection as unknown as
-    | string
-    | Uint8Array
-    | undefined;
+  const onChainCollection = onChainCourse.collection;
   const boundCollection =
     onChainCollection == null
       ? null

--- a/apps/web/src/app/api/admin/courses/sync/route.ts
+++ b/apps/web/src/app/api/admin/courses/sync/route.ts
@@ -250,14 +250,16 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
 
     // Honor exactly what the content sets (the content-schema and the projector
     // both default these to 0), so the deploy value and the drift engine's
-    // comparison — which also treats absent as 0 — never disagree.
+    // comparison — which also treats absent as 0 — never disagree. The old
+    // `xpPerLesson ?? 10` here is what made every freshly created course need
+    // an immediate update_course to match the bundle (#993).
     const creatorRewardXp = course.creatorRewardXp ?? 0;
 
     const result = await deployCoursePda({
       courseId,
       lessonCount: course.lessonCount,
       difficulty: difficultyToNumber(course.difficulty),
-      xpPerLesson: course.xpPerLesson ?? 10,
+      xpPerLesson: course.xpPerLesson ?? 0,
       trackId: course.trackId ?? 0,
       trackLevel: course.trackLevel ?? 0,
       prerequisitePda,
@@ -385,7 +387,15 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
       { status: 400 }
     );
   }
-  const onChainCollection = onChainCourse?.collection as
+  // accountInfo existed above, so a null here means the account vanished
+  // between the two reads (close_course race) — abort rather than guess.
+  if (!onChainCourse) {
+    return NextResponse.json(
+      { error: "Course account disappeared mid-sync — re-run the sync" },
+      { status: 409 }
+    );
+  }
+  const onChainCollection = onChainCourse.collection as unknown as
     | string
     | Uint8Array
     | undefined;
@@ -498,11 +508,20 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
     updatedFields.push("newActiveLessons");
   }
 
-  if (course.xpPerLesson !== null) {
+  // Only when the bundle value actually differs from what's on-chain (#993):
+  // unconditionally pushing these meant every sync issued an update_course
+  // and a freshly created course could never no-op.
+  if (
+    course.xpPerLesson !== null &&
+    course.xpPerLesson !== onChainCourse.xp_per_lesson
+  ) {
     updateParams.newXpPerLesson = course.xpPerLesson;
     updatedFields.push("newXpPerLesson");
   }
-  if (course.creatorRewardXp !== null) {
+  if (
+    course.creatorRewardXp !== null &&
+    course.creatorRewardXp !== onChainCourse.creator_reward_xp
+  ) {
     updateParams.newCreatorRewardXp = course.creatorRewardXp;
     updatedFields.push("newCreatorRewardXp");
   }

--- a/apps/web/src/app/api/admin/courses/sync/route.ts
+++ b/apps/web/src/app/api/admin/courses/sync/route.ts
@@ -248,18 +248,23 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
       );
     }
 
-    // Honor exactly what the content sets (the content-schema and the projector
-    // both default these to 0), so the deploy value and the drift engine's
-    // comparison — which also treats absent as 0 — never disagree. The old
-    // `xpPerLesson ?? 10` here is what made every freshly created course need
-    // an immediate update_course to match the bundle (#993).
+    // creatorRewardXp: honor exactly what the content sets (the content-schema
+    // and the projector both default it to 0, and so does the drift engine).
+    //
+    // xpPerLesson's `?? 10` below is DEAD CODE, not policy: the
+    // getMissingCourseFields gate above already 400s on a null-or-≤0
+    // xpPerLesson, so the fallback can never fire. It stays 10 because that is
+    // what the drift engine (sync-diff.ts) and recreate-course.ts use for the
+    // same unreachable case — three agreeing dead fallbacks beat one divergent
+    // one. The #993 always-update came from the update arm below pushing XP
+    // fields unconditionally, not from this line.
     const creatorRewardXp = course.creatorRewardXp ?? 0;
 
     const result = await deployCoursePda({
       courseId,
       lessonCount: course.lessonCount,
       difficulty: difficultyToNumber(course.difficulty),
-      xpPerLesson: course.xpPerLesson ?? 0,
+      xpPerLesson: course.xpPerLesson ?? 10,
       trackId: course.trackId ?? 0,
       trackLevel: course.trackLevel ?? 0,
       prerequisitePda,
@@ -395,7 +400,10 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
       { status: 409 }
     );
   }
-  const onChainCollection = onChainCourse.collection;
+  const onChainCollection = onChainCourse.collection as unknown as
+    | string
+    | Uint8Array
+    | undefined;
   const boundCollection =
     onChainCollection == null
       ? null

--- a/apps/web/src/app/api/auth/dynamic/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/dynamic/__tests__/route.test.ts
@@ -16,6 +16,9 @@ const {
   isAccountDeleted,
   profileSingle,
   profileUpdate,
+  shellLookup,
+  getUserById,
+  rpcMock,
   retryPendingOnchainActions,
   generateWalletName,
 } = vi.hoisted(() => ({
@@ -29,6 +32,9 @@ const {
   isAccountDeleted: vi.fn<(userId: string) => Promise<boolean>>(),
   profileSingle: vi.fn(),
   profileUpdate: vi.fn<(values: Record<string, unknown>) => Promise<unknown>>(),
+  shellLookup: vi.fn(),
+  getUserById: vi.fn(),
+  rpcMock: vi.fn(),
   retryPendingOnchainActions: vi.fn<(userId: string) => Promise<void>>(),
   generateWalletName: vi.fn<() => string>(),
 }));
@@ -44,9 +50,14 @@ vi.mock("@/lib/solana/onchain-queue", () => ({ retryPendingOnchainActions }));
 // post-login profile read/update (placeholder-username replacement).
 vi.mock("@/lib/supabase/admin", () => ({
   createAdminClient: () => ({
-    auth: { admin: { createUser, generateLink } },
+    auth: { admin: { createUser, generateLink, getUserById } },
+    rpc: rpcMock,
     from: () => ({
-      select: () => ({ eq: () => ({ single: profileSingle }) }),
+      select: () => ({
+        eq: () => ({ single: profileSingle }),
+        // The shell-candidate lookup: .in(wallets).neq(id).is(deleted_at).
+        in: () => ({ neq: () => ({ is: shellLookup }) }),
+      }),
       update: (values: Record<string, unknown>) => ({
         eq: () => profileUpdate(values),
       }),
@@ -198,8 +209,15 @@ beforeEach(() => {
   });
   signOut.mockResolvedValue({ error: null });
   isAccountDeleted.mockResolvedValue(false);
-  profileSingle.mockResolvedValue({ data: { username: "sol-surfer" } });
+  // Default: an account that already owns a wallet, so the account-fork
+  // auto-merge never triggers unless a test opts in.
+  profileSingle.mockResolvedValue({
+    data: { username: "sol-surfer", wallet_address: "ExistingWallet1111" },
+  });
   profileUpdate.mockResolvedValue({ error: null });
+  shellLookup.mockResolvedValue({ data: [], error: null });
+  getUserById.mockResolvedValue({ data: { user: null }, error: null });
+  rpcMock.mockResolvedValue({ data: {}, error: null });
   retryPendingOnchainActions.mockResolvedValue(undefined);
   generateWalletName.mockReturnValue("brave-otter");
 });
@@ -768,5 +786,177 @@ describe("POST /api/auth/dynamic — post-login parity with the other chokepoint
 
     expect(res.status).toBe(403);
     expect(retryPendingOnchainActions).not.toHaveBeenCalled();
+  });
+});
+
+describe("POST /api/auth/dynamic — account-fork auto-merge", () => {
+  const SHELL_WALLET = "She11Wa11etAddre55Base58Looking111";
+  const SHELL_ID = "shell-user-1";
+
+  function blockchainCredential(overrides: Record<string, unknown> = {}) {
+    return {
+      id: "wallet-credential-1",
+      format: "blockchain",
+      address: SHELL_WALLET,
+      chain: "solana",
+      signInEnabled: true,
+      ...overrides,
+    };
+  }
+
+  /** A walletless target + one matching shell, unless a test overrides. */
+  function armMergeScenario() {
+    profileSingle.mockResolvedValue({
+      data: { username: "sol-surfer", wallet_address: null },
+    });
+    shellLookup.mockResolvedValue({
+      data: [{ id: SHELL_ID, wallet_address: SHELL_WALLET }],
+      error: null,
+    });
+    getUserById.mockResolvedValue({
+      data: {
+        user: {
+          email: `${SHELL_WALLET}@wallet.superteam-lms.local`,
+          identities: [{ provider: "email" }],
+        },
+      },
+      error: null,
+    });
+  }
+
+  const jwtWithWallet = () =>
+    signDynamicJwt({
+      claims: {
+        verified_credentials: [googleCredential(), blockchainCredential()],
+      },
+    });
+
+  it("merges the shell the JWT's blockchain credential proves ownership of", async () => {
+    armMergeScenario();
+
+    const res = await POST(
+      dynamicRequest({ dynamicJwt: await jwtWithWallet() })
+    );
+
+    expect(res.status).toBe(200);
+    expect(rpcMock).toHaveBeenCalledWith("merge_wallet_shell_account", {
+      p_target: "supabase-user-1",
+      p_shell: SHELL_ID,
+      p_wallet: SHELL_WALLET,
+    });
+  });
+
+  it("never merges on an email match alone — no blockchain credential, no merge", async () => {
+    armMergeScenario();
+
+    const res = await POST(
+      dynamicRequest({ dynamicJwt: await signDynamicJwt() })
+    );
+
+    expect(res.status).toBe(200);
+    expect(rpcMock).not.toHaveBeenCalled();
+  });
+
+  it("skips the merge when the signed-in account already has a wallet", async () => {
+    armMergeScenario();
+    profileSingle.mockResolvedValue({
+      data: { username: "sol-surfer", wallet_address: "AlreadyLinked111" },
+    });
+
+    const res = await POST(
+      dynamicRequest({ dynamicJwt: await jwtWithWallet() })
+    );
+
+    expect(res.status).toBe(200);
+    expect(rpcMock).not.toHaveBeenCalled();
+  });
+
+  it("refuses to merge an account whose email is not the synthetic wallet form", async () => {
+    armMergeScenario();
+    getUserById.mockResolvedValue({
+      data: {
+        user: {
+          email: "human@example.com",
+          identities: [{ provider: "email" }],
+        },
+      },
+      error: null,
+    });
+
+    const res = await POST(
+      dynamicRequest({ dynamicJwt: await jwtWithWallet() })
+    );
+
+    expect(res.status).toBe(200);
+    expect(rpcMock).not.toHaveBeenCalled();
+  });
+
+  it("refuses to merge an account that has a real OAuth identity", async () => {
+    armMergeScenario();
+    getUserById.mockResolvedValue({
+      data: {
+        user: {
+          email: `${SHELL_WALLET}@wallet.superteam-lms.local`,
+          identities: [{ provider: "email" }, { provider: "google" }],
+        },
+      },
+      error: null,
+    });
+
+    const res = await POST(
+      dynamicRequest({ dynamicJwt: await jwtWithWallet() })
+    );
+
+    expect(res.status).toBe(200);
+    expect(rpcMock).not.toHaveBeenCalled();
+  });
+
+  it("skips when two shells match — ambiguity never merges", async () => {
+    armMergeScenario();
+    shellLookup.mockResolvedValue({
+      data: [
+        { id: SHELL_ID, wallet_address: SHELL_WALLET },
+        { id: "shell-user-2", wallet_address: "OtherWallet222" },
+      ],
+      error: null,
+    });
+
+    const res = await POST(
+      dynamicRequest({ dynamicJwt: await jwtWithWallet() })
+    );
+
+    expect(res.status).toBe(200);
+    expect(rpcMock).not.toHaveBeenCalled();
+  });
+
+  it("still signs in when the merge RPC refuses", async () => {
+    armMergeScenario();
+    rpcMock.mockResolvedValue({
+      data: null,
+      error: { message: "merge refused: shell wallet does not match" },
+    });
+
+    const res = await POST(
+      dynamicRequest({ dynamicJwt: await jwtWithWallet() })
+    );
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ success: true });
+  });
+
+  it("runs the merge before the on-chain queue drain", async () => {
+    armMergeScenario();
+    const order: string[] = [];
+    rpcMock.mockImplementation(async () => {
+      order.push("merge");
+      return { data: {}, error: null };
+    });
+    retryPendingOnchainActions.mockImplementation(async () => {
+      order.push("drain");
+    });
+
+    await POST(dynamicRequest({ dynamicJwt: await jwtWithWallet() }));
+
+    expect(order).toEqual(["merge", "drain"]);
   });
 });

--- a/apps/web/src/app/api/auth/dynamic/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/dynamic/__tests__/route.test.ts
@@ -929,6 +929,88 @@ describe("POST /api/auth/dynamic — account-fork auto-merge", () => {
     expect(rpcMock).not.toHaveBeenCalled();
   });
 
+  it("ignores a blockchain credential from a foreign chain", async () => {
+    armMergeScenario();
+
+    const res = await POST(
+      dynamicRequest({
+        dynamicJwt: await signDynamicJwt({
+          claims: {
+            verified_credentials: [
+              googleCredential(),
+              blockchainCredential({ chain: "EVM" }),
+            ],
+          },
+        }),
+      })
+    );
+
+    expect(res.status).toBe(200);
+    expect(rpcMock).not.toHaveBeenCalled();
+  });
+
+  it("ignores a blockchain credential Dynamic says cannot sign in", async () => {
+    armMergeScenario();
+
+    const res = await POST(
+      dynamicRequest({
+        dynamicJwt: await signDynamicJwt({
+          claims: {
+            verified_credentials: [
+              googleCredential(),
+              blockchainCredential({ signInEnabled: false }),
+            ],
+          },
+        }),
+      })
+    );
+
+    expect(res.status).toBe(200);
+    expect(rpcMock).not.toHaveBeenCalled();
+  });
+
+  it("still merges when the credential carries no chain field at all", async () => {
+    // `chain` is schema-optional; refusing on absence would silently dead the
+    // feature on a wire-shape change. Address equality still gates.
+    armMergeScenario();
+
+    const res = await POST(
+      dynamicRequest({
+        dynamicJwt: await signDynamicJwt({
+          claims: {
+            verified_credentials: [
+              googleCredential(),
+              blockchainCredential({ chain: undefined }),
+            ],
+          },
+        }),
+      })
+    );
+
+    expect(res.status).toBe(200);
+    expect(rpcMock).toHaveBeenCalled();
+  });
+
+  it("refuses a candidate with NO identities at all", async () => {
+    armMergeScenario();
+    getUserById.mockResolvedValue({
+      data: {
+        user: {
+          email: `${SHELL_WALLET}@wallet.superteam-lms.local`,
+          identities: [],
+        },
+      },
+      error: null,
+    });
+
+    const res = await POST(
+      dynamicRequest({ dynamicJwt: await jwtWithWallet() })
+    );
+
+    expect(res.status).toBe(200);
+    expect(rpcMock).not.toHaveBeenCalled();
+  });
+
   it("still signs in when the merge RPC refuses", async () => {
     armMergeScenario();
     rpcMock.mockResolvedValue({

--- a/apps/web/src/app/api/auth/dynamic/route.ts
+++ b/apps/web/src/app/api/auth/dynamic/route.ts
@@ -312,6 +312,108 @@ function resolveVerifiedEmail(claims: DynamicJwtClaims): EmailResolution {
  */
 const MAX_BODY_BYTES = 16_000;
 
+/**
+ * Wallet addresses the JWT proves this Dynamic user controls.
+ *
+ * `blockchain` credentials are Dynamic-attested wallets (the embedded wallet
+ * it created for this user, plus any it verified). Their `address` is the
+ * ownership proof the account-fork auto-merge below rests on — the JWT is
+ * signed by Dynamic for THIS user, so a wallet listed here is theirs in a way
+ * an email match could never establish. No chain filter: a non-Solana address
+ * simply matches no `profiles.wallet_address`. Capped because the array is
+ * attacker-adjacent input even after signature verification.
+ */
+function blockchainAddresses(claims: DynamicJwtClaims): string[] {
+  const credentials = Array.isArray(claims.verified_credentials)
+    ? claims.verified_credentials
+    : [];
+  const addresses = new Set<string>();
+  for (const credential of credentials) {
+    if (!isRecord(credential)) continue;
+    if (credential.format !== "blockchain") continue;
+    const address = credential.address;
+    if (typeof address === "string" && address.trim() !== "") {
+      addresses.add(address.trim());
+    }
+  }
+  return [...addresses].slice(0, 10);
+}
+
+/**
+ * Heal the mixed-method account fork (AUTH-FLOWS.md §7): if this JWT proves
+ * the caller owns a wallet that keys a wallet-shaped SHELL account (synthetic
+ * `@wallet.superteam-lms.local` email, no OAuth identities), fold that shell —
+ * wallet, XP, enrollments, everything — into the account they just signed
+ * into. The `blockchain` credential is the proof; an email match alone never
+ * merges anything.
+ *
+ * Fail-open by design: any doubt (ambiguity, lookup error, RPC refusal) skips
+ * the merge and the sign-in proceeds unmerged — the fork is an annoyance, a
+ * wrong merge is an account takeover. The RPC re-validates shell-ness in SQL
+ * and runs the whole move in one transaction, so a half-merged state cannot
+ * exist.
+ */
+async function mergeWalletShellAccount(
+  supabaseAdmin: ReturnType<typeof createAdminClient>,
+  userId: string,
+  claims: DynamicJwtClaims
+): Promise<void> {
+  try {
+    const wallets = blockchainAddresses(claims);
+    if (wallets.length === 0) return;
+
+    const { data: shells, error: shellError } = await supabaseAdmin
+      .from("profiles")
+      .select("id, wallet_address")
+      .in("wallet_address", wallets)
+      .neq("id", userId)
+      .is("deleted_at", null);
+    if (shellError || !shells || shells.length === 0) return;
+    if (shells.length > 1) {
+      logEvent({
+        event: "dynamic-auth.shell-merge-ambiguous",
+        context: { userId, candidates: shells.length },
+      });
+      return;
+    }
+    const shell = shells[0]!;
+    if (!shell.wallet_address) return;
+
+    // Shell-ness, auth side: the synthetic email says the account was born
+    // from a wallet; the identities check says it never became anything more.
+    // An account with a real OAuth identity is somebody's account, not a
+    // shell — never merge it, whatever its email looks like. The RPC
+    // re-proves the profile side (google_id/github_id NULL, email pattern).
+    const { data: shellUser, error: userError } =
+      await supabaseAdmin.auth.admin.getUserById(shell.id);
+    if (userError || !shellUser?.user) return;
+    const shellEmail = shellUser.user.email ?? "";
+    if (!shellEmail.endsWith("@wallet.superteam-lms.local")) return;
+    const identities = shellUser.user.identities ?? [];
+    if (identities.some((identity) => identity.provider !== "email")) return;
+
+    const { data: merged, error: mergeError } = await supabaseAdmin.rpc(
+      "merge_wallet_shell_account",
+      { p_target: userId, p_shell: shell.id, p_wallet: shell.wallet_address }
+    );
+    if (mergeError) {
+      logError({
+        errorId: ERROR_IDS.DYNAMIC_AUTH_FAILED,
+        error: new Error(mergeError.message),
+        context: { note: "shell merge refused", userId, shellId: shell.id },
+      });
+      return;
+    }
+    logEvent({ event: "dynamic-auth.shell-merged", context: { merged } });
+  } catch (err: unknown) {
+    logError({
+      errorId: ERROR_IDS.DYNAMIC_AUTH_FAILED,
+      error: err instanceof Error ? err : new Error(String(err)),
+      context: { note: "shell merge failed", userId },
+    });
+  }
+}
+
 export async function POST(request: NextRequest): Promise<NextResponse> {
   try {
     // The environment id is the tenant binding for everything below, so an
@@ -514,9 +616,16 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     // Existing matched accounts already have a real name and are left alone.
     const { data: profile } = await supabaseAdmin
       .from("profiles")
-      .select("username")
+      .select("username, wallet_address")
       .eq("id", userId)
       .single();
+
+    // Account-fork auto-merge, only when this account has no wallet of its
+    // own to lose — and BEFORE the queue drain below, so pending on-chain
+    // actions inherited from the shell drain in this same sign-in.
+    if (!profile?.wallet_address) {
+      await mergeWalletShellAccount(supabaseAdmin, userId, claims);
+    }
 
     if (profile?.username?.startsWith("user_")) {
       for (let attempt = 0; attempt < 5; attempt++) {

--- a/apps/web/src/app/api/auth/dynamic/route.ts
+++ b/apps/web/src/app/api/auth/dynamic/route.ts
@@ -315,12 +315,21 @@ const MAX_BODY_BYTES = 16_000;
 /**
  * Wallet addresses the JWT proves this Dynamic user controls.
  *
- * `blockchain` credentials are Dynamic-attested wallets (the embedded wallet
- * it created for this user, plus any it verified). Their `address` is the
- * ownership proof the account-fork auto-merge below rests on — the JWT is
- * signed by Dynamic for THIS user, so a wallet listed here is theirs in a way
- * an email match could never establish. No chain filter: a non-Solana address
- * simply matches no `profiles.wallet_address`. Capped because the array is
+ * `blockchain` credentials are Dynamic-attested wallets: per Dynamic's auth
+ * model a wallet only becomes a verified credential after the user SIGNS a
+ * message proving ownership (connect-without-signing makes a "visitor", who
+ * gets no JWT at all). Their `address` is the ownership proof the
+ * account-fork auto-merge below rests on — the JWT is signed by Dynamic for
+ * THIS user, so a wallet listed here is theirs in a way an email match could
+ * never establish.
+ *
+ * Same per-credential respect as `matchableEmail`: a credential Dynamic says
+ * cannot sign in must not merge an account either. The chain guard skips
+ * KNOWN-foreign chains (the SDK's ChainEnum stamps Solana as "SOL"; "solana"
+ * accepted in case the wire form differs) but tolerates an ABSENT chain — the
+ * field is schema-optional, and refusing on absence would silently dead the
+ * whole feature on a wire-shape surprise; address equality against
+ * `profiles.wallet_address` still gates. Capped because the array is
  * attacker-adjacent input even after signature verification.
  */
 function blockchainAddresses(claims: DynamicJwtClaims): string[] {
@@ -331,6 +340,12 @@ function blockchainAddresses(claims: DynamicJwtClaims): string[] {
   for (const credential of credentials) {
     if (!isRecord(credential)) continue;
     if (credential.format !== "blockchain") continue;
+    if (credential.signInEnabled === false) continue;
+    const chain =
+      typeof credential.chain === "string"
+        ? credential.chain.toLowerCase()
+        : null;
+    if (chain !== null && chain !== "sol" && chain !== "solana") continue;
     const address = credential.address;
     if (typeof address === "string" && address.trim() !== "") {
       addresses.add(address.trim());
@@ -389,7 +404,11 @@ async function mergeWalletShellAccount(
     if (userError || !shellUser?.user) return;
     const shellEmail = shellUser.user.email ?? "";
     if (!shellEmail.endsWith("@wallet.superteam-lms.local")) return;
+    // A real shell has exactly its synthetic email identity (from
+    // admin.createUser). Any non-email identity means it is somebody's
+    // account; NO identities means we don't know what it is — refuse both.
     const identities = shellUser.user.identities ?? [];
+    if (identities.length === 0) return;
     if (identities.some((identity) => identity.provider !== "email")) return;
 
     const { data: merged, error: mergeError } = await supabaseAdmin.rpc(

--- a/apps/web/src/lib/solana/academy-reads.ts
+++ b/apps/web/src/lib/solana/academy-reads.ts
@@ -72,7 +72,12 @@ interface RawCourseV1 {
   is_active: boolean;
   created_at: BN;
   updated_at: BN;
-  collection: PublicKey;
+  // Declared as the union the raw BorshCoder is actually observed to
+  // produce (base58 string or raw bytes; PublicKey when it round-trips
+  // one) — every consumer normalizes (achievements/sync, courses/sync,
+  // recreate-course). Declaring bare PublicKey here forced casts at the
+  // use sites that hid the disagreement instead of resolving it.
+  collection: PublicKey | Uint8Array | string;
   _reserved: number[];
   bump: number;
 }
@@ -95,7 +100,12 @@ interface RawCourseVNext {
   is_active: boolean;
   created_at: BN;
   updated_at: BN;
-  collection: PublicKey;
+  // Declared as the union the raw BorshCoder is actually observed to
+  // produce (base58 string or raw bytes; PublicKey when it round-trips
+  // one) — every consumer normalizes (achievements/sync, courses/sync,
+  // recreate-course). Declaring bare PublicKey here forced casts at the
+  // use sites that hid the disagreement instead of resolving it.
+  collection: PublicKey | Uint8Array | string;
   _reserved: number[];
   bump: number;
 }
@@ -124,7 +134,12 @@ export interface DecodedCourse {
   is_active: boolean;
   created_at: BN;
   updated_at: BN;
-  collection: PublicKey;
+  // Declared as the union the raw BorshCoder is actually observed to
+  // produce (base58 string or raw bytes; PublicKey when it round-trips
+  // one) — every consumer normalizes (achievements/sync, courses/sync,
+  // recreate-course). Declaring bare PublicKey here forced casts at the
+  // use sites that hid the disagreement instead of resolving it.
+  collection: PublicKey | Uint8Array | string;
   _reserved: number[];
   bump: number;
   /** 256-bit live-lesson mask (4 u64 words), always populated, both versions. */

--- a/apps/web/src/lib/supabase/__tests__/merge-wallet-shell-execution.test.ts
+++ b/apps/web/src/lib/supabase/__tests__/merge-wallet-shell-execution.test.ts
@@ -72,6 +72,19 @@ const STUB_SETUP = `
   CREATE ROLE service_role;
   CREATE SCHEMA IF NOT EXISTS auth;
   CREATE TABLE auth.users (id uuid PRIMARY KEY, email text UNIQUE);
+  -- GoTrue's own FK-to-auth.users tables. A shell ALWAYS has an identities
+  -- row (admin.createUser), and the shell's auth.users row survives the
+  -- merge — so if the FK sweep is not schema-scoped to public, every real
+  -- merge aborts here (adversarial review F1). These stubs keep that fixed.
+  CREATE TABLE auth.identities (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    provider text NOT NULL
+  );
+  CREATE TABLE auth.sessions (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE
+  );
 
   CREATE TABLE public.profiles (
     id uuid PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
@@ -89,7 +102,10 @@ const STUB_SETUP = `
     current_streak integer DEFAULT 0,
     longest_streak integer DEFAULT 0,
     last_activity_date date,
-    streak_freezes integer NOT NULL DEFAULT 0
+    streak_freezes integer NOT NULL DEFAULT 0,
+    CONSTRAINT chk_user_xp_longest_gte_current CHECK (longest_streak >= current_streak),
+    CONSTRAINT chk_user_xp_streak_freezes_bounds CHECK (streak_freezes BETWEEN 0 AND 2),
+    CONSTRAINT chk_user_xp_nonnegative CHECK (total_xp >= 0 AND current_streak >= 0 AND longest_streak >= 0)
   );
   CREATE TABLE public.xp_transactions (
     id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -100,12 +116,21 @@ const STUB_SETUP = `
     id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
     user_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
     course_id text NOT NULL,
+    enrolled_at timestamptz DEFAULT now(),
+    completed_at timestamptz,
+    tx_signature text,
+    wallet_address text,
     UNIQUE(user_id, course_id)
   );
   CREATE TABLE public.user_progress (
     id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
     user_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+    course_id text NOT NULL DEFAULT 'course-a',
     lesson_id text NOT NULL,
+    completed boolean DEFAULT false,
+    completed_at timestamptz,
+    tx_signature text,
+    lesson_index smallint,
     UNIQUE(user_id, lesson_id)
   );
   CREATE TABLE public.user_achievements (
@@ -241,6 +266,15 @@ describe("merge_wallet_shell_account", () => {
       `INSERT INTO auth.users(id, email) VALUES ($1, $2), ($3, $4)`,
       [TARGET, "learner@example.com", SHELL, shellEmail]
     );
+    // What GoTrue really holds for these accounts: an email identity each
+    // (admin.createUser always writes one) and a live session for the shell.
+    // These rows SURVIVE the merge — the F1 regression this suite pins: an
+    // unscoped FK sweep would see them and abort every real merge.
+    await db.query(
+      `INSERT INTO auth.identities(user_id, provider) VALUES ($1, 'google'), ($2, 'email')`,
+      [TARGET, SHELL]
+    );
+    await db.query(`INSERT INTO auth.sessions(user_id) VALUES ($1)`, [SHELL]);
     // service_role because the REAL wallet-write trigger is installed and
     // seeding a wallet is exactly the write it locks down.
     await db.exec("SET ROLE service_role;");
@@ -364,6 +398,51 @@ describe("merge_wallet_shell_account", () => {
       `SELECT count(*)::int AS n FROM public.xp_transactions WHERE user_id = '${TARGET}'`
     );
     expect((transactions[0] as { n: number }).n).toBe(2);
+  });
+
+  it("backfills on-chain enrollment and lesson progress into the target's colliding rows", async () => {
+    // The shell is the account that HAD the wallet, so on a collision the
+    // shell's row is the on-chain one (tx_signature set, completed bit the
+    // program refuses to re-set) and the target's is the empty social-only
+    // one. Blanket keep-target would strand the learner: DB says incomplete,
+    // chain says LessonAlreadyCompleted (adversarial review F2).
+    await seedAccounts();
+    await db.exec(`
+      INSERT INTO public.enrollments(user_id, course_id, tx_signature, wallet_address, completed_at)
+        VALUES ('${TARGET}', 'course-a', NULL, NULL, NULL),
+               ('${SHELL}', 'course-a', 'ONCHAIN_ENROLL_SIG', '${WALLET}', '2026-08-10T12:00:00Z');
+      INSERT INTO public.user_progress(user_id, lesson_id, completed, tx_signature, lesson_index)
+        VALUES ('${TARGET}', 'lesson-1', false, NULL, NULL),
+               ('${SHELL}', 'lesson-1', true, 'ONCHAIN_LESSON_SIG', 0);
+    `);
+
+    await merge();
+
+    const { rows: enrollments } = await db.query(
+      `SELECT user_id, tx_signature, wallet_address, completed_at IS NOT NULL AS completed
+       FROM public.enrollments WHERE course_id = 'course-a'`
+    );
+    expect(enrollments).toEqual([
+      {
+        user_id: TARGET,
+        tx_signature: "ONCHAIN_ENROLL_SIG",
+        wallet_address: WALLET,
+        completed: true,
+      },
+    ]);
+
+    const { rows: progress } = await db.query(
+      `SELECT user_id, completed, tx_signature, lesson_index
+       FROM public.user_progress WHERE lesson_id = 'lesson-1'`
+    );
+    expect(progress).toEqual([
+      {
+        user_id: TARGET,
+        completed: true,
+        tx_signature: "ONCHAIN_LESSON_SIG",
+        lesson_index: 0,
+      },
+    ]);
   });
 
   it("moves the shell's user_xp row whole when the target has none", async () => {

--- a/apps/web/src/lib/supabase/__tests__/merge-wallet-shell-execution.test.ts
+++ b/apps/web/src/lib/supabase/__tests__/merge-wallet-shell-execution.test.ts
@@ -110,8 +110,14 @@ const STUB_SETUP = `
   CREATE TABLE public.xp_transactions (
     id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
     user_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
-    amount integer NOT NULL
+    amount integer NOT NULL,
+    idempotency_key text
   );
+  -- The index that made "unkeyed" wrong (adversarial round 2, R4): daily-quest
+  -- keys are identical across users, so a plain move collides.
+  CREATE UNIQUE INDEX idx_xp_transactions_idempotency
+    ON public.xp_transactions (user_id, idempotency_key)
+    WHERE idempotency_key IS NOT NULL;
   CREATE TABLE public.enrollments (
     id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
     user_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
@@ -137,14 +143,27 @@ const STUB_SETUP = `
     id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
     user_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
     achievement_id text NOT NULL,
+    unlocked_at timestamptz DEFAULT now(),
+    tx_signature text,
+    asset_address text,
     UNIQUE(user_id, achievement_id)
   );
   CREATE TABLE public.certificates (
     id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
     user_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
     course_id text NOT NULL,
+    mint_address text,
+    metadata_uri text,
+    minted_at timestamptz DEFAULT now(),
+    tx_signature text,
+    credential_type text DEFAULT 'legacy',
     UNIQUE(user_id, course_id)
   );
+  -- GLOBAL, not per-user (adversarial round 2, R5): the backfill must delete
+  -- the shell's row before the target can hold its signature.
+  CREATE UNIQUE INDEX idx_certificates_tx_signature_unique
+    ON public.certificates (tx_signature)
+    WHERE tx_signature IS NOT NULL;
   CREATE TABLE public.streak_freezes_used (
     user_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
     frozen_date date NOT NULL,
@@ -210,8 +229,14 @@ const STUB_SETUP = `
   CREATE TABLE public.flags (
     id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
     reporter_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+    thread_id uuid REFERENCES public.threads(id) ON DELETE CASCADE,
+    answer_id uuid REFERENCES public.answers(id) ON DELETE CASCADE,
     resolved_by uuid REFERENCES public.profiles(id)
   );
+  CREATE UNIQUE INDEX idx_flags_unique_thread
+    ON public.flags (reporter_id, thread_id) WHERE thread_id IS NOT NULL;
+  CREATE UNIQUE INDEX idx_flags_unique_answer
+    ON public.flags (reporter_id, answer_id) WHERE answer_id IS NOT NULL;
   CREATE TABLE public.thread_views (
     user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
     thread_id uuid NOT NULL REFERENCES public.threads(id) ON DELETE CASCADE,
@@ -443,6 +468,105 @@ describe("merge_wallet_shell_account", () => {
         lesson_index: 0,
       },
     ]);
+  });
+
+  it("drops duplicate daily-quest ledger rows and subtracts them from the fold", async () => {
+    // Same quest, same day, both accounts: byte-identical idempotency_key
+    // (`login_streak:2026-08-15`). A plain move collides on
+    // idx_xp_transactions_idempotency and aborted the whole merge
+    // (adversarial round 2, R4). The duplicate is the same award counted
+    // once — dropped, and its amount subtracted from the XP fold.
+    await seedAccounts();
+    await db.exec(`
+      INSERT INTO public.user_xp(user_id, total_xp, level)
+        VALUES ('${TARGET}', 100, 1), ('${SHELL}', 300, 1);
+      INSERT INTO public.xp_transactions(user_id, amount, idempotency_key)
+        VALUES ('${TARGET}', 10, 'login_streak:2026-08-15'),
+               ('${SHELL}', 10, 'login_streak:2026-08-15'),
+               ('${SHELL}', 50, 'first_lesson:2026-08-14'),
+               ('${SHELL}', 240, NULL);
+    `);
+
+    await merge();
+
+    const { rows: ledger } = await db.query(
+      `SELECT user_id, amount, idempotency_key FROM public.xp_transactions ORDER BY amount`
+    );
+    expect(ledger).toEqual([
+      {
+        user_id: TARGET,
+        amount: 10,
+        idempotency_key: "login_streak:2026-08-15",
+      },
+      {
+        user_id: TARGET,
+        amount: 50,
+        idempotency_key: "first_lesson:2026-08-14",
+      },
+      { user_id: TARGET, amount: 240, idempotency_key: null },
+    ]);
+
+    const { rows: xp } = await db.query(
+      `SELECT total_xp, level FROM public.user_xp WHERE user_id = '${TARGET}'`
+    );
+    // 100 + 300 minus the 10xp duplicate = 390, level floor(sqrt(3.9)) = 1.
+    expect(xp).toEqual([{ total_xp: 390, level: 1 }]);
+  });
+
+  it("backfills minted certificates and achievements, honoring the global signature unique", async () => {
+    // The shell's colliding row is the MINTED one (adversarial round 2, R5).
+    // idx_certificates_tx_signature_unique is global, so the backfill only
+    // works if the shell's row is deleted before the target adopts its
+    // signature. credential_type must follow the mint ('core' would otherwise
+    // regress to the target's 'legacy' default).
+    await seedAccounts();
+    await db.exec(`
+      INSERT INTO public.user_achievements(user_id, achievement_id, tx_signature, asset_address)
+        VALUES ('${TARGET}', 'achievement-first-steps', NULL, NULL),
+               ('${SHELL}', 'achievement-first-steps', 'ACH_SIG', 'ACH_ASSET');
+      INSERT INTO public.certificates(user_id, course_id, mint_address, metadata_uri, tx_signature, credential_type)
+        VALUES ('${TARGET}', 'course-a', NULL, NULL, NULL, 'legacy'),
+               ('${SHELL}', 'course-a', 'CERT_MINT', 'ar://cert-meta', 'CERT_SIG', 'core');
+    `);
+
+    await merge();
+
+    const { rows: achievements } = await db.query(
+      `SELECT user_id, tx_signature, asset_address FROM public.user_achievements`
+    );
+    expect(achievements).toEqual([
+      { user_id: TARGET, tx_signature: "ACH_SIG", asset_address: "ACH_ASSET" },
+    ]);
+
+    const { rows: certificates } = await db.query(
+      `SELECT user_id, mint_address, metadata_uri, tx_signature, credential_type
+       FROM public.certificates`
+    );
+    expect(certificates).toEqual([
+      {
+        user_id: TARGET,
+        mint_address: "CERT_MINT",
+        metadata_uri: "ar://cert-meta",
+        tx_signature: "CERT_SIG",
+        credential_type: "core",
+      },
+    ]);
+  });
+
+  it("keeps the target's flag when both accounts flagged the same thread", async () => {
+    await seedAccounts();
+    await db.exec(`
+      INSERT INTO public.threads(id, author_id)
+        VALUES ('99999999-9999-9999-9999-999999999999', '${TARGET}');
+      INSERT INTO public.flags(reporter_id, thread_id)
+        VALUES ('${TARGET}', '99999999-9999-9999-9999-999999999999'),
+               ('${SHELL}', '99999999-9999-9999-9999-999999999999');
+    `);
+
+    await merge();
+
+    const { rows } = await db.query(`SELECT reporter_id FROM public.flags`);
+    expect(rows).toEqual([{ reporter_id: TARGET }]);
   });
 
   it("moves the shell's user_xp row whole when the target has none", async () => {

--- a/apps/web/src/lib/supabase/__tests__/merge-wallet-shell-execution.test.ts
+++ b/apps/web/src/lib/supabase/__tests__/merge-wallet-shell-execution.test.ts
@@ -1,0 +1,446 @@
+// REAL SQL-execution tests for merge_wallet_shell_account (the account-fork
+// auto-merge, AUTH-FLOWS.md §7), run in in-process Postgres (pglite).
+//
+// Two things only execution can prove, and this suite exists for both:
+//
+//   * The REAL `enforce_profile_wallet_write` trigger (extracted verbatim from
+//     schema.sql) is installed in every test. It blocks wallet_address writes
+//     from anyone but service_role — the exact failure the 2026-08-13 manual
+//     merge hit — so a merge that succeeds here proves the function's
+//     `set_config('request.jwt.claims', …)` genuinely satisfies it. (Plain
+//     `SET ROLE` is forbidden inside SECURITY DEFINER functions; this suite
+//     caught that.) Remove that set_config and the happy-path test goes red
+//     on the trigger's exception.
+//
+//   * The fail-closed FK sweep: a table this function does not know about,
+//     holding a shell row, must abort the WHOLE merge (rollback, nothing
+//     half-moved) — not strand the row silently.
+//
+// RED-PROOF: at the pre-migration head the function does not exist and every
+// test here fails on "function public.merge_wallet_shell_account does not
+// exist".
+//
+// @vitest-environment node
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { PGlite } from "@electric-sql/pglite";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+
+function findRepoRoot(): string {
+  let dir = dirname(fileURLToPath(import.meta.url));
+  while (!existsSync(resolve(dir, "supabase/schema.sql"))) {
+    const parent = dirname(dir);
+    if (parent === dir)
+      throw new Error("repo root (supabase/schema.sql) not found");
+    dir = parent;
+  }
+  return dir;
+}
+
+const repoRoot = findRepoRoot();
+const migration = readFileSync(
+  resolve(
+    repoRoot,
+    "supabase/migrations/20260817180000_merge_wallet_shell_account.sql"
+  ),
+  "utf8"
+);
+const schema = readFileSync(resolve(repoRoot, "supabase/schema.sql"), "utf8");
+
+/** Pull one `CREATE OR REPLACE FUNCTION <sig> … $$;` block out of schema.sql. */
+function extractFunction(sql: string, signature: string): string {
+  const start = sql.indexOf(`CREATE OR REPLACE FUNCTION ${signature}`);
+  if (start < 0) throw new Error(`function ${signature} not found`);
+  const end = sql.indexOf("$$;", start);
+  if (end < 0) throw new Error(`unterminated body for ${signature}`);
+  return sql.slice(start, end + 3);
+}
+
+const walletWriteTrigger = extractFunction(
+  schema,
+  "public.enforce_profile_wallet_write()"
+);
+
+// Stub versions of every table the merge touches, with the REAL user-facing
+// keys (the UNIQUE/PK constraints the conflict policy depends on). Column sets
+// are trimmed to what the function reads or the keys require; shapes mirror
+// supabase/schema.sql.
+const STUB_SETUP = `
+  CREATE ROLE anon;
+  CREATE ROLE authenticated;
+  CREATE ROLE service_role;
+  CREATE SCHEMA IF NOT EXISTS auth;
+  CREATE TABLE auth.users (id uuid PRIMARY KEY, email text UNIQUE);
+
+  CREATE TABLE public.profiles (
+    id uuid PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+    wallet_address text UNIQUE,
+    google_id text UNIQUE,
+    github_id text UNIQUE,
+    username text UNIQUE NOT NULL,
+    deleted_at timestamptz
+  );
+
+  CREATE TABLE public.user_xp (
+    user_id uuid UNIQUE NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+    total_xp integer DEFAULT 0,
+    level integer DEFAULT 0,
+    current_streak integer DEFAULT 0,
+    longest_streak integer DEFAULT 0,
+    last_activity_date date,
+    streak_freezes integer NOT NULL DEFAULT 0
+  );
+  CREATE TABLE public.xp_transactions (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+    amount integer NOT NULL
+  );
+  CREATE TABLE public.enrollments (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+    course_id text NOT NULL,
+    UNIQUE(user_id, course_id)
+  );
+  CREATE TABLE public.user_progress (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+    lesson_id text NOT NULL,
+    UNIQUE(user_id, lesson_id)
+  );
+  CREATE TABLE public.user_achievements (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+    achievement_id text NOT NULL,
+    UNIQUE(user_id, achievement_id)
+  );
+  CREATE TABLE public.certificates (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+    course_id text NOT NULL,
+    UNIQUE(user_id, course_id)
+  );
+  CREATE TABLE public.streak_freezes_used (
+    user_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+    frozen_date date NOT NULL,
+    PRIMARY KEY (user_id, frozen_date)
+  );
+  CREATE TABLE public.pending_onchain_actions (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    action_type text NOT NULL,
+    reference_id text NOT NULL,
+    UNIQUE(user_id, action_type, reference_id)
+  );
+  CREATE TABLE public.user_daily_quests (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+    quest_id text NOT NULL,
+    period_start date NOT NULL,
+    xp integer NOT NULL DEFAULT 0,
+    UNIQUE(user_id, quest_id, period_start)
+  );
+  CREATE TABLE public.deployed_programs (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+    course_id text NOT NULL,
+    lesson_id text NOT NULL,
+    UNIQUE(user_id, course_id, lesson_id)
+  );
+  CREATE TABLE public.challenge_assists (
+    user_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+    lesson_id text NOT NULL,
+    PRIMARY KEY (user_id, lesson_id)
+  );
+  CREATE TABLE public.review_items (
+    user_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+    item_key text NOT NULL,
+    PRIMARY KEY (user_id, item_key)
+  );
+  CREATE TABLE public.league_members (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+    week_start date NOT NULL,
+    UNIQUE (user_id, week_start)
+  );
+  CREATE TABLE public.threads (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    author_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE
+  );
+  CREATE TABLE public.answers (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    author_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE
+  );
+  CREATE TABLE public.votes (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+    thread_id uuid REFERENCES public.threads(id) ON DELETE CASCADE,
+    answer_id uuid REFERENCES public.answers(id) ON DELETE CASCADE,
+    value smallint NOT NULL
+  );
+  CREATE UNIQUE INDEX votes_user_thread_unique
+    ON public.votes(user_id, thread_id) WHERE thread_id IS NOT NULL;
+  CREATE UNIQUE INDEX votes_user_answer_unique
+    ON public.votes(user_id, answer_id) WHERE answer_id IS NOT NULL;
+  CREATE TABLE public.flags (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    reporter_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+    resolved_by uuid REFERENCES public.profiles(id)
+  );
+  CREATE TABLE public.thread_views (
+    user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    thread_id uuid NOT NULL REFERENCES public.threads(id) ON DELETE CASCADE,
+    PRIMARY KEY (user_id, thread_id)
+  );
+  CREATE TABLE public.email_subscriptions (
+    user_id uuid PRIMARY KEY REFERENCES public.profiles(id) ON DELETE CASCADE,
+    opt_in boolean NOT NULL DEFAULT false
+  );
+  CREATE TABLE public.email_reminder_log (
+    user_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+    kind text NOT NULL,
+    sent_on date NOT NULL,
+    PRIMARY KEY (user_id, kind, sent_on)
+  );
+
+  GRANT USAGE ON SCHEMA public, auth TO service_role;
+  GRANT ALL ON ALL TABLES IN SCHEMA public TO service_role;
+  GRANT SELECT ON auth.users TO service_role;
+  ALTER DEFAULT PRIVILEGES IN SCHEMA public
+    GRANT ALL ON TABLES TO service_role;
+`;
+
+const uid = (n: number): string => {
+  const c = String(n % 10);
+  return `${c.repeat(8)}-${c.repeat(4)}-${c.repeat(4)}-${c.repeat(4)}-${c.repeat(12)}`;
+};
+
+const TARGET = uid(1);
+const SHELL = uid(2);
+const WALLET = "So1anaWa11etAddre55ForThisShe11Account";
+const SHELL_EMAIL = `${WALLET}@wallet.superteam-lms.local`;
+
+describe("merge_wallet_shell_account", () => {
+  let db: PGlite;
+
+  const seedAccounts = async (
+    options: {
+      shellEmail?: string;
+      shellGoogleId?: string | null;
+      shellDeleted?: boolean;
+      targetWallet?: string | null;
+    } = {}
+  ): Promise<void> => {
+    const {
+      shellEmail = SHELL_EMAIL,
+      shellGoogleId = null,
+      shellDeleted = false,
+      targetWallet = null,
+    } = options;
+    await db.query(
+      `INSERT INTO auth.users(id, email) VALUES ($1, $2), ($3, $4)`,
+      [TARGET, "learner@example.com", SHELL, shellEmail]
+    );
+    // service_role because the REAL wallet-write trigger is installed and
+    // seeding a wallet is exactly the write it locks down.
+    await db.exec("SET ROLE service_role;");
+    await db.query(
+      `INSERT INTO public.profiles(id, wallet_address, google_id, username, deleted_at)
+       VALUES ($1, $2, NULL, 'real-learner', NULL),
+              ($3, $4, $5, 'user_shell000', $6)`,
+      [
+        TARGET,
+        targetWallet,
+        SHELL,
+        WALLET,
+        shellGoogleId,
+        shellDeleted ? new Date().toISOString() : null,
+      ]
+    );
+    await db.exec("RESET ROLE;");
+  };
+
+  const merge = () =>
+    db.query(`SELECT public.merge_wallet_shell_account($1, $2, $3) AS result`, [
+      TARGET,
+      SHELL,
+      WALLET,
+    ]);
+
+  beforeEach(async () => {
+    db = new PGlite();
+    await db.exec(STUB_SETUP);
+    await db.exec(walletWriteTrigger);
+    await db.exec(`
+      DROP TRIGGER IF EXISTS trg_enforce_profile_wallet_write ON public.profiles;
+      CREATE TRIGGER trg_enforce_profile_wallet_write
+        BEFORE INSERT OR UPDATE ON public.profiles
+        FOR EACH ROW
+        EXECUTE FUNCTION public.enforce_profile_wallet_write();
+    `);
+    await db.exec(migration);
+  });
+
+  afterEach(async () => {
+    await db.close();
+  });
+
+  it("moves the wallet, folds XP, keeps target rows on conflicts, tombstones the shell", async () => {
+    await seedAccounts();
+    await db.exec(`
+      INSERT INTO public.user_xp(user_id, total_xp, level, current_streak, longest_streak, last_activity_date, streak_freezes)
+        VALUES ('${TARGET}', 100, 1, 1, 3, '2026-08-01', 1),
+               ('${SHELL}', 300, 1, 5, 5, '2026-08-15', 2);
+      INSERT INTO public.enrollments(user_id, course_id)
+        VALUES ('${TARGET}', 'course-a'),
+               ('${SHELL}', 'course-a'),
+               ('${SHELL}', 'course-b');
+      INSERT INTO public.xp_transactions(user_id, amount)
+        VALUES ('${SHELL}', 100), ('${SHELL}', 200);
+      INSERT INTO public.user_daily_quests(user_id, quest_id, period_start, xp)
+        VALUES ('${TARGET}', 'q1', '2026-08-10', 25),
+               ('${SHELL}', 'q1', '2026-08-10', 10),
+               ('${SHELL}', 'q2', '2026-08-10', 10);
+    `);
+
+    const { rows } = await merge();
+    const result = (rows[0] as { result: Record<string, unknown> }).result;
+    expect(result.wallet).toBe(WALLET);
+
+    const { rows: profiles } = await db.query(
+      `SELECT id, wallet_address, deleted_at FROM public.profiles ORDER BY id`
+    );
+    const target = profiles.find(
+      (p) => (p as { id: string }).id === TARGET
+    ) as {
+      wallet_address: string | null;
+      deleted_at: string | null;
+    };
+    const shell = profiles.find((p) => (p as { id: string }).id === SHELL) as {
+      wallet_address: string | null;
+      deleted_at: string | null;
+    };
+    expect(target.wallet_address).toBe(WALLET);
+    expect(target.deleted_at).toBeNull();
+    expect(shell.wallet_address).toBeNull();
+    expect(shell.deleted_at).not.toBeNull();
+
+    // XP folded: 100 + 300 = 400 → level floor(sqrt(400/100)) = 2; better
+    // streaks kept; freeze inventory capped at the CHECK bound of 2.
+    const { rows: xp } = await db.query(
+      `SELECT * FROM public.user_xp WHERE user_id = '${TARGET}'`
+    );
+    expect(xp).toHaveLength(1);
+    const fold = xp[0] as Record<string, unknown>;
+    expect(fold.total_xp).toBe(400);
+    expect(fold.level).toBe(2);
+    expect(fold.current_streak).toBe(5);
+    expect(fold.streak_freezes).toBe(2);
+    const { rows: shellXp } = await db.query(
+      `SELECT 1 FROM public.user_xp WHERE user_id = '${SHELL}'`
+    );
+    expect(shellXp).toHaveLength(0);
+
+    // course-a collided → target's row survived; course-b moved.
+    const { rows: enrollments } = await db.query(
+      `SELECT user_id, course_id FROM public.enrollments ORDER BY course_id`
+    );
+    expect(enrollments).toEqual([
+      { user_id: TARGET, course_id: "course-a" },
+      { user_id: TARGET, course_id: "course-b" },
+    ]);
+
+    // q1 collided → target's 25xp row kept (shell's 10xp dropped); q2 moved.
+    const { rows: quests } = await db.query(
+      `SELECT quest_id, xp FROM public.user_daily_quests WHERE user_id = '${TARGET}' ORDER BY quest_id`
+    );
+    expect(quests).toEqual([
+      { quest_id: "q1", xp: 25 },
+      { quest_id: "q2", xp: 10 },
+    ]);
+
+    // Unkeyed ledger rows all moved.
+    const { rows: transactions } = await db.query(
+      `SELECT count(*)::int AS n FROM public.xp_transactions WHERE user_id = '${TARGET}'`
+    );
+    expect((transactions[0] as { n: number }).n).toBe(2);
+  });
+
+  it("moves the shell's user_xp row whole when the target has none", async () => {
+    await seedAccounts();
+    await db.exec(`
+      INSERT INTO public.user_xp(user_id, total_xp, level)
+        VALUES ('${SHELL}', 900, 3);
+    `);
+    await merge();
+    const { rows } = await db.query(
+      `SELECT user_id, total_xp FROM public.user_xp`
+    );
+    expect(rows).toEqual([{ user_id: TARGET, total_xp: 900 }]);
+  });
+
+  it("refuses when the target already has a wallet", async () => {
+    await seedAccounts({ targetWallet: "SomeOtherWalletAddress" });
+    await expect(merge()).rejects.toThrow(/target already has a wallet/);
+  });
+
+  it("refuses when the shell email is not a synthetic wallet email", async () => {
+    await seedAccounts({ shellEmail: "human@example.com" });
+    await expect(merge()).rejects.toThrow(/not a synthetic wallet email/);
+  });
+
+  it("refuses when the shell has a linked OAuth identity", async () => {
+    await seedAccounts({ shellGoogleId: "google-123" });
+    await expect(merge()).rejects.toThrow(/linked OAuth identities/);
+  });
+
+  it("refuses when the shell is tombstoned", async () => {
+    await seedAccounts({ shellDeleted: true });
+    await expect(merge()).rejects.toThrow(/shell is tombstoned/);
+  });
+
+  it("refuses when the wallet does not match the shell's", async () => {
+    await seedAccounts();
+    await expect(
+      db.query(`SELECT public.merge_wallet_shell_account($1, $2, $3)`, [
+        TARGET,
+        SHELL,
+        "DifferentWalletEntirely",
+      ])
+    ).rejects.toThrow(/shell wallet does not match/);
+  });
+
+  it("aborts and rolls back everything when an unknown table still references the shell", async () => {
+    await seedAccounts();
+    await db.exec(`
+      CREATE TABLE public.stray_items (
+        id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+        user_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE
+      );
+      INSERT INTO public.stray_items(user_id) VALUES ('${SHELL}');
+      INSERT INTO public.enrollments(user_id, course_id) VALUES ('${SHELL}', 'course-a');
+    `);
+
+    await expect(merge()).rejects.toThrow(/stray_items/);
+
+    // The whole transaction rolled back: wallet not moved, shell alive, its
+    // enrollment untouched.
+    const { rows } = await db.query(
+      `SELECT id, wallet_address, deleted_at FROM public.profiles ORDER BY id`
+    );
+    const target = rows.find((p) => (p as { id: string }).id === TARGET) as {
+      wallet_address: string | null;
+    };
+    const shell = rows.find((p) => (p as { id: string }).id === SHELL) as {
+      wallet_address: string | null;
+      deleted_at: string | null;
+    };
+    expect(target.wallet_address).toBeNull();
+    expect(shell.wallet_address).toBe(WALLET);
+    expect(shell.deleted_at).toBeNull();
+    const { rows: enrollments } = await db.query(
+      `SELECT user_id FROM public.enrollments`
+    );
+    expect(enrollments).toEqual([{ user_id: SHELL }]);
+  });
+});

--- a/apps/web/src/lib/supabase/types.ts
+++ b/apps/web/src/lib/supabase/types.ts
@@ -1265,6 +1265,17 @@ export type Database = {
         Args: { p_course_id: string };
         Returns: { lesson_id: string; completed_by: number }[];
       };
+      /**
+       * Account-fork auto-merge (AUTH-FLOWS.md §7): folds a wallet-shaped
+       * shell account into the socially-signed-in account whose Dynamic JWT
+       * proved ownership of the shell's wallet. service_role only; one
+       * transaction; re-validates shell-ness in SQL and RAISEs rather than
+       * merge on any doubt.
+       */
+      merge_wallet_shell_account: {
+        Args: { p_target: string; p_shell: string; p_wallet: string };
+        Returns: Record<string, unknown>;
+      };
       // #769 marketing-email consent RPCs.
       set_marketing_opt_in: {
         Args: { p_opt_in: boolean };

--- a/docs/AUTH-FLOWS.md
+++ b/docs/AUTH-FLOWS.md
@@ -288,11 +288,14 @@ end wallet-only.
   wallet-shaped account (synthetic email); the same person's Google login matches their
   real-email account — two accounts, XP split. This is why #1032 removed the email-OTP
   modal entry ("the hazard behind today's manual account merge", 2026-08-13 — one
-  production account pair was merged by hand). A planned auto-merge would use the
-  Dynamic JWT's `blockchain` credential as proof that the wallet-shaped account's
-  wallet belongs to the socially-signed-in user; **no code for it exists in this repo
-  yet** — until it does, the fork is prevented (no email-OTP entry, `bridgingSocial`
-  guard, `/api/auth/dynamic` matching) rather than healed.
+  production account pair was merged by hand). The fork is now both prevented (no
+  email-OTP entry, `bridgingSocial` guard, `/api/auth/dynamic` matching) and HEALED:
+  when a Dynamic sign-in's JWT carries a `blockchain` credential matching a shell
+  profile's `wallet_address`, `/api/auth/dynamic` calls
+  `merge_wallet_shell_account` (one service-role transaction: wallet + per-user rows
+  migrate, keep-target on unique collisions, XP summed, shell tombstoned, fail-closed
+  FK sweep). The JWT credential is the ownership proof; an email match alone never
+  merges. Route side is fail-open — any doubt skips the merge, sign-in proceeds.
 - **Kill switch.** Unset `NEXT_PUBLIC_DYNAMIC_ENVIRONMENT_ID` → `isDynamicEnabled()`
   false → no provider, no SDK init, no Dynamic button; the Supabase-OAuth Google button
   renders instead and `/api/auth/dynamic` 503s. SIWS with an external wallet stays the

--- a/supabase/migrations/20260817180000_merge_wallet_shell_account.sql
+++ b/supabase/migrations/20260817180000_merge_wallet_shell_account.sql
@@ -1,0 +1,325 @@
+-- Auto-merge of a wallet-shaped shell account into the socially-signed-in
+-- account that owns its wallet (AUTH-FLOWS.md §7 "Mixed-method account fork").
+--
+-- The fork: an embedded-wallet SIWS sign-in created a shell account keyed by a
+-- synthetic `<pubkey>@wallet.superteam-lms.local` email; the same person's
+-- Google sign-in through Dynamic lands on their real-email account. Two
+-- accounts, XP split. The Dynamic JWT carries the wallet as a `blockchain`
+-- verified credential — cryptographic proof that the shell's wallet belongs to
+-- the socially-signed-in user. That proof, never an email match, is what
+-- entitles the caller to this merge.
+--
+-- One transaction, called only by service_role from /api/auth/dynamic. Row
+-- policy on unique-key collisions: keep the target's row (precedent: the
+-- 2026-08-13 manual merge, daily-quest rows). user_xp is the one aggregate:
+-- totals are summed, streaks take the greater value.
+--
+-- The final FK sweep is the fail-closed guard for tables this function does
+-- not know about: any remaining row referencing the shell aborts the whole
+-- transaction, so a table added later can never be silently stranded — the
+-- merge just stops happening until this function learns the new table.
+
+CREATE OR REPLACE FUNCTION public.merge_wallet_shell_account(
+  p_target UUID,
+  p_shell  UUID,
+  p_wallet TEXT
+) RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_target_profile public.profiles%ROWTYPE;
+  v_shell_profile  public.profiles%ROWTYPE;
+  v_shell_email    TEXT;
+  v_shell_xp       public.user_xp%ROWTYPE;
+  v_moved          JSONB := '{}'::jsonb;
+  v_count          BIGINT;
+  v_fk             RECORD;
+BEGIN
+  -- trg_enforce_profile_wallet_write only lets service_role touch
+  -- wallet_address, checked as `current_user = 'service_role' OR
+  -- request.jwt.claims->>'role' = 'service_role'`. Inside a SECURITY DEFINER
+  -- function Postgres forbids `SET ROLE` outright (the 2026-08-13 manual
+  -- merge ran it in a raw session, where it IS allowed), so satisfy the
+  -- trigger's claims branch instead — the same channel PostgREST uses when
+  -- the service-role client calls this RPC, made explicit so the function
+  -- also works when invoked from a maintenance session as postgres.
+  -- is_local => reverts at transaction end.
+  PERFORM pg_catalog.set_config(
+    'request.jwt.claims', '{"role":"service_role"}', true
+  );
+
+  IF p_target = p_shell THEN
+    RAISE EXCEPTION 'merge refused: target and shell are the same account';
+  END IF;
+  IF p_wallet IS NULL OR btrim(p_wallet) = '' THEN
+    RAISE EXCEPTION 'merge refused: empty wallet';
+  END IF;
+
+  -- Deterministic lock order so two concurrent merges cannot deadlock.
+  PERFORM 1 FROM public.profiles WHERE id = LEAST(p_target, p_shell) FOR UPDATE;
+  PERFORM 1 FROM public.profiles WHERE id = GREATEST(p_target, p_shell) FOR UPDATE;
+
+  SELECT * INTO v_target_profile FROM public.profiles WHERE id = p_target;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'merge refused: target profile not found';
+  END IF;
+  SELECT * INTO v_shell_profile FROM public.profiles WHERE id = p_shell;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'merge refused: shell profile not found';
+  END IF;
+
+  -- The target must genuinely lack a wallet: this merge exists to give it one.
+  IF v_target_profile.wallet_address IS NOT NULL THEN
+    RAISE EXCEPTION 'merge refused: target already has a wallet';
+  END IF;
+  IF v_target_profile.deleted_at IS NOT NULL THEN
+    RAISE EXCEPTION 'merge refused: target is tombstoned';
+  END IF;
+
+  -- Shell-ness, re-proven here rather than trusted from the caller:
+  -- the wallet is the one the JWT proved, the account was never anything but
+  -- a wallet shell (synthetic email, no linked OAuth), and it is alive. A
+  -- tombstoned shell was deleted by its owner — its data stays dead.
+  IF v_shell_profile.wallet_address IS DISTINCT FROM p_wallet THEN
+    RAISE EXCEPTION 'merge refused: shell wallet does not match';
+  END IF;
+  IF v_shell_profile.deleted_at IS NOT NULL THEN
+    RAISE EXCEPTION 'merge refused: shell is tombstoned';
+  END IF;
+  IF v_shell_profile.google_id IS NOT NULL OR v_shell_profile.github_id IS NOT NULL THEN
+    RAISE EXCEPTION 'merge refused: shell has linked OAuth identities';
+  END IF;
+  SELECT u.email INTO v_shell_email FROM auth.users u WHERE u.id = p_shell;
+  IF v_shell_email IS NULL
+     OR v_shell_email NOT LIKE '%@wallet.superteam-lms.local' THEN
+    RAISE EXCEPTION 'merge refused: shell email is not a synthetic wallet email';
+  END IF;
+
+  -- ── user_xp: the one aggregate. Sum totals, recompute level with the app's
+  -- formula (floor(sqrt(xp/100))), keep the better streak, cap freezes at the
+  -- inventory bound the CHECK constraint enforces.
+  SELECT * INTO v_shell_xp FROM public.user_xp WHERE user_id = p_shell;
+  IF FOUND THEN
+    UPDATE public.user_xp t SET
+      total_xp           = t.total_xp + v_shell_xp.total_xp,
+      level              = floor(sqrt((t.total_xp + v_shell_xp.total_xp) / 100.0))::int,
+      current_streak     = GREATEST(t.current_streak, v_shell_xp.current_streak),
+      longest_streak     = GREATEST(t.longest_streak, v_shell_xp.longest_streak),
+      last_activity_date = GREATEST(t.last_activity_date, v_shell_xp.last_activity_date),
+      streak_freezes     = LEAST(2, t.streak_freezes + v_shell_xp.streak_freezes)
+    WHERE t.user_id = p_target;
+    IF NOT FOUND THEN
+      UPDATE public.user_xp SET user_id = p_target WHERE user_id = p_shell;
+    ELSE
+      DELETE FROM public.user_xp WHERE user_id = p_shell;
+    END IF;
+    v_moved := v_moved || jsonb_build_object('user_xp', 1);
+  END IF;
+
+  -- ── Keyed tables: move what does not collide, keep the target's row where
+  -- it does, then drop the shell's leftovers. Keys mirror each table's
+  -- UNIQUE/PK over user_id.
+  UPDATE public.enrollments s SET user_id = p_target
+    WHERE s.user_id = p_shell
+      AND NOT EXISTS (SELECT 1 FROM public.enrollments x
+                      WHERE x.user_id = p_target AND x.course_id = s.course_id);
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+  v_moved := v_moved || jsonb_build_object('enrollments', v_count);
+  DELETE FROM public.enrollments WHERE user_id = p_shell;
+
+  UPDATE public.user_progress s SET user_id = p_target
+    WHERE s.user_id = p_shell
+      AND NOT EXISTS (SELECT 1 FROM public.user_progress x
+                      WHERE x.user_id = p_target AND x.lesson_id = s.lesson_id);
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+  v_moved := v_moved || jsonb_build_object('user_progress', v_count);
+  DELETE FROM public.user_progress WHERE user_id = p_shell;
+
+  UPDATE public.user_achievements s SET user_id = p_target
+    WHERE s.user_id = p_shell
+      AND NOT EXISTS (SELECT 1 FROM public.user_achievements x
+                      WHERE x.user_id = p_target AND x.achievement_id = s.achievement_id);
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+  v_moved := v_moved || jsonb_build_object('user_achievements', v_count);
+  DELETE FROM public.user_achievements WHERE user_id = p_shell;
+
+  UPDATE public.certificates s SET user_id = p_target
+    WHERE s.user_id = p_shell
+      AND NOT EXISTS (SELECT 1 FROM public.certificates x
+                      WHERE x.user_id = p_target AND x.course_id = s.course_id);
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+  v_moved := v_moved || jsonb_build_object('certificates', v_count);
+  DELETE FROM public.certificates WHERE user_id = p_shell;
+
+  UPDATE public.streak_freezes_used s SET user_id = p_target
+    WHERE s.user_id = p_shell
+      AND NOT EXISTS (SELECT 1 FROM public.streak_freezes_used x
+                      WHERE x.user_id = p_target AND x.frozen_date = s.frozen_date);
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+  v_moved := v_moved || jsonb_build_object('streak_freezes_used', v_count);
+  DELETE FROM public.streak_freezes_used WHERE user_id = p_shell;
+
+  UPDATE public.pending_onchain_actions s SET user_id = p_target
+    WHERE s.user_id = p_shell
+      AND NOT EXISTS (SELECT 1 FROM public.pending_onchain_actions x
+                      WHERE x.user_id = p_target
+                        AND x.action_type = s.action_type
+                        AND x.reference_id = s.reference_id);
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+  v_moved := v_moved || jsonb_build_object('pending_onchain_actions', v_count);
+  DELETE FROM public.pending_onchain_actions WHERE user_id = p_shell;
+
+  UPDATE public.user_daily_quests s SET user_id = p_target
+    WHERE s.user_id = p_shell
+      AND NOT EXISTS (SELECT 1 FROM public.user_daily_quests x
+                      WHERE x.user_id = p_target
+                        AND x.quest_id = s.quest_id
+                        AND x.period_start = s.period_start);
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+  v_moved := v_moved || jsonb_build_object('user_daily_quests', v_count);
+  DELETE FROM public.user_daily_quests WHERE user_id = p_shell;
+
+  UPDATE public.deployed_programs s SET user_id = p_target
+    WHERE s.user_id = p_shell
+      AND NOT EXISTS (SELECT 1 FROM public.deployed_programs x
+                      WHERE x.user_id = p_target
+                        AND x.course_id = s.course_id
+                        AND x.lesson_id = s.lesson_id);
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+  v_moved := v_moved || jsonb_build_object('deployed_programs', v_count);
+  DELETE FROM public.deployed_programs WHERE user_id = p_shell;
+
+  UPDATE public.challenge_assists s SET user_id = p_target
+    WHERE s.user_id = p_shell
+      AND NOT EXISTS (SELECT 1 FROM public.challenge_assists x
+                      WHERE x.user_id = p_target AND x.lesson_id = s.lesson_id);
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+  v_moved := v_moved || jsonb_build_object('challenge_assists', v_count);
+  DELETE FROM public.challenge_assists WHERE user_id = p_shell;
+
+  UPDATE public.review_items s SET user_id = p_target
+    WHERE s.user_id = p_shell
+      AND NOT EXISTS (SELECT 1 FROM public.review_items x
+                      WHERE x.user_id = p_target AND x.item_key = s.item_key);
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+  v_moved := v_moved || jsonb_build_object('review_items', v_count);
+  DELETE FROM public.review_items WHERE user_id = p_shell;
+
+  UPDATE public.league_members s SET user_id = p_target
+    WHERE s.user_id = p_shell
+      AND NOT EXISTS (SELECT 1 FROM public.league_members x
+                      WHERE x.user_id = p_target AND x.week_start = s.week_start);
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+  v_moved := v_moved || jsonb_build_object('league_members', v_count);
+  DELETE FROM public.league_members WHERE user_id = p_shell;
+
+  UPDATE public.thread_views s SET user_id = p_target
+    WHERE s.user_id = p_shell
+      AND NOT EXISTS (SELECT 1 FROM public.thread_views x
+                      WHERE x.user_id = p_target AND x.thread_id = s.thread_id);
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+  v_moved := v_moved || jsonb_build_object('thread_views', v_count);
+  DELETE FROM public.thread_views WHERE user_id = p_shell;
+
+  UPDATE public.email_reminder_log s SET user_id = p_target
+    WHERE s.user_id = p_shell
+      AND NOT EXISTS (SELECT 1 FROM public.email_reminder_log x
+                      WHERE x.user_id = p_target
+                        AND x.kind = s.kind
+                        AND x.sent_on = s.sent_on);
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+  v_moved := v_moved || jsonb_build_object('email_reminder_log', v_count);
+  DELETE FROM public.email_reminder_log WHERE user_id = p_shell;
+
+  -- Votes carry two partial unique indexes (thread / answer), so the collision
+  -- probe is per-target-kind.
+  UPDATE public.votes s SET user_id = p_target
+    WHERE s.user_id = p_shell AND s.thread_id IS NOT NULL
+      AND NOT EXISTS (SELECT 1 FROM public.votes x
+                      WHERE x.user_id = p_target AND x.thread_id = s.thread_id);
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+  v_moved := v_moved || jsonb_build_object('thread_votes', v_count);
+  UPDATE public.votes s SET user_id = p_target
+    WHERE s.user_id = p_shell AND s.answer_id IS NOT NULL
+      AND NOT EXISTS (SELECT 1 FROM public.votes x
+                      WHERE x.user_id = p_target AND x.answer_id = s.answer_id);
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+  v_moved := v_moved || jsonb_build_object('answer_votes', v_count);
+  DELETE FROM public.votes WHERE user_id = p_shell;
+
+  -- email_subscriptions is one row per user. A shell's consent was collected
+  -- against an undeliverable synthetic address; it only moves when the target
+  -- has no row at all, and the target's real consent always wins.
+  UPDATE public.email_subscriptions s SET user_id = p_target
+    WHERE s.user_id = p_shell
+      AND NOT EXISTS (SELECT 1 FROM public.email_subscriptions x
+                      WHERE x.user_id = p_target);
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+  v_moved := v_moved || jsonb_build_object('email_subscriptions', v_count);
+  DELETE FROM public.email_subscriptions WHERE user_id = p_shell;
+
+  -- ── Unkeyed tables: plain moves, nothing can collide.
+  UPDATE public.xp_transactions SET user_id = p_target WHERE user_id = p_shell;
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+  v_moved := v_moved || jsonb_build_object('xp_transactions', v_count);
+
+  UPDATE public.threads SET author_id = p_target WHERE author_id = p_shell;
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+  v_moved := v_moved || jsonb_build_object('threads', v_count);
+
+  UPDATE public.answers SET author_id = p_target WHERE author_id = p_shell;
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+  v_moved := v_moved || jsonb_build_object('answers', v_count);
+
+  UPDATE public.flags SET reporter_id = p_target WHERE reporter_id = p_shell;
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+  v_moved := v_moved || jsonb_build_object('flags', v_count);
+  UPDATE public.flags SET resolved_by = p_target WHERE resolved_by = p_shell;
+
+  -- ── The wallet itself. Shell first (wallet_address is UNIQUE), then target.
+  UPDATE public.profiles SET wallet_address = NULL WHERE id = p_shell;
+  UPDATE public.profiles SET wallet_address = p_wallet WHERE id = p_target;
+
+  -- Tombstone the shell so no sign-in path can revive it: SIWS no longer
+  -- resolves it (wallet nulled) and isAccountDeleted refuses the rest.
+  UPDATE public.profiles SET deleted_at = now() WHERE id = p_shell;
+
+  -- ── Fail-closed sweep: every FK into profiles/auth.users must be clean of
+  -- the shell. A table this function does not cover aborts the merge here and
+  -- rolls everything back.
+  FOR v_fk IN
+    SELECT c.conrelid::regclass AS tbl, a.attname AS col
+    FROM pg_constraint c
+    JOIN LATERAL unnest(c.conkey) AS k(attnum) ON true
+    JOIN pg_attribute a ON a.attrelid = c.conrelid AND a.attnum = k.attnum
+    WHERE c.contype = 'f'
+      AND c.confrelid IN ('public.profiles'::regclass, 'auth.users'::regclass)
+      AND c.conrelid <> 'public.profiles'::regclass
+      AND a.atttypid = 'uuid'::regtype
+  LOOP
+    EXECUTE format('SELECT count(*) FROM %s WHERE %I = $1', v_fk.tbl, v_fk.col)
+      INTO v_count USING p_shell;
+    IF v_count > 0 THEN
+      RAISE EXCEPTION
+        'merge aborted: % row(s) still reference the shell via %.% — extend merge_wallet_shell_account',
+        v_count, v_fk.tbl, v_fk.col;
+    END IF;
+  END LOOP;
+
+  RETURN jsonb_build_object(
+    'target', p_target,
+    'shell', p_shell,
+    'wallet', p_wallet,
+    'moved', v_moved
+  );
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION
+  public.merge_wallet_shell_account(UUID, UUID, TEXT)
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION
+  public.merge_wallet_shell_account(UUID, UUID, TEXT)
+  TO service_role;

--- a/supabase/migrations/20260817180000_merge_wallet_shell_account.sql
+++ b/supabase/migrations/20260817180000_merge_wallet_shell_account.sql
@@ -120,7 +120,7 @@ BEGIN
   SELECT * INTO v_shell_xp FROM public.user_xp WHERE user_id = p_shell;
   IF FOUND THEN
     UPDATE public.user_xp t SET
-      total_xp           = t.total_xp + v_shell_xp.total_xp - v_dup_xp,
+      total_xp           = GREATEST(0, t.total_xp + v_shell_xp.total_xp - v_dup_xp),
       level              = floor(sqrt(GREATEST(0, t.total_xp + v_shell_xp.total_xp - v_dup_xp) / 100.0))::int,
       current_streak     = GREATEST(t.current_streak, v_shell_xp.current_streak),
       longest_streak     = GREATEST(t.longest_streak, v_shell_xp.longest_streak),
@@ -128,7 +128,15 @@ BEGIN
       streak_freezes     = LEAST(2, t.streak_freezes + v_shell_xp.streak_freezes)
     WHERE t.user_id = p_target;
     IF NOT FOUND THEN
-      UPDATE public.user_xp SET user_id = p_target WHERE user_id = p_shell;
+      -- v_dup_xp is necessarily 0 here today (both ledger writers upsert
+      -- user_xp in the same call), but that invariant is held by convention
+      -- across two functions — subtracting is free insurance against a future
+      -- writer breaking it.
+      UPDATE public.user_xp SET
+        user_id  = p_target,
+        total_xp = GREATEST(0, total_xp - v_dup_xp),
+        level    = floor(sqrt(GREATEST(0, total_xp - v_dup_xp) / 100.0))::int
+      WHERE user_id = p_shell;
     ELSE
       DELETE FROM public.user_xp WHERE user_id = p_shell;
     END IF;
@@ -362,12 +370,14 @@ BEGIN
     WHERE s.reporter_id = p_shell AND s.thread_id IS NOT NULL
       AND NOT EXISTS (SELECT 1 FROM public.flags x
                       WHERE x.reporter_id = p_target AND x.thread_id = s.thread_id);
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+  v_moved := v_moved || jsonb_build_object('thread_flags', v_count);
   UPDATE public.flags s SET reporter_id = p_target
     WHERE s.reporter_id = p_shell AND s.answer_id IS NOT NULL
       AND NOT EXISTS (SELECT 1 FROM public.flags x
                       WHERE x.reporter_id = p_target AND x.answer_id = s.answer_id);
   GET DIAGNOSTICS v_count = ROW_COUNT;
-  v_moved := v_moved || jsonb_build_object('flags', v_count);
+  v_moved := v_moved || jsonb_build_object('answer_flags', v_count);
   DELETE FROM public.flags WHERE reporter_id = p_shell;
   UPDATE public.flags SET resolved_by = p_target WHERE resolved_by = p_shell;
 

--- a/supabase/migrations/20260817180000_merge_wallet_shell_account.sql
+++ b/supabase/migrations/20260817180000_merge_wallet_shell_account.sql
@@ -35,6 +35,8 @@ DECLARE
   v_shell_xp       public.user_xp%ROWTYPE;
   v_moved          JSONB := '{}'::jsonb;
   v_count          BIGINT;
+  v_dup_xp         BIGINT := 0;
+  v_cert           public.certificates%ROWTYPE;
   v_fk             RECORD;
 BEGIN
   -- trg_enforce_profile_wallet_write only lets service_role touch
@@ -97,14 +99,29 @@ BEGIN
     RAISE EXCEPTION 'merge refused: shell email is not a synthetic wallet email';
   END IF;
 
-  -- ── user_xp: the one aggregate. Sum totals, recompute level with the app's
-  -- formula (floor(sqrt(xp/100))), keep the better streak, cap freezes at the
-  -- inventory bound the CHECK constraint enforces.
+  -- Shell ledger rows whose idempotency_key collides with a target row are
+  -- the SAME award seen from both accounts (daily-quest keys are
+  -- `<questId>:<period>`, identical for every user on the same day). They are
+  -- dropped below rather than moved — and their amounts are subtracted from
+  -- the XP fold here, so the ledger and the total stay consistent (decided
+  -- explicitly, adversarial round 2: the award is real once, not twice).
+  SELECT COALESCE(sum(s.amount), 0) INTO v_dup_xp
+  FROM public.xp_transactions s
+  WHERE s.user_id = p_shell
+    AND s.idempotency_key IS NOT NULL
+    AND EXISTS (SELECT 1 FROM public.xp_transactions x
+                WHERE x.user_id = p_target
+                  AND x.idempotency_key = s.idempotency_key);
+
+  -- ── user_xp: the one aggregate. Sum totals (minus the duplicate awards
+  -- above), recompute level with the app's formula (floor(sqrt(xp/100))),
+  -- keep the better streak, cap freezes at the inventory bound the CHECK
+  -- constraint enforces.
   SELECT * INTO v_shell_xp FROM public.user_xp WHERE user_id = p_shell;
   IF FOUND THEN
     UPDATE public.user_xp t SET
-      total_xp           = t.total_xp + v_shell_xp.total_xp,
-      level              = floor(sqrt((t.total_xp + v_shell_xp.total_xp) / 100.0))::int,
+      total_xp           = t.total_xp + v_shell_xp.total_xp - v_dup_xp,
+      level              = floor(sqrt(GREATEST(0, t.total_xp + v_shell_xp.total_xp - v_dup_xp) / 100.0))::int,
       current_streak     = GREATEST(t.current_streak, v_shell_xp.current_streak),
       longest_streak     = GREATEST(t.longest_streak, v_shell_xp.longest_streak),
       last_activity_date = GREATEST(t.last_activity_date, v_shell_xp.last_activity_date),
@@ -115,7 +132,7 @@ BEGIN
     ELSE
       DELETE FROM public.user_xp WHERE user_id = p_shell;
     END IF;
-    v_moved := v_moved || jsonb_build_object('user_xp', 1);
+    v_moved := v_moved || jsonb_build_object('user_xp', 1, 'duplicate_xp_dropped', v_dup_xp);
   END IF;
 
   -- ── Keyed tables: move what does not collide, keep the target's row where
@@ -160,6 +177,17 @@ BEGIN
   v_moved := v_moved || jsonb_build_object('user_progress', v_count);
   DELETE FROM public.user_progress WHERE user_id = p_shell;
 
+  -- user_achievements and certificates carry minted on-chain artifacts
+  -- (asset_address, mint_address, tx_signature) — same structural asymmetry
+  -- as enrollments: the shell's colliding row is the minted one. Backfill
+  -- before dropping (adversarial round 2, R5).
+  UPDATE public.user_achievements t SET
+    tx_signature  = COALESCE(t.tx_signature, s.tx_signature),
+    asset_address = COALESCE(t.asset_address, s.asset_address),
+    unlocked_at   = LEAST(t.unlocked_at, s.unlocked_at)
+  FROM public.user_achievements s
+  WHERE t.user_id = p_target AND s.user_id = p_shell
+    AND t.achievement_id = s.achievement_id;
   UPDATE public.user_achievements s SET user_id = p_target
     WHERE s.user_id = p_shell
       AND NOT EXISTS (SELECT 1 FROM public.user_achievements x
@@ -168,13 +196,32 @@ BEGIN
   v_moved := v_moved || jsonb_build_object('user_achievements', v_count);
   DELETE FROM public.user_achievements WHERE user_id = p_shell;
 
-  UPDATE public.certificates s SET user_id = p_target
-    WHERE s.user_id = p_shell
-      AND NOT EXISTS (SELECT 1 FROM public.certificates x
-                      WHERE x.user_id = p_target AND x.course_id = s.course_id);
+  -- Certificates: idx_certificates_tx_signature_unique is GLOBAL (one row per
+  -- signature, not per user), so copying the shell's signature while the
+  -- shell's row still exists would collide mid-statement. Delete the shell's
+  -- colliding rows FIRST, backfilling the target from each deleted row.
+  -- credential_type follows the mint: a target row that never minted adopts
+  -- the shell's type along with its mint (else 'core' regresses to the
+  -- target's default 'legacy').
+  FOR v_cert IN
+    DELETE FROM public.certificates s
+      WHERE s.user_id = p_shell
+        AND EXISTS (SELECT 1 FROM public.certificates x
+                    WHERE x.user_id = p_target AND x.course_id = s.course_id)
+      RETURNING *
+  LOOP
+    UPDATE public.certificates t SET
+      mint_address    = COALESCE(t.mint_address, v_cert.mint_address),
+      metadata_uri    = COALESCE(t.metadata_uri, v_cert.metadata_uri),
+      tx_signature    = COALESCE(t.tx_signature, v_cert.tx_signature),
+      minted_at       = LEAST(t.minted_at, v_cert.minted_at),
+      credential_type = CASE WHEN t.mint_address IS NULL AND v_cert.mint_address IS NOT NULL
+                             THEN v_cert.credential_type ELSE t.credential_type END
+    WHERE t.user_id = p_target AND t.course_id = v_cert.course_id;
+  END LOOP;
+  UPDATE public.certificates SET user_id = p_target WHERE user_id = p_shell;
   GET DIAGNOSTICS v_count = ROW_COUNT;
   v_moved := v_moved || jsonb_build_object('certificates', v_count);
-  DELETE FROM public.certificates WHERE user_id = p_shell;
 
   UPDATE public.streak_freezes_used s SET user_id = p_target
     WHERE s.user_id = p_shell
@@ -283,11 +330,23 @@ BEGIN
   v_moved := v_moved || jsonb_build_object('email_subscriptions', v_count);
   DELETE FROM public.email_subscriptions WHERE user_id = p_shell;
 
-  -- ── Unkeyed tables: plain moves, nothing can collide.
-  UPDATE public.xp_transactions SET user_id = p_target WHERE user_id = p_shell;
+  -- xp_transactions is keyed after all: idx_xp_transactions_idempotency is
+  -- UNIQUE (user_id, idempotency_key), and daily-quest keys
+  -- (`<questId>:<period>`) are identical across users — both accounts doing
+  -- the same quest on the same day WILL collide (adversarial round 2, R4).
+  -- The shell's duplicate is the same award already counted once; drop it
+  -- (its amount was subtracted from the XP fold above).
+  UPDATE public.xp_transactions s SET user_id = p_target
+    WHERE s.user_id = p_shell
+      AND (s.idempotency_key IS NULL
+           OR NOT EXISTS (SELECT 1 FROM public.xp_transactions x
+                          WHERE x.user_id = p_target
+                            AND x.idempotency_key = s.idempotency_key));
   GET DIAGNOSTICS v_count = ROW_COUNT;
   v_moved := v_moved || jsonb_build_object('xp_transactions', v_count);
+  DELETE FROM public.xp_transactions WHERE user_id = p_shell;
 
+  -- ── Unkeyed on author: plain moves, nothing can collide.
   UPDATE public.threads SET author_id = p_target WHERE author_id = p_shell;
   GET DIAGNOSTICS v_count = ROW_COUNT;
   v_moved := v_moved || jsonb_build_object('threads', v_count);
@@ -296,9 +355,20 @@ BEGIN
   GET DIAGNOSTICS v_count = ROW_COUNT;
   v_moved := v_moved || jsonb_build_object('answers', v_count);
 
-  UPDATE public.flags SET reporter_id = p_target WHERE reporter_id = p_shell;
+  -- Flags carry the same partial per-kind uniques as votes
+  -- (idx_flags_unique_thread / idx_flags_unique_answer) — keyed move per
+  -- kind, keep the target's flag on a collision (adversarial round 2, R6).
+  UPDATE public.flags s SET reporter_id = p_target
+    WHERE s.reporter_id = p_shell AND s.thread_id IS NOT NULL
+      AND NOT EXISTS (SELECT 1 FROM public.flags x
+                      WHERE x.reporter_id = p_target AND x.thread_id = s.thread_id);
+  UPDATE public.flags s SET reporter_id = p_target
+    WHERE s.reporter_id = p_shell AND s.answer_id IS NOT NULL
+      AND NOT EXISTS (SELECT 1 FROM public.flags x
+                      WHERE x.reporter_id = p_target AND x.answer_id = s.answer_id);
   GET DIAGNOSTICS v_count = ROW_COUNT;
   v_moved := v_moved || jsonb_build_object('flags', v_count);
+  DELETE FROM public.flags WHERE reporter_id = p_shell;
   UPDATE public.flags SET resolved_by = p_target WHERE resolved_by = p_shell;
 
   -- ── The wallet itself. Shell first (wallet_address is UNIQUE), then target.

--- a/supabase/migrations/20260817180000_merge_wallet_shell_account.sql
+++ b/supabase/migrations/20260817180000_merge_wallet_shell_account.sql
@@ -121,6 +121,21 @@ BEGIN
   -- ── Keyed tables: move what does not collide, keep the target's row where
   -- it does, then drop the shell's leftovers. Keys mirror each table's
   -- UNIQUE/PK over user_id.
+  -- enrollments and user_progress carry ON-CHAIN truth (tx_signature, the
+  -- completed bit the program will refuse to re-set — LessonAlreadyCompleted),
+  -- and the SHELL is precisely the account that had the wallet, so on a
+  -- collision the shell's row is the on-chain one and the target's is the
+  -- empty social-only one. Plain keep-target here would strand the learner:
+  -- DB says incomplete, chain refuses to re-complete. So colliding target
+  -- rows are backfilled from the shell's before the shell's are dropped.
+  UPDATE public.enrollments t SET
+    tx_signature   = COALESCE(t.tx_signature, s.tx_signature),
+    wallet_address = COALESCE(t.wallet_address, s.wallet_address),
+    completed_at   = COALESCE(t.completed_at, s.completed_at),
+    enrolled_at    = LEAST(t.enrolled_at, s.enrolled_at)
+  FROM public.enrollments s
+  WHERE t.user_id = p_target AND s.user_id = p_shell
+    AND t.course_id = s.course_id;
   UPDATE public.enrollments s SET user_id = p_target
     WHERE s.user_id = p_shell
       AND NOT EXISTS (SELECT 1 FROM public.enrollments x
@@ -129,6 +144,14 @@ BEGIN
   v_moved := v_moved || jsonb_build_object('enrollments', v_count);
   DELETE FROM public.enrollments WHERE user_id = p_shell;
 
+  UPDATE public.user_progress t SET
+    completed    = COALESCE(t.completed, false) OR COALESCE(s.completed, false),
+    completed_at = COALESCE(t.completed_at, s.completed_at),
+    tx_signature = COALESCE(t.tx_signature, s.tx_signature),
+    lesson_index = COALESCE(t.lesson_index, s.lesson_index)
+  FROM public.user_progress s
+  WHERE t.user_id = p_target AND s.user_id = p_shell
+    AND t.lesson_id = s.lesson_id;
   UPDATE public.user_progress s SET user_id = p_target
     WHERE s.user_id = p_shell
       AND NOT EXISTS (SELECT 1 FROM public.user_progress x
@@ -286,17 +309,25 @@ BEGIN
   -- resolves it (wallet nulled) and isAccountDeleted refuses the rest.
   UPDATE public.profiles SET deleted_at = now() WHERE id = p_shell;
 
-  -- ── Fail-closed sweep: every FK into profiles/auth.users must be clean of
-  -- the shell. A table this function does not cover aborts the merge here and
-  -- rolls everything back.
+  -- ── Fail-closed sweep: every PUBLIC-schema FK into profiles/auth.users
+  -- must be clean of the shell. A table this function does not cover aborts
+  -- the merge here and rolls everything back. Scoped to the app's own schema
+  -- because the shell's auth.users row deliberately survives the merge, and
+  -- GoTrue's own tables (auth.identities, auth.sessions, auth.mfa_factors,
+  -- auth.one_time_tokens) all FK auth.users — sweeping them would abort every
+  -- real merge (adversarial review F1; a shell ALWAYS has an auth.identities
+  -- row from admin.createUser).
   FOR v_fk IN
     SELECT c.conrelid::regclass AS tbl, a.attname AS col
     FROM pg_constraint c
+    JOIN pg_class rel ON rel.oid = c.conrelid
+    JOIN pg_namespace ns ON ns.oid = rel.relnamespace
     JOIN LATERAL unnest(c.conkey) AS k(attnum) ON true
     JOIN pg_attribute a ON a.attrelid = c.conrelid AND a.attnum = k.attnum
     WHERE c.contype = 'f'
       AND c.confrelid IN ('public.profiles'::regclass, 'auth.users'::regclass)
       AND c.conrelid <> 'public.profiles'::regclass
+      AND ns.nspname = 'public'
       AND a.atttypid = 'uuid'::regtype
   LOOP
     EXECUTE format('SELECT count(*) FROM %s WHERE %I = $1', v_fk.tbl, v_fk.col)


### PR DESCRIPTION
Closes #993. Two halves of the same defect: the create arm defaulted `xpPerLesson ?? 10` (everything else — projector, drift engine, award path — treats absent as 0), and the update arm pushed `newXpPerLesson`/`newCreatorRewardXp` on every sync without comparing to chain, so a created course always ate an immediate `update_course` and could never no-op. Now the create tx writes bundle values and the update arm only includes fields that differ from the decoded on-chain course (plus an explicit 409 if the account vanishes between the two reads). Done-when evidence is operational per the issue: the next prod sync of the two alpha courses should report `action: noop`.