### PR TITLE
fix(a11y): name icon buttons, keyboard-reach click handlers, Monaco loading skeletons

### DIFF
--- a/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/blocks/block-skeleton.tsx
+++ b/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/blocks/block-skeleton.tsx
@@ -1,0 +1,23 @@
+/**
+ * Placeholder for the Monaco-backed lesson blocks, which all load via
+ * `dynamic(..., { ssr: false })`. Without a `loading:` the block occupies zero
+ * height until the chunk arrives, so the reading column jumps once per code
+ * lesson (#933). Reserving roughly the mounted height keeps the shift off.
+ *
+ * Decorative: the surrounding block already announces itself, so this is
+ * hidden from assistive tech rather than given a loading string.
+ */
+export function BlockSkeleton({ height }: { height: string }) {
+  return (
+    <div
+      aria-hidden="true"
+      style={{ height }}
+      className="flex w-full flex-col gap-2 rounded-lg border border-border bg-[var(--surface)] p-4"
+    >
+      <div className="h-4 w-32 animate-pulse rounded [background:var(--border-default)]" />
+      <div className="h-4 w-56 animate-pulse rounded [background:var(--border-default)]" />
+      <div className="h-4 w-40 animate-pulse rounded [background:var(--border-default)]" />
+      <div className="h-4 w-48 animate-pulse rounded [background:var(--border-default)]" />
+    </div>
+  );
+}

--- a/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/blocks/code-block.tsx
+++ b/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/blocks/code-block.tsx
@@ -2,6 +2,7 @@
 
 import dynamic from "next/dynamic";
 import type { CodeBlockData } from "@superteam-lms/types";
