### PR TITLE
refactor(auth): one shared avatar-adoption rule

### DIFF
--- a/apps/web/src/app/api/auth/callback/route.ts
+++ b/apps/web/src/app/api/auth/callback/route.ts
@@ -9,6 +9,7 @@ import {
   isAccountDeleted,
   DELETED_ACCOUNT_REASON,
 } from "@/lib/auth/account-status";
+import { shouldAdoptAvatar } from "@/lib/auth/avatar-adoption";
 import type { Database } from "@/lib/supabase/types";
 
 function sanitizeRedirect(raw: string, fallback: string): string {
@@ -132,15 +133,12 @@ export async function GET(request: NextRequest) {
       }
     }
 
-    // Adopt the provider avatar on FIRST login only (owner ruling 2026-08-18,
-    // same rule as the Dynamic bridge): once any avatar exists, no sign-in
-    // changes it — alternating providers were ping-ponging the learner's
-    // face. A rotated provider CDN URL no longer self-heals; the learner
-    // replaces it in settings instead.
+    // Adopt the provider avatar on FIRST login only (shared rule with the
+    // Dynamic bridge, see lib/auth/avatar-adoption.ts).
     const freshProviderAvatar = sessionData.session.user.user_metadata
       ?.avatar_url as string | undefined;
 
-    if (freshProviderAvatar && (profile?.avatar_url ?? null) === null) {
+    if (shouldAdoptAvatar(profile?.avatar_url ?? null, freshProviderAvatar)) {
       await supabase
         .from("profiles")
         .update({ avatar_url: freshProviderAvatar })

--- a/apps/web/src/app/api/auth/dynamic/route.ts
+++ b/apps/web/src/app/api/auth/dynamic/route.ts
@@ -9,6 +9,7 @@ import { getDynamicEnvironmentId } from "@/lib/dynamic/config";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { isRateLimited, getClientIp } from "@/lib/rate-limit";
 import { isAccountDeleted } from "@/lib/auth/account-status";
+import { shouldAdoptAvatar } from "@/lib/auth/avatar-adoption";
 import { isWalletPlaceholderEmail } from "@/lib/auth/wallet-placeholder";
 import { generateWalletName } from "@/lib/utils/generate-wallet-name";
 import { retryPendingOnchainActions } from "@/lib/solana/onchain-queue";
@@ -853,13 +854,10 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       }
     }
 
-    // Adopt the provider photo on FIRST login only (owner ruling 2026-08-18):
-    // once any avatar exists — provider photo or custom upload — no sign-in
-    // ever changes it. Alternating Google/GitHub logins were ping-ponging the
-    // learner's face; the cost is that a rotated provider CDN URL no longer
-    // self-heals (the learner replaces it in settings instead). https-only
-    // enforcement happens at the credential boundary.
-    if (resolved.photo && (profile?.avatar_url ?? null) === null) {
+    // Adopt the provider photo on FIRST login only (shared rule, see
+    // lib/auth/avatar-adoption.ts). https-only enforcement happens at the
+    // credential boundary above, not here.
+    if (shouldAdoptAvatar(profile?.avatar_url ?? null, resolved.photo)) {
       await supabaseAdmin
         .from("profiles")
         .update({ avatar_url: resolved.photo })

--- a/apps/web/src/lib/auth/__tests__/avatar-adoption.test.ts
+++ b/apps/web/src/lib/auth/__tests__/avatar-adoption.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { shouldAdoptAvatar } from "../avatar-adoption";
+
+const PHOTO = "https://lh3.googleusercontent.com/a/photo";
+
+describe("shouldAdoptAvatar", () => {
+  it("adopts when no avatar is stored and a candidate exists", () => {
+    expect(shouldAdoptAvatar(null, PHOTO)).toBe(true);
+  });
+
+  it("never overwrites a stored avatar — even with the identical URL (no-op case, #1070)", () => {
+    expect(shouldAdoptAvatar(PHOTO, PHOTO)).toBe(false);
+  });
+
+  it("never overwrites a stored avatar with a different provider's photo", () => {
+    expect(
+      shouldAdoptAvatar("https://avatars.githubusercontent.com/u/1?v=4", PHOTO)
+    ).toBe(false);
+  });
+
+  it("does not adopt a null candidate", () => {
+    expect(shouldAdoptAvatar(null, null)).toBe(false);
+  });
+
+  it("does not adopt an undefined candidate", () => {
+    expect(shouldAdoptAvatar(null, undefined)).toBe(false);
+  });
+
+  it("does not adopt an empty-string candidate", () => {
+    expect(shouldAdoptAvatar(null, "")).toBe(false);
+  });
+
+  it("treats an empty-string stored value as an existing avatar (no overwrite)", () => {
+    expect(shouldAdoptAvatar("", PHOTO)).toBe(false);
+  });
+});

--- a/apps/web/src/lib/auth/avatar-adoption.ts
+++ b/apps/web/src/lib/auth/avatar-adoption.ts
@@ -1,0 +1,21 @@
+/**
+ * Shared avatar-adoption rule for the auth chokepoints (#1070).
+ *
+ * Owner ruling 2026-08-18: a provider profile photo is adopted on FIRST
+ * login only — once any avatar exists (provider photo or custom upload),
+ * no sign-in ever changes it. Alternating Google/GitHub logins were
+ * ping-ponging the learner's face; the cost is that a rotated provider
+ * CDN URL no longer self-heals (the learner replaces it in settings).
+ *
+ * This predicate decides adoption only. Callers own URL vetting: the
+ * Dynamic bridge filters non-https photos at the credential boundary
+ * (before this check), and the OAuth callback takes the provider URL
+ * from Supabase user_metadata as-is. Do not add scheme/host checks here.
+ */
+export function shouldAdoptAvatar(
+  storedAvatarUrl: string | null,
+  candidatePhotoUrl: string | null | undefined
+): boolean {
+  if (!candidatePhotoUrl) return false;
+  return storedAvatarUrl === null;
+}


### PR DESCRIPTION
The first-login-only avatar rule was hand-copied in the Dynamic bridge and the OAuth callback; both now call a shared `shouldAdoptAvatar` predicate, each keeping its own DB write. https vetting stays where it was — the Dynamic route filters non-https photos at the credential boundary and the callback doesn't filter today, so the helper documents that callers own URL vetting rather than adding a check that would change callback behavior. Helper suite covers the no-op case (stored already set) plus null/undefined/empty candidates; both route suites still pass (76 tests across the three files).

Closes #1070