### PR TITLE
feat(courses): unlist the Pílula Solana course — direct link only

### DIFF
--- a/apps/web/src/app/api/admin/resync/route.ts
+++ b/apps/web/src/app/api/admin/resync/route.ts
@@ -20,7 +20,10 @@ import {
 } from "@/lib/solana/academy-reads";
 import { isLessonComplete } from "@/lib/solana/bitmap";
 import { slotToLiveLessonId } from "@/lib/courses/lesson-slot";
-import { getAllCourses, getAllAchievements } from "@/lib/content/queries";
+import {
+  getAllCoursesIncludingUnlisted,
+  getAllAchievements,
+} from "@/lib/content/queries";
 import { calculateLevel } from "@/lib/gamification/xp";
 
 function isValidBase58(value: string): boolean {
@@ -128,8 +131,10 @@ export async function POST(req: NextRequest) {
     }
   }
 
-  // 2. Sync enrollments + lesson progress from on-chain Enrollment PDAs
-  const courses = await getAllCourses();
+  // 2. Sync enrollments + lesson progress from on-chain Enrollment PDAs.
+  // Unlisted included: a learner's on-chain enrolment in an unlisted course is
+  // just as real, and resync repairing everything BUT it would be a silent hole.
+  const courses = await getAllCoursesIncludingUnlisted();
 
   for (const course of courses) {
     try {

--- a/apps/web/src/lib/content/__tests__/unlisted-courses.test.ts
+++ b/apps/web/src/lib/content/__tests__/unlisted-courses.test.ts
@@ -1,0 +1,82 @@
+/* eslint-disable import/order -- vi.mock('server-only') must be hoisted above
+   the queries graph so the `server-only` module loads under vitest. */
+import { describe, it, expect, vi } from "vitest";
+vi.mock("server-only", () => ({}));
+import type { DeploymentStatus } from "../deployments";
+import { UNLISTED_COURSE_IDS, isUnlistedCourse } from "@/lib/courses/unlisted";
+import {
+  getAllCourses,
+  getAllCoursesIncludingUnlisted,
+  getCourseBySlug,
+  getRecommendedCourses,
+} from "../queries";
+
+/**
+ * Unlisted = hidden from listings, reachable by direct link — asserted against
+ * the REAL committed bundle (the entry-course-live pattern), mocking only the
+ * on-chain sync gate so every course reads as synced+active. A course that is
+ * both in UNLISTED_COURSE_IDS and absent from getAllCourses here is proven
+ * hidden on every surface that lists through it (catalog, landing count,
+ * sitemap); getCourseBySlug still resolving is what keeps the direct link —
+ * and the landing hero that uses it — alive.
+ */
+
+vi.mock("@/lib/content/deployments", async (importActual) => {
+  const actual =
+    await importActual<typeof import("@/lib/content/deployments")>();
+  const synced = (id: string): DeploymentStatus =>
+    ({
+      content_id: id,
+      kind: "course",
+      status: "synced",
+      is_active: true,
+      achievement_pda: null,
+    }) as DeploymentStatus;
+  return {
+    ...actual,
+    getActiveDeployments: vi.fn(
+      async () =>
+        ({ get: (id: string) => synced(id) }) as unknown as ReadonlyMap<
+          string,
+          DeploymentStatus
+        >
+    ),
+    getDeploymentById: vi.fn(async () => null),
+    getDeploymentByIdSafe: vi.fn(async () => null),
+  };
+});
+
+const PILULA_ID = "course-pilula-solana-superteam";
+const PILULA_SLUG = "pilula-solana-superteam";
+
+describe("unlisted courses — hidden from listings, live by direct link", () => {
+  it("the Pílula course is registered as unlisted", () => {
+    expect(isUnlistedCourse(PILULA_ID)).toBe(true);
+  });
+
+  it("every unlisted id exists in the bundle — a stale entry is dead config", async () => {
+    const all = await getAllCoursesIncludingUnlisted();
+    const ids = new Set(all.map((c) => c._id));
+    for (const id of UNLISTED_COURSE_IDS) {
+      expect(ids.has(id), `unlisted id "${id}" not in the bundle`).toBe(true);
+    }
+  });
+
+  it("the catalog listing excludes it; the admin listing keeps it", async () => {
+    const listed = await getAllCourses();
+    expect(listed.some((c) => c._id === PILULA_ID)).toBe(false);
+    // And the filter didn't eat anything else.
+    const admin = await getAllCoursesIncludingUnlisted();
+    expect(admin.length).toBe(listed.length + UNLISTED_COURSE_IDS.size);
+  });
+
+  it("recommendations never surface it", async () => {
+    const recommended = await getRecommendedCourses([]);
+    expect(recommended.some((c) => c._id === PILULA_ID)).toBe(false);
+  });
+
+  it("the direct link stays live — getCourseBySlug still resolves it", async () => {
+    const course = await getCourseBySlug(PILULA_SLUG);
+    expect(course?._id).toBe(PILULA_ID);
+  });
+});

--- a/apps/web/src/lib/content/queries.ts
+++ b/apps/web/src/lib/content/queries.ts
@@ -7,6 +7,7 @@ import type {
   LearningPath,
   QuizBlockData,
 } from "@superteam-lms/types";
+import { isUnlistedCourse } from "@/lib/courses/unlisted";
 import {
   getActiveDeployments,
   getDeploymentById,
@@ -181,7 +182,26 @@ async function gatedCourses(): Promise<CourseDoc[]> {
 
 // --- Public / catalog queries (gated: synced + active) ---
 
+/**
+ * Catalog listing: synced+active AND listed. Unlisted courses
+ * (lib/courses/unlisted.ts) stay reachable by direct URL — getCourseBySlug /
+ * getLessonBySlug carry no listing filter — but never appear in the catalog,
+ * the landing count, the sitemap, or recommendations.
+ */
 export async function getAllCourses(): Promise<Course[]> {
+  const courses = await gatedCourses();
+  return courses
+    .filter((c) => !isUnlistedCourse(c._id))
+    .map((c) => projectCourse(c, projectionDeps))
+    .sort(byTitle);
+}
+
+/**
+ * Every synced+active course, unlisted included — for ADMIN surfaces only
+ * (resync must see an unlisted course or it could never be repaired). Public
+ * pages use {@link getAllCourses}.
+ */
+export async function getAllCoursesIncludingUnlisted(): Promise<Course[]> {
   const courses = await gatedCourses();
   return courses.map((c) => projectCourse(c, projectionDeps)).sort(byTitle);
 }
@@ -452,7 +472,14 @@ export async function getRecommendedCourses(
   const exclude = new Set(excludeIds);
   const map = await getActiveDeployments();
   return [...coursesById.values()]
-    .filter((c) => !exclude.has(c._id) && isSynced(map.get(c._id)))
+    .filter(
+      (c) =>
+        !exclude.has(c._id) &&
+        isSynced(map.get(c._id)) &&
+        // Recommendations are a listing surface — never surface an unlisted
+        // course, even to a learner who found it by direct link.
+        !isUnlistedCourse(c._id)
+    )
     .map((c) => projectRecommended(c, learningPathTitleFor(c._id)))
     .sort(byTitle);
 }

--- a/apps/web/src/lib/courses/unlisted.ts
+++ b/apps/web/src/lib/courses/unlisted.ts
@@ -1,0 +1,28 @@
+/**
+ * Unlisted courses: reachable by direct link, absent from every listing.
+ *
+ * "Unlisted" is a LISTING property, not an access gate — the course page,
+ * its lessons, enrolment, and completion all keep working for anyone who has
+ * the URL. What goes away is discovery: the catalog, the landing course
+ * count, the sitemap, and recommendations. That is the distribution model
+ * for event/QR-code courses (the Pílula: handed out at the booth, not
+ * browsed to), and it is why the landing hero may still deep-link an
+ * unlisted course — a deliberate direct link is exactly the channel
+ * unlisting preserves.
+ *
+ * App-side constant on purpose, same reasoning as SEGMENT_ENTRY_COURSE
+ * (lib/courses/learner-segment.ts): listing changes ship with a code deploy,
+ * not a content.lock bump through the two-repo staging cycle.
+ *
+ * Admin surfaces must NOT consume this — sync/resync need to see every
+ * course (`getAllCoursesIncludingUnlisted` in lib/content/queries.ts), or an
+ * unlisted course could never be deployed or repaired again.
+ */
+export const UNLISTED_COURSE_IDS: ReadonlySet<string> = new Set([
+  // Event booth micro-course (academy-courses#37) — QR-code distribution.
+  "course-pilula-solana-superteam",
+]);
+
+export function isUnlistedCourse(courseId: string): boolean {
+  return UNLISTED_COURSE_IDS.has(courseId);
+}


### PR DESCRIPTION
## Summary

Makes `pilula-solana-superteam` **unlisted**: hidden from every discovery surface, still fully working for anyone with the direct link (`/en/courses/pilula-solana-superteam`) — which keeps the landing hero's deliberate deep-link to it intact for the event booth flow.

## What changes

- New `lib/courses/unlisted.ts` — `UNLISTED_COURSE_IDS` app-side constant (same ship-with-a-deploy reasoning as `SEGMENT_ENTRY_COURSE`)
- `getAllCourses()` filters unlisted → hides it from the **catalog**, the **landing course count**, and the **sitemap** in one place
- `getRecommendedCourses()` filters unlisted → never recommended
- Admin resync switches to a new `getAllCoursesIncludingUnlisted()` so an unlisted course can still be synced/repaired
- `getCourseBySlug`/`getLessonBySlug` untouched → course page, lessons, enrolment, completion all keep working by URL

## Verification

New live test (real committed bundle, mocked sync gate): catalog excludes it, admin listing keeps it, recommendations never surface it, the slug still resolves, and a stale unlisted id (renamed/removed from the bundle) goes red. Typecheck clean; content/courses suites pass (112 tests).

---
_Generated by [Claude Code](https://claude.ai/code/session_01MJMV9QpjXQ42PVjgEeMQp4)_