### PR TITLE
fix(lessons): topic chips show skills.json labels; discussion fetches on expand

### DIFF
--- a/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/lesson-client.tsx
+++ b/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/lesson-client.tsx
@@ -604,7 +604,12 @@ export function LessonPageClient({
         count={threadCount}
         open={isDiscussionListOpen}
         onOpenChange={setIsDiscussionListOpen}
-        keepMounted
+        // Mount on first expand, not first paint: an unconditional keepMounted
+        // made useThreads fire an uncached /api/community/threads on EVERY
+        // lesson load purely to label this collapsed row (#952). The one state
+        // worth pinning across a collapse is a composer draft, so mount stays
+        // held only while the composer is open.
+        keepMounted={isComposerOpen}
       >
         {/* Composing happens INLINE at the top of the section (LeetCode's
             comment box). A modal over a lesson hid the code the learner was

--- a/apps/web/src/components/lessons/lesson-section.tsx
+++ b/apps/web/src/components/lessons/lesson-section.tsx
@@ -15,9 +15,11 @@ interface LessonSectionProps {
   open?: boolean;
   onOpenChange?: (open: boolean) => void;
   /**
-   * Keep the panel's CHILDREN mounted while collapsed. Used by Discussion so
-   * its thread count is known before the learner opens the row. The panel
-   * element itself is always in the DOM either way (see below).
+   * Keep the panel's CHILDREN mounted while collapsed. Used by Discussion
+   * only while its composer holds a draft — collapsing must not destroy it
+   * (#952; the old unconditional keep fired an uncached threads fetch on
+   * every lesson first paint). The panel element itself is always in the DOM
+   * either way (see below).
    */
   keepMounted?: boolean;
   /**
@@ -86,9 +88,9 @@ export function LessonSection({
       {/* The panel element is ALWAYS rendered so the header button's (and the
           jump chip's) `aria-controls` never points at a missing id; `hidden`
           keeps a collapsed panel out of the a11y tree and the tab order.
-          `keepMounted` still controls whether the CHILDREN are mounted — the
-          Discussion row needs its thread count before it is opened, the rest
-          should not fetch or render until asked for. */}
+          `keepMounted` still controls whether the CHILDREN are mounted —
+          sections should not fetch or render until asked for; Discussion
+          pins its children only while a composer draft is live (#952). */}
       <div id={panelId} hidden={!isOpen} className="pb-4">
         {(isOpen || keepMounted) && children}
       </div>

--- a/apps/web/src/lib/content/queries.ts
+++ b/apps/web/src/lib/content/queries.ts
@@ -7,6 +7,7 @@ import type {
   LearningPath,
   QuizBlockData,
 } from "@superteam-lms/types";
+import skillsJson from "@/content/generated/skills.json";
 import {
   getActiveDeployments,
   getDeploymentById,
@@ -470,11 +471,24 @@ export async function getAllLessonSkills(): Promise<
  * The skill tags authored on ONE lesson — the "Topics" chips in the lesson
  * pane (#942). Bundle-only and ungated: the lesson page has already resolved
  * (and gated) the lesson itself, so this is a pure presentation read.
+ *
+ * Returns DISPLAY labels from the skills.json vocabulary (#952) — the chips
+ * render these verbatim, and learners were seeing raw slugs like
+ * `account-model` in every locale. Unknown slugs fall back to the slug so a
+ * vocabulary gap degrades, not hides. (The radar's getAllLessonSkills keeps
+ * returning slugs: they are attribution KEYS there, not copy.)
  */
 export async function getLessonSkills(lessonId: string): Promise<string[]> {
   const lesson = lessonsById.get(lessonId);
-  return lesson ? strArr(lesson.skills) : [];
+  if (!lesson) return [];
+  return strArr(lesson.skills).map(
+    (slug) => skillLabelBySlug.get(slug) ?? slug
+  );
 }
+
+const skillLabelBySlug: ReadonlyMap<string, string> = new Map(
+  skillsJson.map((skill) => [skill.slug, skill.label])
+);
 
 export async function getAllCourseLessonCounts(): Promise<
   { _id: string; totalLessons: number }[]

--- a/apps/web/src/lib/content/queries.ts
+++ b/apps/web/src/lib/content/queries.ts
@@ -7,7 +7,6 @@ import type {
   LearningPath,
   QuizBlockData,
 } from "@superteam-lms/types";
-import skillsJson from "@/content/generated/skills.json";
 import {
   getActiveDeployments,
   getDeploymentById,
@@ -35,6 +34,7 @@ import {
   lessonsById,
   pathsById,
   questsById,
+  skillLabelBySlug,
 } from "./store";
 import type {
   AchievementDoc,
@@ -481,14 +481,15 @@ export async function getAllLessonSkills(): Promise<
 export async function getLessonSkills(lessonId: string): Promise<string[]> {
   const lesson = lessonsById.get(lessonId);
   if (!lesson) return [];
-  return strArr(lesson.skills).map(
-    (slug) => skillLabelBySlug.get(slug) ?? slug
-  );
+  // Set-dedupe: slugs are unique by schema refinement, labels are not — two
+  // vocabulary entries sharing a label must not yield duplicate chips (and
+  // duplicate React keys) on one lesson.
+  return [
+    ...new Set(
+      strArr(lesson.skills).map((slug) => skillLabelBySlug.get(slug) ?? slug)
+    ),
+  ];
 }
-
-const skillLabelBySlug: ReadonlyMap<string, string> = new Map(
-  skillsJson.map((skill) => [skill.slug, skill.label])
-);
 
 export async function getAllCourseLessonCounts(): Promise<
   { _id: string; totalLessons: number }[]

--- a/apps/web/src/lib/content/store.ts
+++ b/apps/web/src/lib/content/store.ts
@@ -1,7 +1,13 @@
 import "server-only";
 
 import type { SlotsLockT } from "@superteam-lms/content-schema";
-import { buildStore } from "./build-store";
+import achievementsJson from "@/content/generated/achievements.json";
+import coursesJson from "@/content/generated/courses.json";
+import lessonsJson from "@/content/generated/lessons.json";
+import pathsJson from "@/content/generated/paths.json";
+import questsJson from "@/content/generated/quests.json";
+import skillsJson from "@/content/generated/skills.json";
+import slotsJson from "@/content/generated/slots.json";
 import type {
   AchievementDoc,
   CourseDoc,
@@ -9,12 +15,7 @@ import type {
   LessonDoc,
   QuestDoc,
 } from "./types";
-import achievementsJson from "@/content/generated/achievements.json";
-import coursesJson from "@/content/generated/courses.json";
-import lessonsJson from "@/content/generated/lessons.json";
-import pathsJson from "@/content/generated/paths.json";
-import questsJson from "@/content/generated/quests.json";
-import slotsJson from "@/content/generated/slots.json";
+import { buildStore } from "./build-store";
 
 /**
  * SECURITY: this module value-imports the generated content bundle, which
@@ -53,3 +54,17 @@ export const {
   pathsById,
   slotsByCourseId,
 } = store;
+
+/**
+ * Display labels from the skills.json vocabulary (#952). The boundary
+ * assertion mirrors the others above, but against the SCHEMA's shape, not
+ * today's JSON literal: `label` is optional in the content-schema
+ * (skills.ts), and a bundle without skills.yaml compiles to `[]` — typing
+ * off the literal made both valid content states a TS build break here.
+ * Entries without a label simply don't map; consumers fall back to the slug.
+ */
+export const skillLabelBySlug: ReadonlyMap<string, string> = new Map(
+  (skillsJson as { slug: string; label?: string }[]).flatMap((skill) =>
+    skill.label ? [[skill.slug, skill.label] as const] : []
+  )
+);


### PR DESCRIPTION
Closes #952. Chips rendered `getLessonSkills` slugs verbatim ('account-model' in every locale); the skills.json vocabulary now maps them at the query layer, unknown slugs falling back to the slug. And the discussion section's unconditional `keepMounted` made `useThreads` fire an uncached `/api/community/threads` on every lesson first paint just to label a collapsed row — it now mounts on first expand, held mounted only while the composer is open so collapsing can't eat a draft. Tradeoff accepted per the issue: the collapsed row shows no thread count until first expand.