### PR TITLE
fix(analytics): pre-init queue, loud Sentry init, identity reset — audit follow-ups

### DIFF
--- a/apps/web/sentry.edge.config.ts
+++ b/apps/web/sentry.edge.config.ts
@@ -15,4 +15,13 @@ if (dsn) {
     environment: process.env.NODE_ENV,
     tracesSampleRate: process.env.NODE_ENV === "development" ? 1.0 : 0.1,
   });
+
+  // A malformed DSN makes `init` bail without a client — and with `debug`
+  // statements stripped from production bundles, that failure is otherwise
+  // invisible. Shout, so a broken error pipeline is caught at boot.
+  if (!Sentry.getClient()) {
+    console.error(
+      "[sentry] DSN rejected — errors are NOT being reported (check NEXT_PUBLIC_SENTRY_DSN)"
+    );
+  }
 }

--- a/apps/web/sentry.server.config.ts
+++ b/apps/web/sentry.server.config.ts
@@ -15,4 +15,13 @@ if (dsn) {
     environment: process.env.NODE_ENV,
     tracesSampleRate: process.env.NODE_ENV === "development" ? 1.0 : 0.1,
   });
+
+  // A malformed DSN makes `init` bail without a client — and with `debug`
+  // statements stripped from production bundles, that failure is otherwise
+  // invisible. Shout, so a broken error pipeline is caught at boot.
+  if (!Sentry.getClient()) {
+    console.error(
+      "[sentry] DSN rejected — errors are NOT being reported (check NEXT_PUBLIC_SENTRY_DSN)"
+    );
+  }
 }

--- a/apps/web/src/app/[locale]/(platform)/settings/_components/danger-tab.tsx
+++ b/apps/web/src/app/[locale]/(platform)/settings/_components/danger-tab.tsx
@@ -13,6 +13,7 @@ import {
   DialogTitle,
   DialogDescription,
 } from "@/components/ui/dialog";
+import { resetUser } from "@/lib/analytics";
 import { createClient } from "@/lib/supabase/client";
 
 // Danger zone: irreversible account-deletion request (readiness G6).
@@ -57,6 +58,9 @@ export function DangerTab() {
       // guarantees a clean reload with no stale authenticated state.
       const supabase = createClient();
       await supabase.auth.signOut();
+      // Sever the analytics identity — a deleted account must not keep
+      // tagging this browser's events.
+      resetUser();
       window.location.assign(`/${locale}`);
     } catch {
       setError(t("deleteAccountFailed"));

--- a/apps/web/src/components/analytics/analytics-provider.tsx
+++ b/apps/web/src/components/analytics/analytics-provider.tsx
@@ -9,7 +9,8 @@ export function AnalyticsProvider({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
   const initialized = useRef(false);
 
-  // Initialize analytics on mount
+  // Initialize analytics once. Ref-guarded on its own so the guard cannot
+  // take the auth subscription down with it (see next effect).
   useEffect(() => {
     if (initialized.current) return;
     initialized.current = true;
@@ -26,8 +27,14 @@ export function AnalyticsProvider({ children }: { children: React.ReactNode }) {
         });
       }
     });
+  }, []);
 
