### PR TITLE
perf(landing): resolve entry-lesson slugs from the bundle, not Supabase

### DIFF
--- a/apps/web/src/app/[locale]/(marketing)/start/__tests__/routes.test.ts
+++ b/apps/web/src/app/[locale]/(marketing)/start/__tests__/routes.test.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { getCourseById, getCourseLessons } from "@/lib/content/queries";
+import { getCourseLessons, getCourseSlugById } from "@/lib/content/queries";
 import { SEGMENT_ENTRY_COURSE } from "@/lib/courses/learner-segment";
 import { resolveSegmentRoutes } from "../routes";
 
 vi.mock("@/lib/content/queries", () => ({
-  getCourseById: vi.fn(),
+  getCourseSlugById: vi.fn(),
   getCourseLessons: vi.fn(),
 }));
 
@@ -24,7 +24,7 @@ vi.mock("@/lib/courses/learner-segment", () => ({
   },
 }));
 
-const byId = vi.mocked(getCourseById);
+const slugOf = vi.mocked(getCourseSlugById);
 const lessonsOf = vi.mocked(getCourseLessons);
 
 // Use each entry course's id as its slug for the fixtures (1:1, arbitrary).
@@ -32,13 +32,10 @@ const SEG1_ENTRY = SEGMENT_ENTRY_COURSE[1];
 const SEG2_ENTRY = SEGMENT_ENTRY_COURSE[2];
 
 beforeEach(() => {
-  byId.mockReset();
+  slugOf.mockReset();
   lessonsOf.mockReset();
   // Every entry course is present in the bundle (slug == id).
-  byId.mockImplementation(
-    async (id: string) =>
-      ({ slug: id }) as Awaited<ReturnType<typeof getCourseById>>
-  );
+  slugOf.mockImplementation((id: string) => id);
 });
 
 function lesson(slug: string) {
@@ -66,7 +63,7 @@ describe("resolveSegmentRoutes — F1 sync gating (funnel must never 404)", () =
   });
 
   it("falls back to /courses when the entry course is absent from the bundle", async () => {
-    byId.mockResolvedValue(null);
+    slugOf.mockReturnValue(null);
     lessonsOf.mockResolvedValue([]);
     const routes = await resolveSegmentRoutes("en");
     for (const seg of [1, 2, 3] as const) {

--- a/apps/web/src/lib/content/queries.ts
+++ b/apps/web/src/lib/content/queries.ts
@@ -331,6 +331,20 @@ export async function getCourseById(id: string): Promise<Course | null> {
   });
 }
 
+/**
+ * A course's slug straight from the bundle — NO deployment read (#1050). For
+ * callers that only need to build a URL (the landing/funnel entry-lesson
+ * resolution): the sync gate on those paths lives in `getCourseLessons`
+ * (empty for unsynced), so paying a service-role Supabase round-trip here for
+ * a discarded `trackCollectionAddress` was pure liability — the read #931
+ * taught the landing to survive is one it never needed. UNGATED by design;
+ * do not use the returned slug to decide visibility.
+ */
+export function getCourseSlugById(id: string): string | null {
+  const doc = coursesById.get(id);
+  return doc?.slug?.current ?? null;
+}
+
 export async function getCourseIdBySlug(
   slug: string
 ): Promise<{ _id: string; xpPerLesson: number } | null> {

--- a/apps/web/src/lib/courses/__tests__/entry-lesson.test.ts
+++ b/apps/web/src/lib/courses/__tests__/entry-lesson.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { getCourseById, getCourseLessons } from "@/lib/content/queries";
+import { getCourseLessons, getCourseSlugById } from "@/lib/content/queries";
 import {
   DEFAULT_SEGMENT,
   SEGMENT_ENTRY_COURSE,
@@ -10,23 +10,20 @@ import {
 } from "../entry-lesson";
 
 vi.mock("@/lib/content/queries", () => ({
-  getCourseById: vi.fn(),
+  getCourseSlugById: vi.fn(),
   getCourseLessons: vi.fn(),
 }));
 
-const byId = vi.mocked(getCourseById);
+const slugOf = vi.mocked(getCourseSlugById);
 const lessonsOf = vi.mocked(getCourseLessons);
 
 const FLAGSHIP = SEGMENT_ENTRY_COURSE[DEFAULT_SEGMENT];
 
 beforeEach(() => {
-  byId.mockReset();
+  slugOf.mockReset();
   lessonsOf.mockReset();
   // Course present in the bundle; use its id as slug (1:1, arbitrary).
-  byId.mockImplementation(
-    async (id: string) =>
-      ({ slug: id }) as Awaited<ReturnType<typeof getCourseById>>
-  );
+  slugOf.mockImplementation((id: string) => id);
 });
 
 function lesson(slug: string) {
@@ -53,7 +50,7 @@ describe("resolveEntryLessonHref — F1 sync gating", () => {
   });
 
   it("falls back to the locale catalog when the course is ABSENT", async () => {
-    byId.mockResolvedValue(null);
+    slugOf.mockReturnValue(null);
     lessonsOf.mockResolvedValue([]);
     const href = await resolveEntryLessonHref("en", "course-x");
     expect(href).toBe("/en/courses");
@@ -66,7 +63,7 @@ describe("resolveFlagshipLessonHref — landing deep-link (LX-A1)", () => {
   it("targets the DEFAULT_SEGMENT entry course's first lesson", async () => {
     lessonsOf.mockResolvedValue([lesson("welcome")]);
     const href = await resolveFlagshipLessonHref("en");
-    expect(byId).toHaveBeenCalledWith(FLAGSHIP);
+    expect(slugOf).toHaveBeenCalledWith(FLAGSHIP);
     expect(href).toBe(`/en/courses/${FLAGSHIP}/lessons/welcome`);
   });
 

--- a/apps/web/src/lib/courses/entry-lesson.ts
+++ b/apps/web/src/lib/courses/entry-lesson.ts
@@ -1,7 +1,7 @@
 import {
-  getCourseById,
   getCourseIdBySlug,
   getCourseLessons,
+  getCourseSlugById,
 } from "@/lib/content/queries";
 import {
   DEFAULT_SEGMENT,
@@ -24,8 +24,10 @@ export async function resolveEntryLessonHref(
   locale: string,
   courseId: string
 ): Promise<string> {
-  const course = await getCourseById(courseId);
-  const slug = course?.slug ?? null;
+  // Bundle-only slug read (#1050): the old getCourseById here paid a
+  // service-role deployment round-trip per landing render for a field this
+  // caller discards. The sync gate below (getCourseLessons) is unchanged.
+  const slug = getCourseSlugById(courseId);
   const lessons = slug ? await getCourseLessons(slug) : [];
   const firstLessonSlug = lessons[0]?.slug ?? null;
   return slug && firstLessonSlug


### PR DESCRIPTION
Closes #1050. New ungated `getCourseSlugById` (bundle map read, documented as never-for-visibility); `resolveEntryLessonHref` uses it, keeping the F1 sync gate exactly where it was (`getCourseLessons` returns empty for unsynced). Landing now does zero Supabase reads for slug resolution.