### PR TITLE
fix(enroll): await the unknown-course guard — a Promise is always truthy

### DIFF
--- a/apps/web/src/app/api/enroll/sponsor/__tests__/route.test.ts
+++ b/apps/web/src/app/api/enroll/sponsor/__tests__/route.test.ts
@@ -72,7 +72,7 @@ beforeEach(() => {
   h.isRateLimited.mockResolvedValue(false);
   h.isPlatformFrozen.mockResolvedValue(false);
   h.isCourseInMaintenance.mockResolvedValue(false);
-  h.getCourseById.mockReturnValue({ _id: "course-x" });
+  h.getCourseById.mockResolvedValue({ _id: "course-x" });
   h.buildSponsored.mockResolvedValue({
     transaction: "BASE64TX",
     sponsor: "SponsorPubkey111",
@@ -95,7 +95,7 @@ describe("POST /api/enroll/sponsor", () => {
   });
 
   it("refuses an unknown course before spending anything", async () => {
-    h.getCourseById.mockReturnValue(undefined);
+    h.getCourseById.mockResolvedValue(undefined);
     const res = await POST(post({ courseId: "nope" }));
     expect(res.status).toBe(404);
     expect(h.buildSponsored).not.toHaveBeenCalled();

--- a/apps/web/src/app/api/enroll/sponsor/route.ts
+++ b/apps/web/src/app/api/enroll/sponsor/route.ts
@@ -65,7 +65,7 @@ export async function POST(request: NextRequest) {
     // Reject unknown courses before building anything. The program would reject
     // them too, but only after the learner submitted — and a failed transaction
     // still costs the sponsor the fee.
-    if (!getCourseById(courseId)) {
+    if (!(await getCourseById(courseId))) {
       return NextResponse.json({ error: "Unknown course" }, { status: 404 });
     }
 


### PR DESCRIPTION
Closes #1049. `if (!getCourseById(courseId))` never 404'd; awaited now, and the test mocks are async-shaped (red against the unawaited route: the unknown-course test fails).