### PR TITLE
fix(analytics): GA4 page_view carries page_location + page_title

### DIFF
--- a/apps/web/src/lib/analytics/__tests__/ga4.test.ts
+++ b/apps/web/src/lib/analytics/__tests__/ga4.test.ts
@@ -55,7 +55,13 @@ describe("initGA4 dataLayer contract", () => {
     expect(entries[0]![1]).toBe("lesson_completed");
     expect(entries[1]![0]).toBe("event");
     expect(entries[1]![1]).toBe("page_view");
-    expect(entries[1]![2]).toEqual({ page_path: "/en/courses" });
+    // Google's manual-pageview contract: full URL in page_location + title,
+    // page_path kept as a convenience dimension.
+    expect(entries[1]![2]).toMatchObject({
+      page_path: "/en/courses",
+      page_location: window.location.href,
+      page_title: document.title,
+    });
   });
 
   it("injects the script tag exactly once", async () => {

--- a/apps/web/src/lib/analytics/ga4.ts
+++ b/apps/web/src/lib/analytics/ga4.ts
@@ -88,7 +88,12 @@ export function trackGA4Event(
  */
 export function trackGA4PageView(url: string): void {
   if (!isAvailable()) return;
+  // Google's manual-pageview contract wants the FULL URL in page_location
+  // (protocol included) plus page_title; page_path stays as a convenience
+  // dimension for existing reports.
   window.gtag("event", "page_view", {
+    page_location: typeof window !== "undefined" ? window.location.href : url,
+    page_title: typeof document !== "undefined" ? document.title : undefined,
     page_path: url,
   });
 }

--- a/apps/web/src/lib/analytics/index.ts
+++ b/apps/web/src/lib/analytics/index.ts
@@ -81,6 +81,8 @@ export function trackEvent(
  * Track a page view across all configured providers.
  */
 export function trackPageView(url: string): void {
+  // Both providers want the full URL (GA4 page_location, PostHog
+  // $current_url) — trackGA4PageView reads it at capture time too.
   trackGA4PageView(url);
   // PostHog expects a FULL URL in $current_url (host filtering, session
   // replay linking); the bare pathname GA4 wants would register as a


### PR DESCRIPTION
Follow-up from the vendor-docs verification of #1084. Google's manual-pageview doc sends page_location (full URL) and page_title; we sent only a bare page_path, which the current GA4 doc doesn't use — the same class of bug #1084 fixed for PostHog. page_path stays as a convenience dimension. Ops note: the stream's Enhanced measurement 'page changes based on browser history events' toggle must be OFF or manual pageviews double-count — flagged to the owner.