### PR TITLE
fix(lint): widen restricted-import globs past single-star; gate dashboard toasts on active

### DIFF
--- a/apps/web/.eslintrc.json
+++ b/apps/web/.eslintrc.json
@@ -27,7 +27,7 @@
       {
         "patterns": [
           {
-            "group": ["@/content/generated/*", "**/content/generated/*"],
+            "group": ["@/content/generated/**", "**/content/generated/**"],
             "message": "The generated content bundle holds quiz answers, code solutions and hidden tests. Import it ONLY through src/lib/content/store.ts (server-only) — never directly, or those secrets leak into the client bundle."
           }
         ]
@@ -49,11 +49,16 @@
           {
             "patterns": [
               {
-                "group": ["@/content/generated/*", "**/content/generated/*"],
+                "group": ["@/content/generated/**", "**/content/generated/**"],
                 "message": "The generated content bundle holds quiz answers, code solutions and hidden tests. Import it ONLY through src/lib/content/store.ts (server-only) — never directly, or those secrets leak into the client bundle."
               },
               {
-                "group": ["@/lib/solana/*", "**/lib/solana/*"],
+                "group": [
+                  "@/lib/solana/**",
+                  "**/lib/solana/**",
+                  "**/solana/*",
+                  "**/solana/**"
+                ],
                 "message": "lib/gamification must stay chain-free: importing the Solana client graph here drags @solana/web3.js + @coral-xyz/anchor into every quest/XP route (dev-compile and cold-start cost). Pass chain clients in as parameters instead."
               }
             ]

--- a/apps/web/src/hooks/use-dashboard-data.ts
+++ b/apps/web/src/hooks/use-dashboard-data.ts
@@ -241,26 +241,32 @@ export function useDashboardData(
           questsResult.questPeriod
             ? questsResult.questPeriod
             : questPeriodUtc();
-        for (const reward of pickQuestRewardToasts(
-          (questsResult.quests ?? []) as DailyQuest[],
-          questPeriod,
-          authUserId
-        )) {
-          dispatchXpGain(reward.xpReward);
-          // Same celebration the Realtime path fires — one component, one look,
-          // wherever the learner happens to be standing.
-          dispatchQuestReward({
-            questId: reward.questId,
-            xpReward: reward.xpReward,
-          });
-        }
-        for (const amount of pickSurpriseBonusToasts(
-          transactions ?? [],
-          authUserId
-        )) {
-          dispatchXpGain(amount);
-          celebrate("surprise-bonus");
-          dispatchSurpriseBonus(amount);
+        // Gated on `active` for consistency with every other post-await effect
+        // in this fetch (#976 finding 4) — the session-wide dedupe already
+        // prevents double-toasts, but an unmounted hook should not fire UI
+        // events at all.
+        if (active) {
+          for (const reward of pickQuestRewardToasts(
+            (questsResult.quests ?? []) as DailyQuest[],
+            questPeriod,
+            authUserId
+          )) {
+            dispatchXpGain(reward.xpReward);
+            // Same celebration the Realtime path fires — one component, one
+            // look, wherever the learner happens to be standing.
+            dispatchQuestReward({
+              questId: reward.questId,
+              xpReward: reward.xpReward,
+            });
+          }
+          for (const amount of pickSurpriseBonusToasts(
+            transactions ?? [],
+            authUserId
+          )) {
+            dispatchXpGain(amount);
+            celebrate("surprise-bonus");
+            dispatchSurpriseBonus(amount);
+          }
         }
 
         const activityRows = activityRowsResult.data;


### PR DESCRIPTION
Closes #976. Single `*` doesn't cross `/`, so `@/lib/solana/idl/…` and relative `../../solana/pda` escaped both the content-generated and lib-solana bans; the widened `**`-form groups catch all three escape shapes in a lint fixture while `@solana/*` packages stay unmatched (`@solana` is a different path segment than `solana`). Folds in the same review's finding 4: the dashboard quest/bonus toast dispatches now respect the fetch's `active` cancellation flag.