### PR TITLE
fix(landing): the hero must not promote an unlisted course

### DIFF
--- a/apps/web/src/lib/content/__tests__/unlisted-courses.test.ts
+++ b/apps/web/src/lib/content/__tests__/unlisted-courses.test.ts
@@ -10,6 +10,7 @@ import {
   getCourseBySlug,
   getRecommendedCourses,
 } from "../queries";
+import { resolveHeroHref } from "@/lib/courses/entry-lesson";
 
 /**
  * Unlisted = hidden from listings, reachable by direct link — asserted against
@@ -78,5 +79,15 @@ describe("unlisted courses — hidden from listings, live by direct link", () =>
   it("the direct link stays live — getCourseBySlug still resolves it", async () => {
     const course = await getCourseBySlug(PILULA_SLUG);
     expect(course?._id).toBe(PILULA_ID);
+  });
+
+  it("the landing hero does NOT promote it — it falls back to the flagship deep-link", async () => {
+    // The homepage CTA is the biggest discovery surface of all; promoting a
+    // course there while hiding it from the catalog would be the two halves
+    // of the site contradicting each other. The QR/direct link keeps working
+    // (previous test); only the hero PROMOTION falls back.
+    const href = await resolveHeroHref("en");
+    expect(href).not.toContain(PILULA_SLUG);
+    expect(href).toMatch(/^\/en\/courses\/[^/]+\/lessons\/[^/]+$/);
   });
 });

--- a/apps/web/src/lib/courses/entry-lesson.ts
+++ b/apps/web/src/lib/courses/entry-lesson.ts
@@ -7,6 +7,7 @@ import {
   DEFAULT_SEGMENT,
   SEGMENT_ENTRY_COURSE,
 } from "@/lib/courses/learner-segment";
+import { isUnlistedCourse } from "@/lib/courses/unlisted";
 
 /**
  * Resolves a content course id into its first-lesson deep-link for `locale`.
@@ -56,10 +57,18 @@ const HERO_COURSE_SLUG = "pilula-solana-superteam";
  * deployed+synced (`getCourseIdBySlug` is the sync-gated read; the ungated
  * `getCourseById` would happily link a course whose page 404s). Until the
  * admin sync runs, the hero keeps the flagship lesson deep-link.
+ *
+ * UNLISTED demotes the hero too: unlisting removes a course from every
+ * discovery surface, and the homepage's primary CTA is the biggest discovery
+ * surface there is — promoting a course there while hiding it from the
+ * catalog would be the two halves of the site contradicting each other. The
+ * course page itself stays reachable (that is what unlisted means), so the
+ * booth QR/direct links keep working; only the hero's PROMOTION falls back
+ * to the flagship deep-link.
  */
 export async function resolveHeroHref(locale: string): Promise<string> {
   const synced = await getCourseIdBySlug(HERO_COURSE_SLUG);
-  return synced
+  return synced && !isUnlistedCourse(synced._id)
     ? `/${locale}/courses/${HERO_COURSE_SLUG}`
     : resolveFlagshipLessonHref(locale);
 }


### PR DESCRIPTION
## Summary

After #1062 unlisted the Pílula course, the homepage "Start building" CTA still opened it: `resolveHeroHref`'s event override (from #1024) deep-links the hero straight to the Pílula course page, and the unlisting deliberately kept direct links working. Net effect: hidden from the catalog, promoted from the homepage — contradictory.

## Fix

`resolveHeroHref` now checks the hero course against `UNLISTED_COURSE_IDS` and falls back to the flagship deep-link (the Speedrun's first lesson) when it's unlisted. This wires the two systems together permanently: unlisting any future hero course automatically demotes the hero too.

- The Pílula course page **stays reachable by direct URL / QR code** — that's what unlisted means; only the homepage promotion moves
- Also fixes a latent type bug in the check (`getCourseIdBySlug` returns `{ _id }`, not a string)

## Verification

New assertion in the live `unlisted-courses` suite (real bundle, mocked sync gate): the hero href must not contain the Pílula slug and must match a lesson deep-link. Full suite: 296 files / 2893 tests green; typecheck clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MJMV9QpjXQ42PVjgEeMQp4)_