### PR TITLE
fix(catalog): sort courses by trackLevel, not title

### DIFF
--- a/apps/web/src/lib/content/__tests__/queries.test.ts
+++ b/apps/web/src/lib/content/__tests__/queries.test.ts
@@ -54,6 +54,7 @@ const h = vi.hoisted(() => {
       title: "Zeta",
       difficulty: "beginner",
       tags: ["z"],
+      trackLevel: 1,
       xpPerLesson: 20,
       creator: WALLET_A,
       modules: [{ key: "m1", title: "M1", lessons: [ref("lesson-live-1")] }],
@@ -257,10 +258,24 @@ import * as q from "../queries";
 
 beforeEach(() => vi.clearAllMocks());
 
-describe("gated catalog fns — synced+active only, order(title asc)", () => {
-  it("getAllCourses hides deactivated + not-synced, sorts by title", async () => {
+describe("gated catalog fns — synced+active only, trackLevel asc", () => {
+  // Zeta has trackLevel 1, Alpha has none (→ sorts last): trackLevel beats
+  // title order, unset trackLevel goes to the end (#929).
+  it("getAllCourses hides deactivated + not-synced, sorts by trackLevel then title", async () => {
     const res = await q.getAllCourses();
-    expect(res.map((c) => c._id)).toEqual(["course-alpha", "course-zeta"]);
+    expect(res.map((c) => c._id)).toEqual(["course-zeta", "course-alpha"]);
+  });
+
+  it("byTrackLevel tie-breaks equal levels by title, sends unset last", () => {
+    const beta = { trackLevel: 1, title: "Beta" };
+    const zeta = { trackLevel: 1, title: "Zeta" };
+    const unsetA = { title: "Aardvark" };
+    const unsetB = { title: "Bee" };
+    expect(q.byTrackLevel(beta, zeta)).toBeLessThan(0);
+    expect(q.byTrackLevel(zeta, beta)).toBeGreaterThan(0);
+    expect(q.byTrackLevel(unsetA, zeta)).toBeGreaterThan(0);
+    // Both unset: Infinity - Infinity is NaN (falsy) → title tie-break fires.
+    expect(q.byTrackLevel(unsetA, unsetB)).toBeLessThan(0);
   });
 
   it("getCourseBySlug admits synced+active, rejects deactivated", async () => {
@@ -318,6 +333,8 @@ describe("gated catalog fns — synced+active only, order(title asc)", () => {
   it("getRecommendedCourses excludes ids + gates + sorts", async () => {
     const res = await q.getRecommendedCourses(["course-zeta"]);
     expect(res.map((c) => c._id)).toEqual(["course-alpha"]);
+    const all = await q.getRecommendedCourses([]);
+    expect(all.map((c) => c._id)).toEqual(["course-zeta", "course-alpha"]);
   });
 
   it("getAllCourseTags / getAllCourseLessonCounts only synced+active", async () => {

--- a/apps/web/src/lib/content/queries.ts
+++ b/apps/web/src/lib/content/queries.ts
@@ -109,6 +109,23 @@ function byField<T>(pick: (x: T) => string | null) {
 const byTitle = byField<{ title: string | null }>((x) => x.title);
 const byName = byField<{ name: string | null }>((x) => x.name);
 
+/**
+ * Learner-facing catalog order (#929): `trackLevel` ascending (unset sorts
+ * last), title as tie-break — so the entry course renders first, not whichever
+ * title happens to sort first. Admin reads stay alphabetical.
+ */
+export function byTrackLevel(
+  a: { trackLevel?: number; title: string | null },
+  b: { trackLevel?: number; title: string | null }
+): number {
+  // Two unset levels subtract to NaN, which is falsy — so they fall through
+  // to the title tie-break rather than comparing as equal-and-stable.
+  return (
+    (a.trackLevel ?? Number.POSITIVE_INFINITY) -
+      (b.trackLevel ?? Number.POSITIVE_INFINITY) || byTitle(a, b)
+  );
+}
+
 const projectionDeps = { lessonsById };
 
 // --- store traversal helpers ---
@@ -193,7 +210,7 @@ export async function getAllCourses(): Promise<Course[]> {
   return courses
     .filter((c) => !isUnlistedCourse(c._id))
     .map((c) => projectCourse(c, projectionDeps))
-    .sort(byTitle);
+    .sort(byTrackLevel);
 }
 
 /**
@@ -481,7 +498,7 @@ export async function getRecommendedCourses(
         !isUnlistedCourse(c._id)
     )
     .map((c) => projectRecommended(c, learningPathTitleFor(c._id)))
-    .sort(byTitle);
+    .sort(byTrackLevel);
 }
 
 export async function getAllCourseTags(): Promise<


### PR DESCRIPTION
The catalog sorted by title, so a beginner landed on the intermediate courses first and the entry course last. getAllCourses and getRecommendedCourses now sort by trackLevel ascending (unset sorts last) with title as tie-break; queries.test.ts asserts the new order. Admin reads (getAllCoursesAdmin/Safe) stay alphabetical on purpose — that surface is a lookup table, not a learning sequence.

Closes #929