### PR TITLE
fix(email): case-insensitive placeholder predicate

### DIFF
--- a/apps/web/src/app/[locale]/(platform)/settings/_components/account-tab.tsx
+++ b/apps/web/src/app/[locale]/(platform)/settings/_components/account-tab.tsx
@@ -14,6 +14,7 @@ import { SolanaLogo } from "@/components/icons/solana-logo";
 import { createClient } from "@/lib/supabase/client";
 import type { Database } from "@/lib/supabase/types";
 import { useAuth } from "@/lib/auth/auth-provider";
+import { isWalletPlaceholderEmail } from "@/lib/auth/wallet-placeholder";
 import { isDynamicEnabled } from "@/lib/dynamic/config";
 import { createSIWSMessage, formatSIWSMessage } from "@/lib/solana/wallet-auth";
 import {
@@ -498,8 +499,7 @@ export function AccountTab({
   // access is lost — the server refuses to unlink it and the button says why
   // up front. Real-email accounts get the opposite message: unlinking is
   // safe, the bridge matches by email.
-  const isSyntheticEmail =
-    accountEmail?.endsWith("@wallet.superteam-lms.local") ?? false;
+  const isSyntheticEmail = isWalletPlaceholderEmail(accountEmail);
   const oauthCount = (googleIdentity ? 1 : 0) + (gitHubIdentity ? 1 : 0);
   const soleOauthLocked = isSyntheticEmail && oauthCount === 1;
 

--- a/apps/web/src/app/api/auth/dynamic/route.ts
+++ b/apps/web/src/app/api/auth/dynamic/route.ts
@@ -9,6 +9,7 @@ import { getDynamicEnvironmentId } from "@/lib/dynamic/config";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { isRateLimited, getClientIp } from "@/lib/rate-limit";
 import { isAccountDeleted } from "@/lib/auth/account-status";
+import { isWalletPlaceholderEmail } from "@/lib/auth/wallet-placeholder";
 import { generateWalletName } from "@/lib/utils/generate-wallet-name";
 import { retryPendingOnchainActions } from "@/lib/solana/onchain-queue";
 import { logError, logEvent } from "@/lib/logging";
@@ -520,8 +521,10 @@ async function mergeWalletShellAccount(
     const { data: shellUser, error: userError } =
       await supabaseAdmin.auth.admin.getUserById(shell.id);
     if (userError || !shellUser?.user) return;
-    const shellEmail = shellUser.user.email ?? "";
-    if (!shellEmail.endsWith("@wallet.superteam-lms.local")) return;
+    // Case-insensitive (#921) — identical for anything GoTrue can store (it
+    // lowercases emails), and a hypothetical odd-cased shell still hits the
+    // RPC's own shell-ness re-proof, which refuses and leaves sign-in unmerged.
+    if (!isWalletPlaceholderEmail(shellUser.user.email)) return;
     // A real shell has exactly its synthetic email identity (from
     // admin.createUser). Any non-email identity means it is somebody's
     // account; NO identities means we don't know what it is — refuse both.

--- a/apps/web/src/app/api/auth/unlink/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/unlink/__tests__/route.test.ts
@@ -89,6 +89,20 @@ describe("POST /api/auth/unlink — recovery guard", () => {
     expect(unlinkIdentity).not.toHaveBeenCalled();
   });
 
+  it("refuses on a MIXED-CASE synthetic-email domain too (#921)", async () => {
+    getUser.mockResolvedValue(
+      sessionUser("Wa11etPubkey@Wallet.Superteam-LMS.LOCAL", ["google"])
+    );
+
+    const res = await POST(unlinkRequest("google"));
+
+    expect(res.status).toBe(403);
+    await expect(res.json()).resolves.toEqual({
+      error: "cannotUnlinkOnlyRecovery",
+    });
+    expect(unlinkIdentity).not.toHaveBeenCalled();
+  });
+
   it("lets a synthetic-email account with TWO OAuth identities drop one", async () => {
     getUser.mockResolvedValue(sessionUser(SYNTHETIC, ["google", "github"]));
 

--- a/apps/web/src/app/api/auth/unlink/route.ts
+++ b/apps/web/src/app/api/auth/unlink/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
+import { isWalletPlaceholderEmail } from "@/lib/auth/wallet-placeholder";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { logError } from "@/lib/logging";
 import { ERROR_IDS } from "@/constants/errorIds";
@@ -100,9 +101,7 @@ export async function POST(request: NextRequest) {
     // 68 wallet-first accounts could walk into it, zero have — this keeps it
     // at zero). Real-email accounts stay freely unlinkable: the bridge
     // matches by email, identity-agnostic.
-    const syntheticEmail = (user.email ?? "").endsWith(
-      "@wallet.superteam-lms.local"
-    );
+    const syntheticEmail = isWalletPlaceholderEmail(user.email);
     const unlinkingSoleOauth =
       (provider === "google" && hasGoogle && !hasGitHub) ||
       (provider === "github" && hasGitHub && !hasGoogle);

--- a/apps/web/src/app/api/auth/wallet/route.ts
+++ b/apps/web/src/app/api/auth/wallet/route.ts
@@ -9,6 +9,7 @@ import { ERROR_IDS } from "@/constants/errorIds";
 import { retryPendingOnchainActions } from "@/lib/solana/onchain-queue";
 import { serverEnv } from "@/lib/env.server";
 import { isAccountDeleted } from "@/lib/auth/account-status";
+import { WALLET_PLACEHOLDER_EMAIL_DOMAIN } from "@/lib/auth/wallet-placeholder";
 import type { Database } from "@/lib/supabase/types";
 
 interface WalletAuthRequest {
@@ -18,7 +19,7 @@ interface WalletAuthRequest {
 }
 
 function walletEmail(publicKey: string): string {
-  return `${publicKey}@wallet.superteam-lms.local`;
+  return `${publicKey}${WALLET_PLACEHOLDER_EMAIL_DOMAIN}`;
 }
 
 export async function POST(request: NextRequest) {

--- a/apps/web/src/lib/auth/__tests__/wallet-placeholder.test.ts
+++ b/apps/web/src/lib/auth/__tests__/wallet-placeholder.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import {
+  WALLET_PLACEHOLDER_EMAIL_DOMAIN,
+  isWalletPlaceholderEmail,
+} from "../wallet-placeholder";
+
+describe("isWalletPlaceholderEmail", () => {
+  it("detects the canonical lowercase placeholder", () => {
+    expect(
+      isWalletPlaceholderEmail("So11111111111111@wallet.superteam-lms.local")
+    ).toBe(true);
+  });
+
+  it("detects a mixed-case placeholder domain (#921)", () => {
+    expect(
+      isWalletPlaceholderEmail("So11111111111111@Wallet.Superteam-LMS.LOCAL")
+    ).toBe(true);
+    expect(isWalletPlaceholderEmail("PUBKEY@WALLET.SUPERTEAM-LMS.LOCAL")).toBe(
+      true
+    );
+  });
+
+  it("matches what the wallet route mints", () => {
+    expect(
+      isWalletPlaceholderEmail(`AnyPubkey${WALLET_PLACEHOLDER_EMAIL_DOMAIN}`)
+    ).toBe(true);
+  });
+
+  it("rejects real emails, including lookalikes", () => {
+    expect(isWalletPlaceholderEmail("learner@gmail.com")).toBe(false);
+    // Suffix check must anchor on the @-domain, not a substring anywhere.
+    expect(
+      isWalletPlaceholderEmail("a@notwallet.superteam-lms.localhost")
+    ).toBe(false);
+    expect(
+      isWalletPlaceholderEmail("wallet.superteam-lms.local@gmail.com")
+    ).toBe(false);
+  });
+
+  it("rejects null, undefined and empty", () => {
+    expect(isWalletPlaceholderEmail(null)).toBe(false);
+    expect(isWalletPlaceholderEmail(undefined)).toBe(false);
+    expect(isWalletPlaceholderEmail("")).toBe(false);
+  });
+});

--- a/apps/web/src/lib/auth/wallet-placeholder.ts
+++ b/apps/web/src/lib/auth/wallet-placeholder.ts
@@ -1,0 +1,24 @@
+/**
+ * Synthetic wallet-placeholder email — single source of truth (#921).
+ *
+ * Wallet-first accounts are created with a deterministic, undeliverable
+ * `<pubkey>@wallet.superteam-lms.local` address (see
+ * `app/api/auth/wallet/route.ts`). Everything that needs to ask "is this a
+ * real, deliverable email?" must go through {@link isWalletPlaceholderEmail}
+ * rather than string-matching the domain locally: the predicate is
+ * case-insensitive, so a differently-cased placeholder can never slip past a
+ * call site (GoTrue lowercases stored emails today, but no caller should have
+ * to know that).
+ *
+ * Importable from both server and client code — keep it dependency-free.
+ */
+
+/** Domain suffix of the synthetic wallet-auth placeholder email. */
+export const WALLET_PLACEHOLDER_EMAIL_DOMAIN = "@wallet.superteam-lms.local";
+
+/** True when `email` is a synthetic wallet-placeholder address (any casing). */
+export function isWalletPlaceholderEmail(
+  email: string | null | undefined
+): boolean {
+  return (email ?? "").toLowerCase().endsWith(WALLET_PLACEHOLDER_EMAIL_DOMAIN);
+}


### PR DESCRIPTION
Part 1 of #921: the wallet-placeholder email check was a case-sensitive `endsWith` copied across four call sites. This adds one shared `isWalletPlaceholderEmail` (lowercases before matching) in `lib/auth/wallet-placeholder.ts`, uses it in the unlink guard, the settings account tab and the Dynamic bridge's shell-merge gate, and mints the wallet route's synthetic address from the same constant. Bridge behavior is unchanged for anything GoTrue can actually store (it lowercases emails), and an odd-cased shell would still be refused by the merge RPC's own SQL re-proof, so sign-in stays fail-open unmerged.

Part 2 (post-claim consent re-check) is deferred: none of the three send pipelines fetches `opt_in`/`reminder_opt_in` at send time — consent lives entirely inside the claim RPCs' SQL — so a send-time re-check means either a new per-batch DB read plus claim-release semantics for mid-flight unsubscribes, or widening the claim RPCs to return consent columns (a migration). Both are their own change; the SQL `lower(u.email) NOT LIKE` fix for the claim RPCs belongs in that same migration.

Tests: new predicate suite (mixed-case detected, lookalike domains rejected) plus a mixed-case unlink-guard case; auth/settings vitest suites 92 passed, typecheck and lint clean.