### PR TITLE
fix(analytics): GA4 stub must push raw arguments

### DIFF
--- a/apps/web/src/lib/analytics/__tests__/ga4.test.ts
+++ b/apps/web/src/lib/analytics/__tests__/ga4.test.ts
@@ -1,0 +1,69 @@
+// @vitest-environment jsdom
+// Pins the shape gtag.js actually consumes: raw `arguments` objects pushed to
+// the dataLayer (Google's official snippet). The launch bug this guards
+// against: a stub that pushed plain objects instead — silently ignored by the
+// library, so GA4 never received a single hit ("data collection isn't
+// active"). Discovered 2026-08-19 with a live-page probe.
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+describe("initGA4 dataLayer contract", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.stubEnv("NEXT_PUBLIC_GA4_MEASUREMENT_ID", "G-TEST123");
+    document
+      .querySelectorAll('script[src*="googletagmanager"]')
+      .forEach((s) => s.remove());
+    // @ts-expect-error test reset of globals the module owns
+    delete window.dataLayer;
+    // @ts-expect-error test reset of globals the module owns
+    delete window.gtag;
+  });
+
+  it("pushes raw arguments objects, never plain records", async () => {
+    const { initGA4 } = await import("../ga4");
+    initGA4();
+
+    expect(window.dataLayer.length).toBe(2);
+    for (const entry of window.dataLayer) {
+      // An Arguments object is array-like (numeric keys + length) and NOT a
+      // plain object literal — gtag.js branches on exactly this.
+      expect(Object.prototype.toString.call(entry)).toBe("[object Arguments]");
+    }
+
+    const first = window.dataLayer[0] as IArguments;
+    expect(first[0]).toBe("js");
+    expect(first[1]).toBeInstanceOf(Date);
+
+    const second = window.dataLayer[1] as IArguments;
+    expect(second[0]).toBe("config");
+    expect(second[1]).toBe("G-TEST123");
+    expect(second[2]).toEqual({ send_page_view: false });
+  });
+
+  it("trackGA4Event and trackGA4PageView push arguments too", async () => {
+    const { initGA4, trackGA4Event, trackGA4PageView } = await import("../ga4");
+    initGA4();
+    trackGA4Event("lesson_completed", { lesson_id: "l1" });
+    trackGA4PageView("/en/courses");
+
+    const entries = window.dataLayer.slice(2) as IArguments[];
+    expect(entries).toHaveLength(2);
+    expect(Object.prototype.toString.call(entries[0])).toBe(
+      "[object Arguments]"
+    );
+    expect(entries[0]![0]).toBe("event");
+    expect(entries[0]![1]).toBe("lesson_completed");
+    expect(entries[1]![0]).toBe("event");
+    expect(entries[1]![1]).toBe("page_view");
+    expect(entries[1]![2]).toEqual({ page_path: "/en/courses" });
+  });
+
+  it("injects the script tag exactly once", async () => {
+    const { initGA4 } = await import("../ga4");
+    initGA4();
+    initGA4();
+    expect(
+      document.querySelectorAll('script[src*="googletagmanager"]')
+    ).toHaveLength(1);
+  });
+});

--- a/apps/web/src/lib/analytics/ga4.ts
+++ b/apps/web/src/lib/analytics/ga4.ts
@@ -11,10 +11,12 @@ declare global {
   interface Window {
     gtag: (
       command: string,
-      targetOrEvent: string,
+      targetOrEvent: string | Date,
       params?: Record<string, unknown>
     ) => void;
-    dataLayer: Array<Record<string, unknown>>;
+    // gtag.js consumes the raw `arguments` objects pushed by the stub — the
+    // array must be typed to carry them, not plain records.
+    dataLayer: unknown[];
   }
 }
 
@@ -42,15 +44,17 @@ export function initGA4(): void {
   document.head.appendChild(script);
 
   window.dataLayer = window.dataLayer ?? [];
-  window.gtag = function gtag(
-    command: string,
-    targetOrEvent: string,
-    params?: Record<string, unknown>
-  ) {
-    window.dataLayer.push({ event: command, ...params, target: targetOrEvent });
+  // Google's snippet verbatim: gtag.js only recognizes commands pushed as the
+  // raw `arguments` object. Pushing a plain object instead is silently ignored
+  // by the library — config never registers, no hit is ever sent, and GA4
+  // shows "data collection isn't active" forever. That exact bug shipped at
+  // launch; do not "clean this up" into an object push.
+  window.gtag = function gtag() {
+    // eslint-disable-next-line prefer-rest-params
+    window.dataLayer.push(arguments);
   };
 
-  window.gtag("js", new Date().toISOString());
+  window.gtag("js", new Date());
   window.gtag("config", GA4_ID, {
     send_page_view: false, // we manage page views ourselves
   });


### PR DESCRIPTION
GA4 has been silently dead since launch: our gtag stub pushed plain objects into the dataLayer, but gtag.js only consumes raw arguments objects (Google's snippet verbatim), so the config never registered and no hit was ever sent — the property shows 'data collection isn't active' to this day. Found while wiring the GA4 Data API: tag loads on prod with the right measurement id, dataLayer populates, yet zero /g/collect requests leave the page. Same silent-death family as the posthog-js webpackIgnore bug (#1037). New test pins the [object Arguments] shape so a cleanup can't reintroduce it.