+import { BlockSkeleton } from "./block-skeleton";
 import type { BlockRenderProps } from "./types";
 
 const ChallengeInterface = dynamic(
@@ -9,7 +10,7 @@ const ChallengeInterface = dynamic(
     import("@/components/editor/challenge-interface").then((mod) => ({
       default: mod.ChallengeInterface,
     })),
-  { ssr: false }
+  { ssr: false, loading: () => <BlockSkeleton height="32rem" /> }
 );
 
 /**

--- a/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/blocks/deployed-program-card-block.tsx
+++ b/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/blocks/deployed-program-card-block.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import dynamic from "next/dynamic";
+import { BlockSkeleton } from "./block-skeleton";
 import type { BlockRenderProps } from "./types";
 
 const DeployPanel = dynamic(
@@ -8,7 +9,7 @@ const DeployPanel = dynamic(
     import("@/components/deploy/deploy-panel").then((mod) => ({
       default: mod.DeployPanel,
     })),
-  { ssr: false }
+  { ssr: false, loading: () => <BlockSkeleton height="20rem" /> }
 );
 
 export function DeployedProgramCardBlock({ ctx }: BlockRenderProps) {

--- a/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/blocks/program-explorer-block.tsx
+++ b/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/blocks/program-explorer-block.tsx
@@ -2,6 +2,7 @@
 
 import dynamic from "next/dynamic";
 import type { ProgramExplorerBlockData } from "@superteam-lms/types";
+import { BlockSkeleton } from "./block-skeleton";
 import type { BlockRenderProps } from "./types";
 
 const GenericProgramExplorer = dynamic(
@@ -9,7 +10,7 @@ const GenericProgramExplorer = dynamic(
     import("@/components/deploy/generic-program-explorer").then((mod) => ({
       default: mod.GenericProgramExplorer,
     })),
-  { ssr: false }
+  { ssr: false, loading: () => <BlockSkeleton height="24rem" /> }
 );
 
 export function ProgramExplorerBlock({ block, ctx }: BlockRenderProps) {

--- a/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/blocks/wallet-funding-block.tsx
+++ b/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/blocks/wallet-funding-block.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import dynamic from "next/dynamic";
+import { BlockSkeleton } from "./block-skeleton";
 import type { BlockRenderProps } from "./types";
 
 const WalletFundingCard = dynamic(
@@ -8,7 +9,7 @@ const WalletFundingCard = dynamic(
     import("@/components/deploy/wallet-funding-card").then((mod) => ({
       default: mod.WalletFundingCard,
     })),
-  { ssr: false }
+  { ssr: false, loading: () => <BlockSkeleton height="14rem" /> }
 );
 
 export function WalletFundingBlock(_props: BlockRenderProps) {

--- a/apps/web/src/components/dashboard/achievements-strip.tsx
+++ b/apps/web/src/components/dashboard/achievements-strip.tsx
@@ -79,6 +79,10 @@ export function AchievementsStrip({
                   name={ach.name}
                   hint={ach.description}
                   state={earned ? (isSol ? "sol" : "earned") : "locked"}
+                  label={t("achievementTokenLabel", {
+                    name: ach.name,
+                    state: earned ? (isSol ? "sol" : "earned") : "locked",
+                  })}
                   isOpen={openTip === tipId}
                   onTap={() =>
                     setOpenTip((prev) => (prev === tipId ? null : tipId))

--- a/apps/web/src/components/gamification/dashboard-identity-panel.tsx
+++ b/apps/web/src/components/gamification/dashboard-identity-panel.tsx
@@ -176,6 +176,7 @@ export function AchievementToken({
   name,
   hint,
   state,
+  label,
   isOpen,
   onTap,
   onOpenChange,
@@ -185,6 +186,12 @@ export function AchievementToken({
   name: string;
   hint: string;
   state: "earned" | "sol" | "locked";
+  /**
+   * Full accessible name, translated by the caller (the token itself is
+   * rendered from several namespaces). Carries the earned/locked state, which
+   * is otherwise conveyed by colour alone.
+   */
+  label: string;
   isOpen?: boolean;
   onTap?: () => void;
   onOpenChange?: (open: boolean) => void;
@@ -195,23 +202,25 @@ export function AchievementToken({
   return (
     <Tooltip.Root open={isOpen} onOpenChange={onOpenChange}>
       <Tooltip.Trigger asChild>
-        <div
+        {/* A real button, not a div: this opens the achievement tooltip, and as
+            a div it was mouse-only — Radix gives the trigger no focus of its
+            own, so the hint was unreachable by keyboard (#933). */}
+        <button
+          type="button"
           className="dm"
+          aria-label={label}
           onClick={(e) => {
             if (wasDrag?.()) return;
             e.stopPropagation();
             onTap?.();
           }}
         >
-          <div
-            className={cn("dm-oct", state)}
-            aria-label={`${name} achievement — ${state}`}
-          >
+          <div className={cn("dm-oct", state)} aria-hidden="true">
             <div className="dm-face" />
             <span className="dm-glyph">{glyph}</span>
           </div>
           <span className="dm-name">{name}</span>
-        </div>
+        </button>
       </Tooltip.Trigger>
       <Tooltip.Portal>
         <Tooltip.Content
@@ -376,6 +385,13 @@ export function DashboardIdentityPanel({
                               setOpenTip(open ? cellTipId : null)
                             }
                           >
+                            {/* Stays a div on purpose (#933): the grid above is
+                                exposed as a single labelled image, so these
+                                ~365 11px cells are already presentational to
+                                assistive tech. Promoting each to a button
+                                would add 365 tab stops without exposing
+                                anything new. The click is a touch affordance —
+                                pointer devices get the same tooltip on hover. */}
                             <Tooltip.Trigger asChild>
                               <div
                                 className={cn(

--- a/apps/web/src/components/gamification/profile-body.tsx
+++ b/apps/web/src/components/gamification/profile-body.tsx
@@ -97,6 +97,10 @@ export function ProfileBody({
                   name={ach.name}
                   hint={ach.description}
                   state={earned ? (isSol ? "sol" : "earned") : "locked"}
+                  label={tGam("achievementTokenLabel", {
+                    name: ach.name,
+                    state: earned ? (isSol ? "sol" : "earned") : "locked",
+                  })}
                   isOpen={openTip === tipId}
                   onTap={() =>
                     setOpenTip((prev) => (prev === tipId ? null : tipId))

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -483,6 +483,7 @@
     "category_special": "Special",
     "noEntries": "No rankings yet. Complete lessons to earn XP and appear here.",
     "noAchievements": "Complete a lesson to earn your first achievement",
+    "achievementTokenLabel": "{name} — {state, select, earned {earned} sol {earned, Solana tier} locked {locked} other {locked}}",
     "showLocked": "Show locked",
     "viewOnExplorer": "View on Explorer",
     "onChain": "on-chain",

--- a/apps/web/src/messages/es.json
+++ b/apps/web/src/messages/es.json
@@ -483,6 +483,7 @@
     "category_special": "Especial",
     "noEntries": "Sin ranking aún. Completa lecciones para ganar XP y aparecer aquí.",
     "noAchievements": "Completa una lección para ganar tu primer logro",
+    "achievementTokenLabel": "{name} — {state, select, earned {conseguido} sol {conseguido, nivel Solana} locked {bloqueado} other {bloqueado}}",
     "showLocked": "Mostrar bloqueados",
     "viewOnExplorer": "Ver en Explorer",
     "onChain": "on-chain",

--- a/apps/web/src/messages/pt-BR.json
+++ b/apps/web/src/messages/pt-BR.json
@@ -483,6 +483,7 @@
     "category_special": "Especial",
     "noEntries": "Nenhum ranking ainda. Complete aulas para ganhar XP e aparecer aqui.",
     "noAchievements": "Complete uma lição para ganhar sua primeira conquista",
+    "achievementTokenLabel": "{name} — {state, select, earned {conquistada} sol {conquistada, nível Solana} locked {bloqueada} other {bloqueada}}",
     "showLocked": "Mostrar bloqueados",
     "viewOnExplorer": "Ver no Explorer",
     "onChain": "on-chain",

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -4074,6 +4074,8 @@ a.path-step-card:hover .path-step-badge.skip {
 }
 
 /* Mini achievement tokens */
+/* A <button> since #933 — the reset keeps the token looking identical while
+   the element carries native focus and Enter/Space activation. */
 .dm {
   display: flex;
   flex-direction: column;
@@ -4082,6 +4084,12 @@ a.path-step-card:hover .path-step-badge.skip {
   cursor: default;
   flex-shrink: 0;
   animation: dm-in 0.45s cubic-bezier(0.34, 1.56, 0.64, 1) both;
+  appearance: none;
+  background: none;
+  border: 0;
+  padding: 0;
+  font: inherit;
+  color: inherit;
 }
 .dm:nth-child(1) {
   animation-delay: 0.05s;


### PR DESCRIPTION
Most of #933's locations had already been fixed by the 31-07 and #969 UI waves — all five "unnamed icon buttons" carry visible text labels today, and the loop-widgets/learning-path-section handlers already had tabIndex + Enter/Space. What was still real: the dashboard achievement token was a `div` inside a Radix tooltip trigger, so it took no focus and its hint was mouse-only, and the four Monaco blocks had no `loading:`, shifting layout on every code lesson.

An ad-hoc jsx-a11y sweep (`click-events-have-key-events`, `no-static-element-interactions`, `interactive-supports-focus`) over all of `src/**/*.tsx` confirms the token was the only remaining reachable-control defect; the heatmap cells stay divs on purpose (~365 11px cells inside a `role="img"` summary must not become 365 tab stops) with a comment saying so.

`landing.poweredBy` was already translated in pt-BR/es, and `featureOssTitle` is intentionally "Open Source" in all three locales, so nothing was needed there.

tsc clean, eslint clean on every touched file, 105 tests green, locale key parity verified identical across en/pt-BR/es (1524 keys). Closes #933.