### PR TITLE
fix(landing): survive deployment-read failures; localized marketing error boundary

### DIFF
--- a/apps/web/src/app/[locale]/(marketing)/error.tsx
+++ b/apps/web/src/app/[locale]/(marketing)/error.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { useEffect } from "react";
+import Link from "next/link";
+import { useLocale, useTranslations } from "next-intl";
+import * as Sentry from "@sentry/nextjs";
+
+/**
+ * Marketing-group error boundary (#931). Without one, a landing-page failure
+ * escalated to the root `app/error.tsx`, which renders outside the `[locale]`
+ * layout and so hardcodes English — a PT-BR visitor hitting a transient error
+ * on the front door got an English page. This boundary renders inside that
+ * layout, where `NextIntlClientProvider` is mounted, so it uses the same
+ * `error` namespace as the platform boundary rather than inline translations.
+ */
+export default function MarketingError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  const t = useTranslations("error");
+  const locale = useLocale();
+
+  useEffect(() => {
+    Sentry.captureException(error);
+  }, [error]);
+
+  return (
+    <div className="flex min-h-[60vh] flex-col items-center justify-center bg-bg px-4 text-center">
+      <h1 className="font-display text-6xl font-black text-primary">Oops!</h1>
+      <p className="mt-4 text-xl font-semibold text-text">{t("title")}</p>
+      <p className="mt-2 max-w-md text-text-3">{t("description")}</p>
+      <div className="mt-8 flex items-center gap-4">
+        <button
+          onClick={reset}
+          className="inline-flex items-center rounded-lg bg-primary px-6 py-3 text-sm font-medium text-white transition-opacity hover:opacity-90"
+        >
+          {t("tryAgain")}
+        </button>
+        <Link
+          href={`/${locale}`}
+          className="inline-flex items-center rounded-lg border-[2.5px] border-border px-6 py-3 text-sm font-medium text-text transition-colors hover:bg-subtle"
+        >
+          {t("goHome")}
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/global-error.tsx
+++ b/apps/web/src/app/global-error.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import "@/styles/globals.css";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import * as Sentry from "@sentry/nextjs";
 
 /**
@@ -12,6 +12,33 @@ import * as Sentry from "@sentry/nextjs";
  * Inline translations: this renders outside the `[locale]` layout, so next-intl
  * is unavailable (same constraint as `error.tsx` / `not-found.tsx`).
  */
+
+/**
+ * The theme next-themes would have resolved, read straight from its storage
+ * (#931). This boundary replaces the document, so the `ThemeProvider` that
+ * normally stamps `data-theme` is gone — without this the dark tokens in
+ * globals.css never apply and a dark-mode reader gets a white page. Duplicating
+ * the lookup is the price of the "assume no providers" rule; it is pinned to
+ * next-themes' defaults (storage key `theme`, `defaultTheme="light"`,
+ * `enableSystem`) as configured in `app/[locale]/layout.tsx`.
+ */
+function storedTheme(): "light" | "dark" {
+  if (typeof window === "undefined") return "light";
+  try {
+    const stored = window.localStorage.getItem("theme");
+    if (stored === "dark" || stored === "light") return stored;
+    if (stored === "system") {
+      return window.matchMedia("(prefers-color-scheme: dark)").matches
+        ? "dark"
+        : "light";
+    }
+  } catch {
+    // Storage can throw outright (Safari private mode, blocked third-party
+    // cookies). A themed error page is not worth a second error.
+  }
+  return "light";
+}
+
 export default function GlobalError({
   error,
   reset,
@@ -19,19 +46,30 @@ export default function GlobalError({
   error: Error & { digest?: string };
   reset: () => void;
 }) {
+  // Initial state covers the client-render path (the common one) so the correct
+  // theme is in the first commit; the effect covers the server-rendered path,
+  // where this initializer ran on the server and could only answer "light".
+  const [theme, setTheme] = useState(storedTheme);
+
+  useEffect(() => {
+    setTheme(storedTheme());
+  }, []);
+
   useEffect(() => {
     Sentry.captureException(error);
   }, [error]);
 
   return (
-    <html lang="en">
-      <body className="flex min-h-screen flex-col items-center justify-center px-4 text-center">
-        <h1 className="text-6xl font-black">Oops!</h1>
+    <html lang="en" data-theme={theme} suppressHydrationWarning>
+      <body className="flex min-h-screen flex-col items-center justify-center bg-bg px-4 text-center text-text">
+        <h1 className="font-display text-6xl font-black text-primary">Oops!</h1>
         <p className="mt-4 text-xl font-semibold">Something Went Wrong</p>
-        <p className="mt-2 max-w-md">An unexpected error occurred.</p>
+        <p className="mt-2 max-w-md text-text-3">
+          An unexpected error occurred.
+        </p>
         <button
           onClick={reset}
-          className="mt-8 inline-flex items-center rounded-lg px-6 py-3 text-sm font-medium underline"
+          className="mt-8 inline-flex items-center rounded-lg bg-primary px-6 py-3 text-sm font-medium text-white transition-opacity hover:opacity-90"
         >
           Try Again
         </button>

--- a/apps/web/src/lib/content/__tests__/queries.test.ts
+++ b/apps/web/src/lib/content/__tests__/queries.test.ts
@@ -368,6 +368,31 @@ describe("getCourseById — UNGATED, trackCollectionAddress from the full row", 
     const c = await q.getCourseById("course-zeta");
     expect(c).not.toBeNull();
     expect(c?.trackCollectionAddress).toBeNull();
+    expect(c?.deploymentReadFailed).toBeUndefined();
+  });
+
+  // #931: this call sits on the landing render path (resolveFlagshipLessonHref,
+  // outside page.tsx's try) — a throw here took the whole page to the root
+  // error boundary. It must degrade instead.
+  it("degrades to a null collection instead of throwing when the read fails", async () => {
+    const deployments = await import("../deployments");
+    vi.mocked(deployments.getDeploymentById).mockRejectedValueOnce(
+      new Error("connection refused")
+    );
+    const c = await q.getCourseById("course-off");
+    expect(c?._id).toBe("course-off");
+    expect(c?.trackCollectionAddress).toBeNull();
+  });
+
+  // The null above is ambiguous on its own — "never synced" reads identically.
+  // Reward paths branch on this flag, so it must not silently disappear.
+  it("marks a failed read so it is distinguishable from an absent row", async () => {
+    const deployments = await import("../deployments");
+    vi.mocked(deployments.getDeploymentById).mockRejectedValueOnce(
+      new Error("connection refused")
+    );
+    const c = await q.getCourseById("course-off");
+    expect(c?.deploymentReadFailed).toBe(true);
   });
 });
 

--- a/apps/web/src/lib/content/project.ts
+++ b/apps/web/src/lib/content/project.ts
@@ -258,6 +258,9 @@ export interface CourseProjectionOptions {
   /** Attach `trackCollectionAddress` (getCourseById reward path only). Omitted
    *  from the object entirely when not provided, matching getCourseBySlug. */
   trackCollectionAddress?: string | null;
+  /** Attach `deploymentReadFailed` (#931) — only when the deployment read
+   *  actually failed, so the common path keeps its exact previous shape. */
+  deploymentReadFailed?: boolean;
 }
 
 /**
@@ -296,6 +299,7 @@ export function projectCourse(
     ...(opts.trackCollectionAddress !== undefined
       ? { trackCollectionAddress: opts.trackCollectionAddress }
       : {}),
+    ...(opts.deploymentReadFailed ? { deploymentReadFailed: true } : {}),
   };
 
   return projected as unknown as Course;

--- a/apps/web/src/lib/content/queries.ts
+++ b/apps/web/src/lib/content/queries.ts
@@ -304,17 +304,30 @@ export async function getAllLearningPaths(): Promise<LearningPath[]> {
 }
 
 /**
- * Fetch a course by its Sanity `_id`. UNGATED (API routes pass the raw `_id`).
- * `trackCollectionAddress` comes from the full Supabase deployment row via
- * `getDeploymentById` (service-role, uncached) — this is a reward-path read.
+ * Fetch a course by its Sanity `_id`. UNGATED (API routes pass the raw `_id`) —
+ * the deployment row supplies `trackCollectionAddress` only; it gates nothing,
+ * so a failed read cannot leak a hidden course.
+ *
+ * The read goes through `getDeploymentByIdSafe` (#931): `getDeploymentById`
+ * throws on any Supabase error, and callers on the render path — the landing
+ * page's `resolveFlagshipLessonHref` — sit outside a `try`, so one DB blip took
+ * the whole page to the root error boundary. Degrading to a null collection
+ * keeps every read-only caller alive.
+ *
+ * `deploymentReadFailed` carries the distinction the null erases: "never
+ * synced" vs "could not tell". Reward paths that refuse to mint without a
+ * collection MUST branch on it rather than reporting a transient outage as a
+ * missing sync (see the certificate case in lib/solana/onchain-queue.ts).
+ * Same contract, same field name, as `AdminCourse.deploymentReadFailed` (#436).
  */
 export async function getCourseById(id: string): Promise<Course | null> {
   const doc = coursesById.get(id);
   if (!doc) return null;
-  const dep = await getDeploymentById(id);
+  const { row, failed } = await getDeploymentByIdSafe(id);
   return projectCourse(doc, projectionDeps, {
     fullLessons: true,
-    trackCollectionAddress: dep?.track_collection_address ?? null,
+    trackCollectionAddress: row?.track_collection_address ?? null,
+    deploymentReadFailed: failed,
   });
 }
 

--- a/apps/web/src/lib/courses/__tests__/entry-course-live.test.ts
+++ b/apps/web/src/lib/courses/__tests__/entry-course-live.test.ts
@@ -54,7 +54,7 @@ vi.mock("@/lib/content/deployments", async (importActual) => {
         >
     ),
     getDeploymentById: vi.fn(async () => null),
-    getDeploymentByIdSafe: vi.fn(async () => null),
+    getDeploymentByIdSafe: vi.fn(async () => ({ row: null, failed: false })),
   };
 });
 

