### PR TITLE
fix(lesson): derive completion gate from BLOCK_REGISTRY

### DIFF
--- a/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/blocks/__tests__/parsons-block.test.tsx
+++ b/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/blocks/__tests__/parsons-block.test.tsx
@@ -213,6 +213,37 @@ describe("ParsonsBlock — arrange interaction", () => {
   });
 });
 
+describe("ParsonsBlock — completion-gate report (#970)", () => {
+  it("reports done after a correct Check", () => {
+    const ctx = makeCtx();
+    renderWithIntl(<ParsonsBlock block={parsonsBlock} ctx={ctx} />);
+    expect(ctx.setBlockDone).toHaveBeenLastCalledWith("p-block", false);
+    buildCorrect();
+    fireEvent.click(screen.getByRole("button", { name: "Check order" }));
+    expect(ctx.setBlockDone).toHaveBeenLastCalledWith("p-block", true);
+  });
+
+  it("stays not-done after an incorrect Check", () => {
+    const ctx = makeCtx();
+    renderWithIntl(<ParsonsBlock block={parsonsBlock} ctx={ctx} />);
+    fireEvent.click(
+      screen.getByRole("button", { name: /Add line: function add/ })
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Check order" }));
+    expect(ctx.setBlockDone).toHaveBeenLastCalledWith("p-block", false);
+  });
+
+  it("editing after a correct Check retracts done (proof no longer judged)", () => {
+    const ctx = makeCtx();
+    renderWithIntl(<ParsonsBlock block={parsonsBlock} ctx={ctx} />);
+    buildCorrect();
+    fireEvent.click(screen.getByRole("button", { name: "Check order" }));
+    expect(ctx.setBlockDone).toHaveBeenLastCalledWith("p-block", true);
+    fireEvent.click(screen.getByRole("button", { name: /Remove line: \}/ }));
+    expect(ctx.setBlockDone).toHaveBeenLastCalledWith("p-block", false);
+  });
+});
+
 /** A block whose distractor `bad` is paired with the real line `ret` (F13). */
 const pairedBlock: ParsonsBlockData = {
   _type: "parsons",

--- a/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/blocks/parsons-block.tsx
+++ b/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/blocks/parsons-block.tsx
@@ -137,6 +137,14 @@ export function ParsonsBlock({ block, ctx }: BlockRenderProps) {
     ctx.setProof(b.key, { order: solution });
   }, [solution, b.key, ctx]);
 
+  // Completion-gate report (#970): done only while the LAST Check judged the
+  // current arrangement correct. Any edit clears `result`, so a scrambled-after
+  // -checking solution re-disables Mark Complete instead of letting the server
+  // 403 a proof that no longer matches.
+  useEffect(() => {
+    ctx.setBlockDone(b.key, result?.correct === true);
+  }, [result, b.key, ctx]);
+
   // Any edit retires the last verdict — feedback always describes what is
   // currently arranged.
   const mutate = useCallback((next: (prev: string[]) => string[]) => {

--- a/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/lesson-client.tsx
+++ b/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/lesson-client.tsx
@@ -17,6 +17,7 @@ import { ProgressBar } from "@/components/course/progress-bar";
 import { AuthModal } from "@/components/auth/auth-modal";
 import { trackEvent } from "@/lib/analytics";
 import { completionErrorKey } from "@/lib/lessons/completion-error";
+import { isGateBlock } from "@/lib/lessons/gate-blocks";
 import { createClient } from "@/lib/supabase/client";
 import { isCapstoneLesson } from "@/lib/credentials/capstone-identity";
 import { useAuth } from "@/lib/auth/auth-provider";
@@ -296,19 +297,19 @@ export function LessonPageClient({
     );
   }, []);
 
-  // Client-side completion gate (owner 2026-08-02): every gateable block
-  // (quiz, reflection) must report done before Mark Complete enables. The
-  // server's inverted gate re-grades regardless — this is honest UI, not the
-  // enforcement.
+  // Client-side completion gate (owner 2026-08-02): every gateable block must
+  // report done before Mark Complete enables. Which types gate is derived from
+  // BLOCK_REGISTRY (via isGateBlock, #970) — the same registry the server's
+  // completion gate dispatches on — never a hardcoded type list, so the client
+  // can't show an enabled button the server would 403. The server's inverted
+  // gate re-grades regardless — this is honest UI, not the enforcement.
   const [doneBlocks, setDoneBlocks] = useState<Record<string, boolean>>({});
   const setBlockDone = useCallback((blockKey: string, done: boolean) => {
     setDoneBlocks((prev) =>
       prev[blockKey] === done ? prev : { ...prev, [blockKey]: done }
     );
   }, []);
-  const gateBlocks = lesson.blocks.filter(
-    (b) => b._type === "quiz" || b._type === "openEnded"
-  );
+  const gateBlocks = lesson.blocks.filter((b) => isGateBlock(b._type));
   const gateReady =
     isCompleted || gateBlocks.every((b) => doneBlocks[b.key] === true);
   // AI hard-off on the capstone (#867) — the CLIENT leg of the server refusal

--- a/apps/web/src/lib/lessons/__tests__/gate-blocks.test.ts
+++ b/apps/web/src/lib/lessons/__tests__/gate-blocks.test.ts
@@ -1,0 +1,47 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, it, expect } from "vitest";
+import { BLOCK_REGISTRY, type BlockType } from "@superteam-lms/content-schema";
+import { GATE_BLOCK_TYPES, isGateBlock } from "../gate-blocks";
+
+/**
+ * The server's completion gate (/api/lessons/complete) denies unless every
+ * `graded` block passes and every `required` ungraded block is attested — so
+ * the client's Mark Complete gate must cover exactly that union. #969's gate
+ * review found the client hardcoding quiz/openEnded while the registry also
+ * grades `parsons`; this pins both sides to BLOCK_REGISTRY so a future block
+ * type cannot drift silently.
+ */
+describe("client completion gate ↔ BLOCK_REGISTRY", () => {
+  it("gate set equals the registry's graded ∪ required set", () => {
+    const registryGate = (Object.keys(BLOCK_REGISTRY) as BlockType[]).filter(
+      (t) => BLOCK_REGISTRY[t].graded || BLOCK_REGISTRY[t].required
+    );
+    expect([...GATE_BLOCK_TYPES].sort()).toEqual(registryGate.sort());
+  });
+
+  it("gates parsons — the #970 disagreement", () => {
+    expect(isGateBlock("parsons")).toBe(true);
+  });
+
+  it("keeps the pre-existing gate members and non-members", () => {
+    expect(isGateBlock("quiz")).toBe(true);
+    expect(isGateBlock("openEnded")).toBe(true);
+    expect(isGateBlock("code")).toBe(true);
+    expect(isGateBlock("prose")).toBe(false);
+    expect(isGateBlock("video")).toBe(false);
+    expect(isGateBlock("wallet-funding")).toBe(false);
+  });
+
+  it("lesson-client derives its gate from this module, not a type list", () => {
+    const src = readFileSync(
+      join(
+        __dirname,
+        "../../../app/[locale]/(platform)/courses/[slug]/lessons/[id]/lesson-client.tsx"
+      ),
+      "utf8"
+    );
+    expect(src).toContain('from "@/lib/lessons/gate-blocks"');
+    expect(src).toContain("isGateBlock(b._type)");
+  });
+});