-    // Listen for auth state changes
+  // Auth subscription: subscribe on EVERY mount, clean up on unmount. When
+  // this shared an effect with the ref-guarded init, a StrictMode/remount
+  // cycle ran the cleanup (unsubscribe) but the guard skipped the re-run —
+  // leaving no listener for the rest of the session.
+  useEffect(() => {
+    const supabase = createClient();
     const {
       data: { subscription },
     } = supabase.auth.onAuthStateChange((_event, session) => {

--- a/apps/web/src/components/auth/user-menu.tsx
+++ b/apps/web/src/components/auth/user-menu.tsx
@@ -21,6 +21,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { resetUser } from "@/lib/analytics";
 import { createClient } from "@/lib/supabase/client";
 import { logoutDynamic } from "@/lib/dynamic/client";
 
@@ -56,6 +57,9 @@ export function UserMenu({
     await logoutDynamic();
     const supabase = createClient();
     await supabase.auth.signOut();
+    // Sever the analytics identity so the next visitor on this browser is not
+    // attributed to the signed-out account.
+    resetUser();
     window.location.href = `/${locale}`;
   }, [locale, connected, disconnect]);
 

--- a/apps/web/src/instrumentation-client.ts
+++ b/apps/web/src/instrumentation-client.ts
@@ -17,6 +17,15 @@ if (dsn) {
     // 100% of transactions in dev, 10% in production.
     tracesSampleRate: process.env.NODE_ENV === "development" ? 1.0 : 0.1,
   });
+
+  // A malformed DSN makes `init` bail without a client — and with `debug`
+  // statements stripped from production bundles, that failure is otherwise
+  // invisible. Shout, so a broken error pipeline is caught on first load.
+  if (!Sentry.getClient()) {
+    console.error(
+      "[sentry] DSN rejected — errors are NOT being reported (check NEXT_PUBLIC_SENTRY_DSN)"
+    );
+  }
 }
 
 // Instruments App Router navigations for tracing. Safe to export even when the

--- a/apps/web/src/lib/analytics/README.md
+++ b/apps/web/src/lib/analytics/README.md
@@ -199,3 +199,12 @@ social channel — so one event with a `channel` property is the honest shape,
 and a separate LinkedIn-only event would have split the same surface in two.
 Both click events fire from both surfaces (`mint_success` and
 `certificate_page`) and each surface is pinned by a test.
+
+## PostHog pre-init buffering
+
+`posthog.ts` loads posthog-js asynchronously; capture/identify/reset calls made
+before the import resolves are buffered (cap 50, drop-oldest) and flushed in
+order once the SDK is up — the first pageview of every session used to be
+silently dropped by this race. If PostHog is unconfigured or the SDK failed to
+load, the first attempted capture logs a single console.warn and subsequent
+calls drop quietly. Debugging "my early event never arrived" starts here.

--- a/apps/web/src/lib/analytics/__tests__/posthog.test.ts
+++ b/apps/web/src/lib/analytics/__tests__/posthog.test.ts
@@ -1,0 +1,146 @@
+// @vitest-environment jsdom
+// Pins the pre-init queue contract: PostHog init is async (dynamic import),
+// but the first pageview and first-render events fire synchronously before it
+// resolves. Without buffering, every one of those events hit the
+// `if (!posthog) return` no-op — the 53-pageleave / 14-pageview gap observed
+// in production on 2026-08-19. These tests fail against the unbuffered
+// implementation.
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+type PostHogModule = typeof import("../posthog");
+
+const mockPostHog = {
+  init: vi.fn(),
+  capture: vi.fn(),
+  identify: vi.fn(),
+  reset: vi.fn(),
+};
+
+async function loadModule(): Promise<PostHogModule> {
+  vi.doMock("posthog-js", () => ({ default: mockPostHog }));
+  return import("../posthog");
+}
+
+async function loadModuleWithFailingImport(): Promise<PostHogModule> {
+  vi.doMock("posthog-js", () => {
+    throw new Error("simulated load failure (adblock)");
+  });
+  return import("../posthog");
+}
+
+describe("PostHog pre-init queue", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    vi.stubEnv("NEXT_PUBLIC_POSTHOG_KEY", "phc_test");
+    vi.stubEnv("NEXT_PUBLIC_POSTHOG_HOST", "https://ph.example.com");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.doUnmock("posthog-js");
+    vi.restoreAllMocks();
+  });
+
+  it("delivers an event captured before init resolves, after init", async () => {
+    const { initPostHog, trackPostHogEvent } = await loadModule();
+
+    // Fire before init is even started — the first-pageview scenario.
+    trackPostHogEvent("$pageview", { $current_url: "https://a.test/en" });
+    expect(mockPostHog.capture).not.toHaveBeenCalled();
+
+    await initPostHog();
+
+    expect(mockPostHog.capture).toHaveBeenCalledWith("$pageview", {
+      $current_url: "https://a.test/en",
+    });
+  });
+
+  it("flushes buffered capture/identify calls in order", async () => {
+    const { initPostHog, trackPostHogEvent, identifyPostHogUser } =
+      await loadModule();
+    const order: string[] = [];
+    mockPostHog.capture.mockImplementation((name: string) => {
+      order.push(`capture:${name}`);
+    });
+    mockPostHog.identify.mockImplementation((id: string) => {
+      order.push(`identify:${id}`);
+    });
+
+    trackPostHogEvent("first");
+    identifyPostHogUser("user-1");
+    trackPostHogEvent("second");
+
+    const pending = initPostHog();
+    // Still buffered while the dynamic import is in flight.
+    expect(order).toEqual([]);
+    await pending;
+
+    expect(order).toEqual([
+      "capture:first",
+      "identify:user-1",
+      "capture:second",
+    ]);
+  });
+
+  it("caps the buffer at 50, dropping the oldest", async () => {
+    const { initPostHog, trackPostHogEvent } = await loadModule();
+
+    for (let i = 0; i < 60; i++) {
+      trackPostHogEvent(`event-${i}`);
+    }
+    await initPostHog();
+
+    expect(mockPostHog.capture).toHaveBeenCalledTimes(50);
+    // Oldest 10 dropped: first delivered is event-10, last is event-59.
+    expect(mockPostHog.capture.mock.calls[0]?.[0]).toBe("event-10");
+    expect(mockPostHog.capture.mock.calls[49]?.[0]).toBe("event-59");
+  });
+
+  it("delivers directly (no buffering) once initialized", async () => {
+    const { initPostHog, trackPostHogEvent } = await loadModule();
+    await initPostHog();
+
+    trackPostHogEvent("live-event", { a: 1 });
+    expect(mockPostHog.capture).toHaveBeenCalledWith("live-event", { a: 1 });
+  });
+
+  it("warns exactly once when unconfigured, and drops", async () => {
+    vi.stubEnv("NEXT_PUBLIC_POSTHOG_KEY", "");
+    vi.stubEnv("NEXT_PUBLIC_POSTHOG_HOST", "");
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { trackPostHogEvent } = await loadModule();
+
+    trackPostHogEvent("dropped-1");
+    trackPostHogEvent("dropped-2");
+
+    expect(mockPostHog.capture).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(String(warn.mock.calls[0]?.[0])).toContain("not initialized");
+  });
+
+  it("warns once and drops after a failed posthog-js load", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { initPostHog, trackPostHogEvent } =
+      await loadModuleWithFailingImport();
+
+    trackPostHogEvent("buffered-then-lost");
+    await initPostHog();
+    const warnsAfterInit = warn.mock.calls.length; // load-failure warn
+
+    trackPostHogEvent("dropped-1");
+    trackPostHogEvent("dropped-2");
+
+    expect(mockPostHog.capture).not.toHaveBeenCalled();
+    // Exactly one additional "dropping events" warn, not one per capture.
+    expect(warn.mock.calls.length).toBe(warnsAfterInit + 1);
+  });
+
+  it("resetPostHogUser delegates to posthog.reset once initialized", async () => {
+    const { initPostHog, resetPostHogUser } = await loadModule();
+    await initPostHog();
+
+    resetPostHogUser();
+    expect(mockPostHog.reset).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/lib/analytics/ga4.ts
+++ b/apps/web/src/lib/analytics/ga4.ts
@@ -22,6 +22,12 @@ declare global {
 
 const GA4_ID = process.env.NEXT_PUBLIC_GA4_MEASUREMENT_ID ?? "";
 
+// Stub + config must run exactly once per page load, tracked here — NOT by
+// the presence of a googletagmanager script tag. A foreign tag (e.g. GTM
+// injected by an extension or an embedded widget) would otherwise make init
+// silently skip our own stub and config, and no hit would ever be sent.
+let ga4Configured = false;
+
 function isAvailable(): boolean {
   return (
     typeof window !== "undefined" &&
@@ -36,12 +42,18 @@ function isAvailable(): boolean {
  */
 export function initGA4(): void {
   if (typeof window === "undefined" || GA4_ID.length === 0) return;
-  if (document.querySelector(`script[src*="googletagmanager"]`)) return;
 
-  const script = document.createElement("script");
-  script.async = true;
-  script.src = `https://www.googletagmanager.com/gtag/js?id=${GA4_ID}`;
-  document.head.appendChild(script);
+  // The selector only guards SCRIPT INJECTION (avoid loading gtag.js twice);
+  // stub + config below run regardless, gated by the module flag.
+  if (!document.querySelector(`script[src*="googletagmanager"]`)) {
+    const script = document.createElement("script");
+    script.async = true;
+    script.src = `https://www.googletagmanager.com/gtag/js?id=${GA4_ID}`;
+    document.head.appendChild(script);
+  }
+
+  if (ga4Configured) return;
+  ga4Configured = true;
 
   window.dataLayer = window.dataLayer ?? [];
   // Google's snippet verbatim: gtag.js only recognizes commands pushed as the

--- a/apps/web/src/lib/analytics/index.ts
+++ b/apps/web/src/lib/analytics/index.ts
@@ -21,8 +21,13 @@
  */
 
 import { initGA4, trackGA4Event, trackGA4PageView } from "./ga4";
-import { initPostHog, trackPostHogEvent, identifyPostHogUser } from "./posthog";
-import { initSentry, setSentryUser } from "./sentry";
+import {
+  initPostHog,
+  trackPostHogEvent,
+  identifyPostHogUser,
+  resetPostHogUser,
+} from "./posthog";
+import { initSentry, setSentryUser, clearSentryUser } from "./sentry";
 
 // Re-export individual modules for granular access
 export { initGA4, trackGA4Event, trackGA4PageView } from "./ga4";
@@ -32,7 +37,12 @@ export {
   identifyPostHogUser,
   resetPostHogUser,
 } from "./posthog";
-export { initSentry, captureError, setSentryUser } from "./sentry";
+export {
+  initSentry,
+  captureError,
+  setSentryUser,
+  clearSentryUser,
+} from "./sentry";
 export {
   EVALUATION_WINDOW_WEEKS,
   EVALUATION_WINDOW_DAYS,
@@ -72,7 +82,12 @@ export function trackEvent(
  */
 export function trackPageView(url: string): void {
   trackGA4PageView(url);
-  trackPostHogEvent("$pageview", { $current_url: url });
+  // PostHog expects a FULL URL in $current_url (host filtering, session
+  // replay linking); the bare pathname GA4 wants would register as a
+  // malformed URL. Read it at capture time so buffered pre-init events keep
+  // the page they were fired on.
+  const currentUrl = typeof window !== "undefined" ? window.location.href : url;
+  trackPostHogEvent("$pageview", { $current_url: currentUrl });
 }
 
 /**
@@ -84,4 +99,13 @@ export function identifyUser(
 ): void {
   identifyPostHogUser(userId, traits);
   setSentryUser(userId);
+}
+
+/**
+ * Reset user identity across all configured providers. Call on sign-out so
+ * subsequent events and errors are not attributed to the previous account.
+ */
+export function resetUser(): void {
+  resetPostHogUser();
+  clearSentryUser();
 }

--- a/apps/web/src/lib/analytics/posthog.ts
+++ b/apps/web/src/lib/analytics/posthog.ts
@@ -4,6 +4,12 @@
  * Uses posthog-js (available via pnpm). Only initializes when both
  * NEXT_PUBLIC_POSTHOG_KEY and NEXT_PUBLIC_POSTHOG_HOST are set.
  * All calls gracefully degrade to no-ops when env vars are missing.
+ *
+ * Init is async (dynamic import), but the first pageview and first-render
+ * events fire synchronously before it resolves. Those calls land in a
+ * module-level pre-init queue and are flushed in order once posthog-js loads —
+ * without it, every session's first pageview was silently dropped (the
+ * 53-pageleave / 14-pageview gap observed 2026-08-19).
  */
 
 type PostHogInstance = {
@@ -13,14 +19,66 @@ type PostHogInstance = {
   reset: () => void;
 };
 
+type QueuedCall =
+  | { kind: "capture"; name: string; properties?: Record<string, unknown> }
+  | { kind: "identify"; userId: string; traits?: Record<string, unknown> }
+  | { kind: "reset" };
+
 const POSTHOG_KEY = process.env.NEXT_PUBLIC_POSTHOG_KEY ?? "";
 const POSTHOG_HOST = process.env.NEXT_PUBLIC_POSTHOG_HOST ?? "";
 
+/** Bounded pre-init buffer; oldest entries are dropped past this. */
+const MAX_QUEUE_LENGTH = 50;
+
 let posthog: PostHogInstance | null = null;
 let initAttempted = false;
+let initFailed = false;
+let warnedDropping = false;
+const preInitQueue: QueuedCall[] = [];
 
 function isConfigured(): boolean {
   return POSTHOG_KEY.length > 0 && POSTHOG_HOST.length > 0;
+}
+
+function deliver(call: QueuedCall): void {
+  if (!posthog) return;
+  switch (call.kind) {
+    case "capture":
+      posthog.capture(call.name, call.properties);
+      break;
+    case "identify":
+      posthog.identify(call.userId, call.traits);
+      break;
+    case "reset":
+      posthog.reset();
+      break;
+  }
+}
+
+/**
+ * Deliver immediately when initialized; buffer while init is pending; warn
+ * once (then drop) when PostHog is unconfigured or its load failed.
+ */
+function dispatch(call: QueuedCall): void {
+  if (posthog) {
+    deliver(call);
+    return;
+  }
+
+  if (!isConfigured() || initFailed) {
+    if (!warnedDropping) {
+      warnedDropping = true;
+      console.warn(
+        "[analytics] PostHog is not initialized — events are being dropped"
+      );
+    }
+    return;
+  }
+
+  if (preInitQueue.length >= MAX_QUEUE_LENGTH) {
+    preInitQueue.shift();
+  }
+  preInitQueue.push(call);
 }
 
 /**
@@ -52,41 +110,45 @@ export async function initPostHog(): Promise<void> {
     });
 
     posthog = ph;
+    // Flush everything captured while the import was in flight, in order.
+    while (preInitQueue.length > 0) {
+      deliver(preInitQueue.shift() as QueuedCall);
+    }
   } catch (err) {
     // Degrade to no-op analytics, but never silently: a swallowed failure
     // here is how a broken import shipped unnoticed for the platform's whole
     // life. One warn per load is cheap; invisible data loss is not.
     console.warn("[analytics] posthog-js failed to load:", err);
     posthog = null;
+    initFailed = true;
+    preInitQueue.length = 0;
   }
 }
 
 /**
- * Track a custom event in PostHog.
+ * Track a custom event in PostHog. Buffered if called before init resolves.
  */
 export function trackPostHogEvent(
   name: string,
   properties?: Record<string, unknown>
 ): void {
-  if (!posthog) return;
-  posthog.capture(name, properties);
+  dispatch({ kind: "capture", name, properties });
 }
 
 /**
- * Identify a user in PostHog.
+ * Identify a user in PostHog. Buffered if called before init resolves.
  */
 export function identifyPostHogUser(
   userId: string,
   traits?: Record<string, unknown>
 ): void {
-  if (!posthog) return;
-  posthog.identify(userId, traits);
+  dispatch({ kind: "identify", userId, traits });
 }
 
 /**
- * Reset PostHog identity (call on logout).
+ * Reset PostHog identity (call on logout). Buffered if called before init
+ * resolves so a fast logout still severs the previous identity.
  */
 export function resetPostHogUser(): void {
-  if (!posthog) return;
-  posthog.reset();
+  dispatch({ kind: "reset" });
 }

--- a/apps/web/src/lib/analytics/sentry.ts
+++ b/apps/web/src/lib/analytics/sentry.ts
@@ -9,10 +9,12 @@
  */
 import * as Sentry from "@sentry/nextjs";
 
-const SENTRY_DSN = process.env.NEXT_PUBLIC_SENTRY_DSN ?? "";
-
 function isConfigured(): boolean {
-  return SENTRY_DSN.length > 0;
+  // Actual initialization, not raw env truthiness: a malformed DSN makes
+  // `Sentry.init` reject the client silently, and gating on the env var alone
+  // would ALSO suppress the dev-console fallback in captureError — the exact
+  // combination that hides a dead error pipeline.
+  return Sentry.isInitialized();
 }
 
 /**
@@ -53,4 +55,13 @@ export function captureError(
 export function setSentryUser(userId: string): void {
   if (!isConfigured()) return;
   Sentry.setUser({ id: userId });
+}
+
+/**
+ * Clear the Sentry user context (call on logout) so errors after sign-out are
+ * not attributed to the previous account.
+ */
+export function clearSentryUser(): void {
+  if (!isConfigured()) return;
+  Sentry.setUser(null);
 }


### PR DESCRIPTION
Follow-ups from today's analytics audit (builds on #1083).

What was being lost: PostHog init is an async dynamic import, but the first pageview and first-render events fire synchronously and hit the `if (!posthog) return` no-op — that's the 53-pageleave/14-pageview gap. Events are now buffered pre-init (cap 50, drop-oldest) and flushed in order, with a single console.warn when PostHog is unconfigured or failed to load. A malformed Sentry DSN also failed silently in prod (debug is stripped); all three inits now check `Sentry.getClient()` and console.error when a DSN was provided but no client came up, and `sentry.ts` gates on `Sentry.isInitialized()` so the dev-console fallback works with a bad DSN. And `resetPostHogUser` had zero callers, so identity bled across sign-outs — sign-out and account-delete now call a `resetUser()` facade (PostHog reset + `Sentry.setUser(null)`).

Also: `$current_url` now carries the full URL (was a bare pathname; GA4's `page_path` unchanged), the GA4 init no longer skips stub+config when a foreign googletagmanager tag exists (script injection still deduped), and the analytics provider's auth subscription survives a StrictMode remount (split from the ref-guarded init effect).

Red-proof: the new `posthog.test.ts` run against main fails 5/7 — including "event captured before init resolves is delivered after init". Against this branch, all 7 pass; full `src/lib/analytics` + `src/components` suites are green (64 files / 457 tests), eslint and `tsc --noEmit` clean.