--- a/apps/web/src/lib/solana/onchain-queue.ts
+++ b/apps/web/src/lib/solana/onchain-queue.ts
@@ -218,8 +218,14 @@ export async function retryPendingOnchainActions(
             | string
             | undefined;
           if (!trackCollectionAddress) {
+            // Since #931 getCourseById degrades a failed deployment read to a
+            // null collection instead of throwing, so "no collection" no longer
+            // implies "never synced" — say which, or an outage reads as an
+            // operator error nobody acts on.
             throw new Error(
-              `Course "${courseId}" has no trackCollectionAddress — sync the course first`
+              sanityCourse.deploymentReadFailed
+                ? `Course "${courseId}" deployment read failed — collection unknown, retrying`
+                : `Course "${courseId}" has no trackCollectionAddress — sync the course first`
             );
           }
 

--- a/packages/types/src/course.ts
+++ b/packages/types/src/course.ts
@@ -203,6 +203,13 @@ export interface Course {
   xpReward: number;
   modules: Module[];
   trackCollectionAddress?: string | null;
+  /**
+   * True when the Supabase deployment-row read failed (#931), as opposed to a
+   * genuinely absent row — both read `trackCollectionAddress: null`. Set only
+   * by `getCourseById`. Reward paths must not report "not synced" when the
+   * truth is "could not tell". Mirrors `AdminCourse.deploymentReadFailed` (#436).
+   */
+  deploymentReadFailed?: boolean;
   trackId?: number;
   trackLevel?: number;
   /** Authoring workflow state (issue #263). Legacy/repo-synced docs may omit this. */


### PR DESCRIPTION
`getCourseById` threw on any Supabase error and the landing page reaches it via `resolveFlagshipLessonHref`, which sits outside `page.tsx`'s try/catch — one DB blip took the whole front door to the root error boundary. It now reads through the existing `getDeploymentByIdSafe`; the row gates nothing (it only supplies `trackCollectionAddress`), so degrading cannot leak a hidden course, but the resulting null is ambiguous with "never synced", and `deploymentReadFailed` keeps the credential queue from reporting a transient outage as an operator error.

Also adds a `(marketing)/error.tsx` so a front-door failure stops falling through to the root boundary's hardcoded English — it renders inside the `[locale]` layout, so it reuses the existing `error` namespace like `(platform)/error.tsx` (no new message keys), and themes `global-error.tsx` off the tokens so dark-mode readers no longer get a white page.

Red-proof: both new `getCourseById` tests fail with `Error: connection refused` against the pre-change code.

Closes #931