### PR TITLE
fix(nav): show bottom nav on mobile landing

### DIFF
--- a/apps/web/src/components/layout/__tests__/mobile-bottom-nav.test.tsx
+++ b/apps/web/src/components/layout/__tests__/mobile-bottom-nav.test.tsx
@@ -42,10 +42,15 @@ describe("MobileBottomNav", () => {
     }
   });
 
-  it("keeps the landing page clean for signed-out visitors", () => {
+  it("shows the public tabs on the landing page for signed-out visitors", () => {
+    // #930: the header hides its links below lg, so the bottom nav is the only
+    // mobile route into Courses/Community from the landing page.
     state.pathname = "/en";
-    const { container } = render(<MobileBottomNav />);
-    expect(container).toBeEmptyDOMElement();
+    render(<MobileBottomNav />);
+    expect(screen.getByText("courses")).toBeInTheDocument();
+    expect(screen.getByText("community")).toBeInTheDocument();
+    expect(screen.queryByText("dashboard")).not.toBeInTheDocument();
+    expect(screen.queryByText("review")).not.toBeInTheDocument();
   });
 
   it("shows the nav on the landing page for a signed-in learner", () => {

--- a/apps/web/src/components/layout/mobile-bottom-nav.tsx
+++ b/apps/web/src/components/layout/mobile-bottom-nav.tsx
@@ -37,10 +37,11 @@ export function MobileBottomNav() {
   const isLessonPage = /\/courses\/[^/]+\/lessons\//.test(pathname);
   const stripLocale = pathname.replace(/^\/[a-z]{2}(-[A-Z]{2})?/, "");
   const isLanding = stripLocale === "" || stripLocale === "/";
-  // Landing: signed-out visitors keep the clean marketing page, but a
-  // SIGNED-IN learner landing on `/` on a phone had no way into the platform
-  // except the cramped header — show them the same tabs as everywhere else.
-  if (isLessonPage || (isLanding && !isLoggedIn)) return null;
+  // Landing renders the nav for everyone (#930): the header hides its link
+  // cluster below lg, so without this bar an anonymous phone visitor's only
+  // route to Courses/Community was the footer. Signed-out visitors get the
+  // public tabs; signed-in learners the full set.
+  if (isLessonPage) return null;
 
   return (
     <>


### PR DESCRIPTION
The landing-page bail-out in mobile-bottom-nav hid the bar for signed-out visitors, and the header hides its links below lg — so anonymous mobile visitors on `/{locale}` had no navigation except the footer. The bail-out only protected the clean-marketing-page look; the actual layout concern (footer hidden behind the fixed bar) is handled by the landing spacer, which renders regardless of auth. Dropped the auth half of the condition so signed-out visitors get the public tabs (Courses/Community); lesson pages stay nav-free. Updated the landing test to assert the public tabs instead of an empty render.

Closes #930