### PR TITLE
test(i18n): guard locale key parity in CI

### DIFF
--- a/apps/web/src/messages/__tests__/parity.test.ts
+++ b/apps/web/src/messages/__tests__/parity.test.ts
@@ -4,54 +4,83 @@ import ptBR from "../pt-BR.json";
 import es from "../es.json";
 
 /**
- * Deep i18n key-structure parity guard (no equivalent existed before this
- * task). `apps/web/CLAUDE.md` states all 3 locale files must have identical
- * key structures — a mismatch surfaces as `MISSING_MESSAGE` at runtime,
- * silently, only for the locale that's missing the key. This recursively
- * flattens each message tree to a sorted list of dot-path leaf keys and
- * fails per-locale on any key present in another locale but missing here.
+ * i18n key-structure parity guard (#1047). `apps/web/CLAUDE.md` states all 3
+ * locale files must have identical key structures — a mismatch surfaces as
+ * `MISSING_MESSAGE` at runtime, silently, only for the affected locale.
+ *
+ * en.json is canonical. For each other locale this collects every key path
+ * (intermediate objects and string leaves) and fails on:
+ *   - missing: path exists in en.json but not in the locale
+ *   - extra:   path exists in the locale but not in en.json
+ *   - type mismatch: path exists in both but is a string in one and an
+ *     object in the other
+ * The offending paths are listed verbatim in the assertion message.
  */
 
 type MessageValue = string | { [key: string]: MessageValue };
 type MessageTree = { [key: string]: MessageValue };
+type PathType = "string" | "object";
 
-function flattenKeys(tree: MessageTree, prefix = ""): string[] {
-  const keys: string[] = [];
+function collectPaths(
+  tree: MessageTree,
+  prefix = "",
+  out: Map<string, PathType> = new Map()
+): Map<string, PathType> {
   for (const [key, value] of Object.entries(tree)) {
     const path = prefix ? `${prefix}.${key}` : key;
     if (typeof value === "object" && value !== null) {
-      keys.push(...flattenKeys(value as MessageTree, path));
+      out.set(path, "object");
+      collectPaths(value, path, out);
     } else {
-      keys.push(path);
+      out.set(path, "string");
     }
   }
-  return keys.sort();
+  return out;
 }
 
-const locales: Record<string, MessageTree> = {
-  en: en as MessageTree,
+const enPaths = collectPaths(en as MessageTree);
+
+const otherLocales: Record<string, MessageTree> = {
   "pt-BR": ptBR as MessageTree,
   es: es as MessageTree,
 };
 
-const keysByLocale = Object.fromEntries(
-  Object.entries(locales).map(([name, tree]) => [name, flattenKeys(tree)])
-);
-
-const unionOfAllKeys = Array.from(
-  new Set(Object.values(keysByLocale).flat())
-).sort();
-
-describe("i18n message parity (en / pt-BR / es)", () => {
-  it("has a non-empty key set to compare (sanity check the fixtures loaded)", () => {
-    expect(unionOfAllKeys.length).toBeGreaterThan(0);
+describe("i18n message parity against en.json (canonical)", () => {
+  it("en.json loaded with a non-trivial key set (fixture sanity)", () => {
+    expect(enPaths.size).toBeGreaterThan(100);
   });
 
-  for (const [locale, keys] of Object.entries(keysByLocale)) {
-    it(`${locale}.json contains every key present in the other locales`, () => {
-      const present = new Set(keys);
-      const missing = unionOfAllKeys.filter((k) => !present.has(k));
-      expect(missing).toEqual([]);
+  for (const [locale, tree] of Object.entries(otherLocales)) {
+    describe(`${locale}.json`, () => {
+      const paths = collectPaths(tree);
+
+      it("has every key path present in en.json", () => {
+        const missing = [...enPaths.keys()].filter((p) => !paths.has(p));
+        expect(
+          missing,
+          `${locale}.json is missing ${missing.length} key path(s) present in en.json:\n  ${missing.join("\n  ")}`
+        ).toEqual([]);
+      });
+
+      it("has no key path absent from en.json", () => {
+        const extra = [...paths.keys()].filter((p) => !enPaths.has(p));
+        expect(
+          extra,
+          `${locale}.json has ${extra.length} key path(s) not present in en.json (remove or add to en.json):\n  ${extra.join("\n  ")}`
+        ).toEqual([]);
+      });
+
+      it("agrees with en.json on the value type of every shared path", () => {
+        const mismatched = [...paths.entries()]
+          .filter(([p, type]) => enPaths.has(p) && enPaths.get(p) !== type)
+          .map(
+            ([p, type]) => `${p} (en: ${enPaths.get(p)}, ${locale}: ${type})`
+          );
+        expect(
+          mismatched,
+          `${locale}.json disagrees with en.json on value type for:\n  ${mismatched.join("\n  ")}`
+        ).toEqual([]);
+      });
     });
   }
 });


### PR DESCRIPTION
#1047 says no parity guard exists — one actually has since #412 (src/messages/__tests__/parity.test.ts, and it runs under pnpm -r test in CI), but it compared against the union of all locales, so an extra key in pt-BR/es got blamed on en.json, and string-vs-object type flips were only caught indirectly through leaf diffs. This rewrites it en-canonical: per locale, explicit missing / extra / type-mismatch checks that list the exact offending key paths in the assertion message.

Negative check (not committed): deleted common.appName from es.json, added a bogus top-level key, and flipped common.tagline to an object — all three tests failed naming those exact paths. Restored, suite passes 11/11.

Closes #1047