### PR TITLE
fix(ui): card-owned course titles, mobile thread rows, neutral signing copy

### DIFF
--- a/apps/web/src/components/community/thread-card.tsx
+++ b/apps/web/src/components/community/thread-card.tsx
@@ -102,7 +102,10 @@ export function ThreadCard({
       {/* Title takes the slack and truncates; meta is a fixed compact cluster
           pinned right, so there is no ocean of space between them. */}
       <div className="flex min-w-0 flex-1 flex-wrap items-center justify-between gap-x-3 gap-y-0.5">
-        <div className="flex min-w-0 flex-1 items-center gap-2">
+        {/* flex-basis 14rem: below that width the title stops shrinking and
+            the meta block wraps to its own row — a title crushed to zero was
+            exactly the mobile bug. */}
+        <div className="flex min-w-0 flex-[1_1_14rem] items-center gap-2">
           {isPinned && (
             <PushPin
               size={12}
@@ -139,12 +142,16 @@ export function ThreadCard({
               ) : (
                 <div className="h-3.5 w-3.5 rounded-full bg-[var(--primary-dim)]" />
               )}
-              <span className="max-w-[10rem] truncate">{author.username}</span>
+              <span className="max-w-[7rem] truncate sm:max-w-[10rem]">
+                {author.username}
+              </span>
             </Link>
           ) : (
             <span className="flex items-center gap-1">
               <div className="h-3.5 w-3.5 rounded-full bg-[var(--primary-dim)]" />
-              <span className="max-w-[10rem] truncate">{t("anonymous")}</span>
+              <span className="max-w-[7rem] truncate sm:max-w-[10rem]">
+                {t("anonymous")}
+              </span>
             </span>
           )}
           {author.level > 0 && <LevelBadge level={author.level} size="xs" />}

--- a/apps/web/src/components/course/course-card.tsx
+++ b/apps/web/src/components/course/course-card.tsx
@@ -53,6 +53,14 @@ export function CourseCard({
           loading="lazy"
           aria-hidden="true"
         />
+        {/* The card owns the title as an overlay — banner art ships text-free
+            so one image serves every locale and a retitle never needs a
+            re-render of the art. */}
+        {thumbnail && (
+          <h3 className="course-card-thumb-title">
+            <span>{title}</span>
+          </h3>
+        )}
         {status === "completed" && (
           <span
             className="course-card-status completed"

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -92,7 +92,7 @@
     "retry": "Try again",
     "sendCode": "Send code",
     "signFailed": "Could not sign the verification message. Please try again.",
-    "signingIn": "Signing in with your wallet...",
+    "signingIn": "Signing you in...",
     "settingUpWallet": "Setting up your wallet…",
     "settingUpWalletHint": "This can take a few seconds — keep this tab open.",
     "signingMessage": "Sign this message to verify your wallet ownership",

--- a/apps/web/src/messages/es.json
+++ b/apps/web/src/messages/es.json
@@ -92,7 +92,7 @@
     "retry": "Reintentar",
     "sendCode": "Enviar código",
     "signFailed": "No se pudo firmar el mensaje de verificación. Inténtalo de nuevo.",
-    "signingIn": "Iniciando sesión con tu billetera...",
+    "signingIn": "Iniciando sesión...",
     "settingUpWallet": "Preparando tu billetera…",
     "settingUpWalletHint": "Esto puede tardar unos segundos — mantén esta pestaña abierta.",
     "signingMessage": "Firma este mensaje para verificar la propiedad de tu billetera",

--- a/apps/web/src/messages/pt-BR.json
+++ b/apps/web/src/messages/pt-BR.json
@@ -92,7 +92,7 @@
     "retry": "Tentar novamente",
     "sendCode": "Enviar código",
     "signFailed": "Não foi possível assinar a mensagem de verificação. Tente novamente.",
-    "signingIn": "Entrando com sua carteira...",
+    "signingIn": "Entrando...",
     "settingUpWallet": "Preparando sua carteira…",
     "settingUpWalletHint": "Isso pode levar alguns segundos — mantenha esta aba aberta.",
     "signingMessage": "Assine esta mensagem para verificar a propriedade da sua carteira",

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -1809,6 +1809,22 @@
     line-height: 1.3;
     margin-bottom: 7px;
   }
+  /* Title overlaid on the banner art (art ships text-free). The scrim keeps
+     white text readable over any artwork; padding-top gives the gradient room
+     to fade before the text starts. */
+  .course-card-thumb-title {
+    position: absolute;
+    inset: auto 0 0 0;
+    margin: 0;
+    padding: 34px 14px 10px;
+    background: linear-gradient(to top, rgb(6 10 14 / 0.88), transparent);
+    font-family: var(--font-display, var(--font-d));
+    font-weight: 900;
+    font-size: 17px;
+    line-height: 1.2;
+    color: #fff;
+    text-wrap: balance;
+  }
 
   /* 3. Description — 2-line clamp, readable */
   .course-card-desc {

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -1824,6 +1824,13 @@
     line-height: 1.2;
     color: #fff;
     text-wrap: balance;
+    /* The thumb is overflow:hidden with a fixed aspect-ratio, so an unclamped
+       title hard-clips mid-line; two lines then ellipsis instead. */
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 
   /* 3. Description — 2-line clamp, readable */

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -4447,9 +4447,8 @@ a.path-step-card:hover .path-step-badge.skip {
   display: flex;
   flex-wrap: nowrap;
   align-items: center;
-  /* `safe` so an overflowing row falls back to flex-start — with plain
-     flex-end the leading tokens scroll off and cannot be reached. */
-  justify-content: safe flex-end;
+  /* Left-aligned (owner, 18-08); overflow scrolls rightward naturally. */
+  justify-content: flex-start;
   gap: 10px;
   min-width: 0;
   flex: 1;


### PR DESCRIPTION
Three owner-reported polish items: course cards render the title as an overlay on the banner (banner art ships text-free — the BTC and Speedrun banners still carry baked-in titles and need text-free re-exports in academy-courses, tracked separately); thread-list rows on mobile crushed the title to zero width (meta was shrink-0, title the only shrinkable item — a flex-basis makes meta wrap to a second row instead); auth.signingIn said 'with your wallet' on Google returns.

Verified: 75 component tests green, tsc/eslint/prettier clean.