--- a/apps/web/src/lib/lessons/gate-blocks.ts
+++ b/apps/web/src/lib/lessons/gate-blocks.ts
@@ -8,6 +8,12 @@ import { BLOCK_REGISTRY, type BlockType } from "@superteam-lms/content-schema";
  * must gate on the same union or it shows an enabled button the server 403s
  * (the #969 gate finding: `parsons` is graded but the client only knew
  * quiz/openEnded).
+ *
+ * `code` is in the set but currently unused by the gate UI: lesson-client
+ * hides the Mark Complete button entirely for code lessons (they complete via
+ * the editor's submit path), and code-block never calls setBlockDone — lifting
+ * that restriction without wiring setBlockDone would ship a permanently
+ * disabled button.
  */
 export const GATE_BLOCK_TYPES: ReadonlySet<BlockType> = new Set(
   (Object.keys(BLOCK_REGISTRY) as BlockType[]).filter(

--- a/apps/web/src/lib/lessons/gate-blocks.ts
+++ b/apps/web/src/lib/lessons/gate-blocks.ts
@@ -1,0 +1,19 @@
+import { BLOCK_REGISTRY, type BlockType } from "@superteam-lms/content-schema";
+
+/**
+ * Block types the client's Mark Complete gate waits on — derived from
+ * BLOCK_REGISTRY, never hardcoded (#970). The server's completion gate
+ * (/api/lessons/complete) denies unless every `graded` block passes its grader
+ * and every `required` ungraded block carries an attestation, so the client
+ * must gate on the same union or it shows an enabled button the server 403s
+ * (the #969 gate finding: `parsons` is graded but the client only knew
+ * quiz/openEnded).
+ */
+export const GATE_BLOCK_TYPES: ReadonlySet<BlockType> = new Set(
+  (Object.keys(BLOCK_REGISTRY) as BlockType[]).filter(
+    (t) => BLOCK_REGISTRY[t].graded || BLOCK_REGISTRY[t].required
+  )
+);
+
+export const isGateBlock = (type: BlockType): boolean =>
+  GATE_BLOCK_TYPES.has(type);


### PR DESCRIPTION
The lesson client hardcoded which block types gate Mark Complete (quiz/openEnded) while the server gates on BLOCK_REGISTRY, where parsons is graded — so a parsons-only lesson would show an enabled button the server 403s. The gate set now comes from a shared registry-derived module (graded ∪ required, matching the server's two gate loops exactly).

ParsonsBlock is fully renderable and completable in the UI (Check judges the arrangement client-side), it just never reported done — it now calls setBlockDone on a correct Check and retracts it when the learner edits afterward. A new test pins the client gate set to the registry-derived set so a future block type can't drift silently.

apps/web: eslint clean on touched files (one pre-existing warning), typecheck clean, full vitest suite green (292 files / 2873 tests).

Closes #970