### PR TITLE
fix(auth): sign-in surface polish — Dynamic-aware settings, dedup, one error style

### DIFF
--- a/apps/web/src/app/[locale]/(marketing)/__tests__/landing-client.test.tsx
+++ b/apps/web/src/app/[locale]/(marketing)/__tests__/landing-client.test.tsx
@@ -33,6 +33,9 @@ vi.mock("@/components/auth/auth-modal", () => ({
   AuthModal: ({ trigger }: { trigger?: ReactNode }) => (
     <span data-testid="auth-modal">{trigger}</span>
   ),
+  // The landing hero reuses the modal's own trigger button since #1077 —
+  // stubbed to its label so CTA assertions keep working.
+  AuthTriggerButton: ({ label }: { label: string }) => <button>{label}</button>,
 }));
 vi.mock("@/lib/supabase/client", () => ({
   createClient: () => ({

--- a/apps/web/src/app/[locale]/(marketing)/landing-client.tsx
+++ b/apps/web/src/app/[locale]/(marketing)/landing-client.tsx
@@ -13,8 +13,7 @@ import {
 } from "@phosphor-icons/react";
 import { Footer } from "@/components/layout/footer";
 import { Button } from "@/components/ui/button";
-import { AuthModal } from "@/components/auth/auth-modal";
-import { useSocialReturnPending } from "@/hooks/use-social-return-pending";
+import { AuthModal, AuthTriggerButton } from "@/components/auth/auth-modal";
 import { AuthErrorToast } from "@/components/auth/auth-error-toast";
 import { HeroShowcase } from "@/components/landing/hero-showcase";
 import {
@@ -283,9 +282,6 @@ export function LandingPageClient({
 }: LandingPageProps) {
   const t = useTranslations("landing");
   const tCommon = useTranslations("common");
-  const tAuth = useTranslations("auth");
-  // Sign-up trigger carries the Google-return loading state (see AuthModal).
-  const socialReturnPending = useSocialReturnPending();
   const locale = useLocale();
   const [isLoggedIn, setIsLoggedIn] = useState(false);
 
@@ -478,23 +474,11 @@ export function LandingPageClient({
                   {!isLoggedIn && (
                     <AuthModal
                       trigger={
-                        <Button
+                        <AuthTriggerButton
                           variant="outline"
                           size="lg"
-                          disabled={socialReturnPending}
-                        >
-                          {socialReturnPending ? (
-                            <span className="inline-flex items-center gap-2">
-                              <span
-                                className="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent"
-                                aria-hidden="true"
-                              />
-                              {tAuth("signingIn")}
-                            </span>
-                          ) : (
-                            tCommon("signUp")
-                          )}
-                        </Button>
+                          label={tCommon("signUp")}
+                        />
                       }
                     />
                   )}

--- a/apps/web/src/app/[locale]/(platform)/settings/_components/__tests__/account-tab.test.tsx
+++ b/apps/web/src/app/[locale]/(platform)/settings/_components/__tests__/account-tab.test.tsx
@@ -158,6 +158,33 @@ describe("AccountTab — Dynamic session", () => {
     ).toBeInTheDocument();
   });
 
+  it("reconciles the method-count hint when the only extra sign-in is via Dynamic (#1077)", async () => {
+    dyn.enabled = true;
+    dyn.user = { verifiedCredentials: [{ oauthProvider: "google" }] };
+
+    renderTab(); // wallet linked (count 1) + Google via Dynamic, unlinked
+
+    expect(
+      await screen.findByText(messages.settings.dynamicMethodCountNote)
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(messages.settings.cannotUnlinkLastHint)
+    ).not.toBeInTheDocument();
+  });
+
+  it("keeps the plain safety hint when no Dynamic provider is in play", () => {
+    dyn.enabled = true;
+
+    renderTab();
+
+    expect(
+      screen.getByText(messages.settings.cannotUnlinkLastHint)
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(messages.settings.dynamicMethodCountNote)
+    ).not.toBeInTheDocument();
+  });
+
   it("leaves every row unchanged when there is no Dynamic session", () => {
     dyn.enabled = true;
 

--- a/apps/web/src/app/[locale]/(platform)/settings/_components/account-tab.tsx
+++ b/apps/web/src/app/[locale]/(platform)/settings/_components/account-tab.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, useRef } from "react";
+import { useEffect, useState, useRef, useCallback } from "react";
 import { useTranslations, useLocale } from "next-intl";
 import { useSearchParams } from "next/navigation";
 import { useWallet } from "@solana/wallet-adapter-react";
@@ -38,6 +38,52 @@ interface AccountTabProps {
   onAvatarChange: (url: string | null) => void;
 }
 
+type OAuthProvider = "google" | "github";
+
+/**
+ * Everything that differs between the Google and GitHub rows — the two link
+ * flows, unlink flows, and post-redirect sync effects are otherwise the same
+ * code, and were literally copy-pasted before #1077.
+ */
+const OAUTH_PROVIDERS: Record<
+  OAuthProvider,
+  {
+    idColumn: "google_id" | "github_id";
+    nameKey: string;
+    linkLabelKey: string;
+    linkedKey: string;
+    unlinkedKey: string;
+    alreadyLinkedKey: string;
+  }
+> = {
+  google: {
+    idColumn: "google_id",
+    nameKey: "googleAccount",
+    linkLabelKey: "linkGoogle",
+    linkedKey: "googleLinked",
+    unlinkedKey: "googleUnlinked",
+    alreadyLinkedKey: "googleAlreadyLinked",
+  },
+  github: {
+    idColumn: "github_id",
+    nameKey: "githubAccount",
+    linkLabelKey: "linkGitHub",
+    linkedKey: "githubLinked",
+    unlinkedKey: "githubUnlinked",
+    alreadyLinkedKey: "githubAlreadyLinked",
+  },
+};
+
+const PROVIDER_ICONS: Record<OAuthProvider, React.ReactNode> = {
+  google: <GoogleLogo className="h-5 w-5" />,
+  github: <GithubLogo className="h-5 w-5" weight="fill" />,
+};
+
+interface OAuthAccountState {
+  email: string | null;
+  identity: UserIdentity | null;
+}
+
 export function AccountTab({
   accountEmail,
   initialWalletAddress,
@@ -57,13 +103,16 @@ export function AccountTab({
 
   // ── Local state ───────────────────────────────────────────────
   const [walletAddress, setWalletAddress] = useState(initialWalletAddress);
-  const [googleEmail, setGoogleEmail] = useState(initialGoogleEmail);
-  const [googleIdentity, setGoogleIdentity] = useState(initialGoogleIdentity);
-  const [gitHubEmail, setGitHubEmail] = useState(initialGitHubEmail);
-  const [gitHubIdentity, setGitHubIdentity] = useState(initialGitHubIdentity);
+  const [oauth, setOauth] = useState<Record<OAuthProvider, OAuthAccountState>>({
+    google: { email: initialGoogleEmail, identity: initialGoogleIdentity },
+    github: { email: initialGitHubEmail, identity: initialGitHubIdentity },
+  });
   const [isLinkingWallet, setIsLinkingWallet] = useState(false);
-  const [isLinkingGoogle, setIsLinkingGoogle] = useState(false);
-  const [isLinkingGitHub, setIsLinkingGitHub] = useState(false);
+  // Which OAuth link redirect is starting; link ends in a full-page nav, so
+  // only one can be in flight.
+  const [linkingProvider, setLinkingProvider] = useState<OAuthProvider | null>(
+    null
+  );
   // Shared across BOTH unlink buttons (#1053 gate F2): firing google+github
   // unlinks inside one round-trip let a synthetic-email account race past the
   // sole-OAuth guard, since each request read pre-unlink state.
@@ -80,13 +129,23 @@ export function AccountTab({
     useState<DynamicSessionInfo | null>(null);
   const pendingWalletLink = useRef(false);
 
-  // ── Post-Google-link handler ──────────────────────────────────
-  // After Google OAuth redirect, the URL contains ?linked=google.
-  // We sync the Google identity's `sub` to profiles.google_id.
-  useEffect(() => {
-    if (searchParams.get("linked") !== "google") return;
+  const setProviderAccount = useCallback(
+    (provider: OAuthProvider, account: OAuthAccountState) => {
+      setOauth((prev) => ({ ...prev, [provider]: account }));
+    },
+    []
+  );
 
-    async function syncGoogleId() {
+  // ── Post-OAuth-link handler ───────────────────────────────────
+  // After the OAuth redirect, the URL contains ?linked=google|github.
+  // We sync the identity's `sub` to profiles.google_id / github_id.
+  useEffect(() => {
+    const linked = searchParams.get("linked");
+    if (linked !== "google" && linked !== "github") return;
+    const provider: OAuthProvider = linked;
+    const config = OAUTH_PROVIDERS[provider];
+
+    async function syncProviderId() {
       try {
         const supabase = createClient();
         const {
@@ -94,24 +153,24 @@ export function AccountTab({
         } = await supabase.auth.getUser();
         if (!user) return;
 
-        const gIdentity = user.identities?.find(
-          (id) => id.provider === "google"
+        const identity = user.identities?.find(
+          (id) => id.provider === provider
         );
-        if (!gIdentity) return;
+        if (!identity) return;
 
-        const googleId = gIdentity.identity_data?.sub as string | undefined;
-        const email = gIdentity.identity_data?.email as string | undefined;
-        const googleAvatar = gIdentity.identity_data?.avatar_url as
+        const providerId = identity.identity_data?.sub as string | undefined;
+        const email = identity.identity_data?.email as string | undefined;
+        const providerAvatar = identity.identity_data?.avatar_url as
           | string
           | undefined;
 
-        if (googleId) {
+        if (providerId) {
           const updatePayload: Database["public"]["Tables"]["profiles"]["Update"] =
             {
-              google_id: googleId,
+              [config.idColumn]: providerId,
             };
-          if (!avatarUrl && googleAvatar) {
-            updatePayload.avatar_url = googleAvatar;
+          if (!avatarUrl && providerAvatar) {
+            updatePayload.avatar_url = providerAvatar;
           }
 
           const { error } = await supabase
@@ -121,15 +180,17 @@ export function AccountTab({
 
           if (error) {
             if (error.code === "23505") {
-              setLinkMessage({ type: "error", text: t("googleAlreadyLinked") });
+              setLinkMessage({
+                type: "error",
+                text: t(config.alreadyLinkedKey),
+              });
             } else {
               setLinkMessage({ type: "error", text: t("linkFailed") });
             }
           } else {
-            setGoogleIdentity(gIdentity);
-            setGoogleEmail(email ?? null);
-            if (!avatarUrl && googleAvatar) onAvatarChange(googleAvatar);
-            setLinkMessage({ type: "success", text: t("googleLinked") });
+            setProviderAccount(provider, { email: email ?? null, identity });
+            if (!avatarUrl && providerAvatar) onAvatarChange(providerAvatar);
+            setLinkMessage({ type: "success", text: t(config.linkedKey) });
           }
         }
       } catch {
@@ -141,160 +202,15 @@ export function AccountTab({
       window.history.replaceState({}, "", url.toString());
     }
 
-    syncGoogleId();
-  }, [searchParams, t, avatarUrl, onAvatarChange]);
+    syncProviderId();
+  }, [searchParams, t, avatarUrl, onAvatarChange, setProviderAccount]);
 
-  // ── Post-GitHub-link handler ──────────────────────────────────
-  // After GitHub OAuth redirect, the URL contains ?linked=github.
-  // We sync the GitHub identity's `id` to profiles.github_id.
-  useEffect(() => {
-    if (searchParams.get("linked") !== "github") return;
-
-    async function syncGitHubId() {
-      try {
-        const supabase = createClient();
-        const {
-          data: { user },
-        } = await supabase.auth.getUser();
-        if (!user) return;
-
-        const ghIdentity = user.identities?.find(
-          (id) => id.provider === "github"
-        );
-        if (!ghIdentity) return;
-
-        const githubId = ghIdentity.identity_data?.sub as string | undefined;
-        const email = ghIdentity.identity_data?.email as string | undefined;
-        const ghAvatar = ghIdentity.identity_data?.avatar_url as
-          | string
-          | undefined;
-
-        if (githubId) {
-          const updatePayload: Database["public"]["Tables"]["profiles"]["Update"] =
-            {
-              github_id: githubId,
-            };
-          if (!avatarUrl && ghAvatar) {
-            updatePayload.avatar_url = ghAvatar;
-          }
-
-          const { error } = await supabase
-            .from("profiles")
-            .update(updatePayload)
-            .eq("id", user.id);
-
-          if (error) {
-            if (error.code === "23505") {
-              setLinkMessage({ type: "error", text: t("githubAlreadyLinked") });
-            } else {
-              setLinkMessage({ type: "error", text: t("linkFailed") });
-            }
-          } else {
-            setGitHubIdentity(ghIdentity);
-            setGitHubEmail(email ?? null);
-            if (!avatarUrl && ghAvatar) onAvatarChange(ghAvatar);
-            setLinkMessage({ type: "success", text: t("githubLinked") });
-          }
-        }
-      } catch {
-        setLinkMessage({ type: "error", text: t("linkFailed") });
-      }
-
-      const url = new URL(window.location.href);
-      url.searchParams.delete("linked");
-      window.history.replaceState({}, "", url.toString());
-    }
-
-    syncGitHubId();
-  }, [searchParams, t, avatarUrl, onAvatarChange]);
-
-  // ── Deferred wallet link ──────────────────────────────────────
-  useEffect(() => {
-    if (!pendingWalletLink.current || !publicKey || !signMessage) return;
-    pendingWalletLink.current = false;
-
-    let cancelled = false;
-
-    async function linkWallet() {
-      setIsLinkingWallet(true);
-      setLinkMessage(null);
-
-      try {
-        const address = publicKey!.toBase58();
-
-        // Fetch server-issued nonce (must exist in siws_nonces table)
-        const nonceRes = await fetch("/api/auth/nonce");
-        if (!nonceRes.ok) throw new Error("Failed to fetch nonce");
-        const { nonce, domain } = (await nonceRes.json()) as {
-          nonce: string;
-          domain: string;
-        };
-        if (cancelled) return;
-
-        const siwsMessage = createSIWSMessage({
-          domain,
-          address,
-          statement: "Link this wallet to your Superteam LMS account",
-          nonce,
-        });
-        const formatted = formatSIWSMessage(siwsMessage);
-        const encoded = new TextEncoder().encode(formatted);
-        const sig = await signMessage!(encoded);
-
-        if (cancelled) return;
-
-        const res = await fetch("/api/auth/link-wallet", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            message: formatted,
-            signature: Array.from(sig),
-            publicKey: address,
-          }),
-        });
-
-        if (cancelled) return;
-
-        if (!res.ok) {
-          const data = await res.json();
-          if (
-            data.error === "walletAlreadyLinked" ||
-            data.error === "differentWalletLinked"
-          ) {
-            setLinkMessage({
-              type: "error",
-              text: t("walletAlreadyLinked"),
-            });
-          } else {
-            setLinkMessage({ type: "error", text: t("linkFailed") });
-          }
-          return;
-        }
-
-        setWalletAddress(address);
-        setLinkMessage({ type: "success", text: t("walletLinked") });
-        await refreshProfile();
-      } catch {
-        if (!cancelled) {
-          setLinkMessage({ type: "error", text: t("linkFailed") });
-        }
-      } finally {
-        if (!cancelled) {
-          setIsLinkingWallet(false);
-        }
-      }
-    }
-
-    linkWallet();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [publicKey, signMessage, t, refreshProfile]);
-
-  // ── Link handlers ─────────────────────────────────────────────
-  const handleLinkWallet = async () => {
-    if (connected && publicKey && signMessage) {
+  // ── Wallet link (shared by the button and the deferred effect) ─
+  // `isCancelled` lets the effect path bail after unmount; the direct
+  // button path passes a constant false.
+  const performWalletLink = useCallback(
+    async (isCancelled: () => boolean) => {
+      if (!publicKey || !signMessage) return;
       setIsLinkingWallet(true);
       setLinkMessage(null);
 
@@ -308,6 +224,7 @@ export function AccountTab({
           nonce: string;
           domain: string;
         };
+        if (isCancelled()) return;
 
         const siwsMessage = createSIWSMessage({
           domain,
@@ -319,6 +236,8 @@ export function AccountTab({
         const encoded = new TextEncoder().encode(formatted);
         const sig = await signMessage(encoded);
 
+        if (isCancelled()) return;
+
         const res = await fetch("/api/auth/link-wallet", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
@@ -328,6 +247,8 @@ export function AccountTab({
             publicKey: address,
           }),
         });
+
+        if (isCancelled()) return;
 
         if (!res.ok) {
           const data = await res.json();
@@ -349,33 +270,58 @@ export function AccountTab({
         setLinkMessage({ type: "success", text: t("walletLinked") });
         await refreshProfile();
       } catch {
-        setLinkMessage({ type: "error", text: t("linkFailed") });
+        if (!isCancelled()) {
+          setLinkMessage({ type: "error", text: t("linkFailed") });
+        }
       } finally {
-        setIsLinkingWallet(false);
+        if (!isCancelled()) {
+          setIsLinkingWallet(false);
+        }
       }
+    },
+    [publicKey, signMessage, t, refreshProfile]
+  );
+
+  // ── Deferred wallet link ──────────────────────────────────────
+  useEffect(() => {
+    if (!pendingWalletLink.current || !publicKey || !signMessage) return;
+    pendingWalletLink.current = false;
+
+    let cancelled = false;
+    performWalletLink(() => cancelled);
+
+    return () => {
+      cancelled = true;
+    };
+  }, [publicKey, signMessage, performWalletLink]);
+
+  // ── Link handlers ─────────────────────────────────────────────
+  const handleLinkWallet = async () => {
+    if (connected && publicKey && signMessage) {
+      await performWalletLink(() => false);
     } else {
       pendingWalletLink.current = true;
       openWalletModal(true);
     }
   };
 
-  const handleLinkGoogle = async () => {
-    setIsLinkingGoogle(true);
+  const handleLinkOAuth = async (provider: OAuthProvider) => {
+    setLinkingProvider(provider);
     setLinkMessage(null);
 
     try {
       const supabase = createClient();
       const redirectPath = `/${locale}/settings`;
-      const callbackUrl = `${window.location.origin}/api/auth/callback?next=${encodeURIComponent(`${redirectPath}?linked=google`)}`;
+      const callbackUrl = `${window.location.origin}/api/auth/callback?next=${encodeURIComponent(`${redirectPath}?linked=${provider}`)}`;
 
       const { data, error } = await supabase.auth.linkIdentity({
-        provider: "google",
+        provider,
         options: { redirectTo: callbackUrl },
       });
 
       if (error) {
-        console.error("[link-google]", error.message);
-        setIsLinkingGoogle(false);
+        console.error(`[link-${provider}]`, error.message);
+        setLinkingProvider(null);
         setLinkMessage({ type: "error", text: t("linkFailed") });
         return;
       }
@@ -384,42 +330,12 @@ export function AccountTab({
         window.location.assign(data.url);
       }
     } catch {
-      setIsLinkingGoogle(false);
+      setLinkingProvider(null);
       setLinkMessage({ type: "error", text: t("linkFailed") });
     }
   };
 
-  const handleLinkGitHub = async () => {
-    setIsLinkingGitHub(true);
-    setLinkMessage(null);
-
-    try {
-      const supabase = createClient();
-      const redirectPath = `/${locale}/settings`;
-      const callbackUrl = `${window.location.origin}/api/auth/callback?next=${encodeURIComponent(`${redirectPath}?linked=github`)}`;
-
-      const { data, error } = await supabase.auth.linkIdentity({
-        provider: "github",
-        options: { redirectTo: callbackUrl },
-      });
-
-      if (error) {
-        console.error("[link-github]", error.message);
-        setIsLinkingGitHub(false);
-        setLinkMessage({ type: "error", text: t("linkFailed") });
-        return;
-      }
-
-      if (data?.url) {
-        window.location.assign(data.url);
-      }
-    } catch {
-      setIsLinkingGitHub(false);
-      setLinkMessage({ type: "error", text: t("linkFailed") });
-    }
-  };
-
-  const handleUnlinkGoogle = async () => {
+  const handleUnlinkOAuth = async (provider: OAuthProvider) => {
     if (isUnlinking) return;
     setIsUnlinking(true);
     setLinkMessage(null);
@@ -427,7 +343,7 @@ export function AccountTab({
       const res = await fetch("/api/auth/unlink", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ provider: "google" }),
+        body: JSON.stringify({ provider }),
       });
       const data = await res.json();
       if (!res.ok) {
@@ -443,43 +359,11 @@ export function AccountTab({
         }
         return;
       }
-      setGoogleIdentity(null);
-      setGoogleEmail(null);
-      setLinkMessage({ type: "success", text: t("googleUnlinked") });
-    } catch {
-      setLinkMessage({ type: "error", text: t("unlinkFailed") });
-    } finally {
-      setIsUnlinking(false);
-    }
-  };
-
-  const handleUnlinkGitHub = async () => {
-    if (isUnlinking) return;
-    setIsUnlinking(true);
-    setLinkMessage(null);
-    try {
-      const res = await fetch("/api/auth/unlink", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ provider: "github" }),
+      setProviderAccount(provider, { email: null, identity: null });
+      setLinkMessage({
+        type: "success",
+        text: t(OAUTH_PROVIDERS[provider].unlinkedKey),
       });
-      const data = await res.json();
-      if (!res.ok) {
-        if (data.error === "cannotUnlinkLast") {
-          setLinkMessage({ type: "error", text: t("cannotUnlinkLastHint") });
-        } else if (data.error === "cannotUnlinkOnlyRecovery") {
-          setLinkMessage({
-            type: "error",
-            text: t("cannotUnlinkOnlyRecoveryHint"),
-          });
-        } else {
-          setLinkMessage({ type: "error", text: t("unlinkFailed") });
-        }
-        return;
-      }
-      setGitHubIdentity(null);
-      setGitHubEmail(null);
-      setLinkMessage({ type: "success", text: t("githubUnlinked") });
     } catch {
       setLinkMessage({ type: "error", text: t("unlinkFailed") });
     } finally {
@@ -490,8 +374,8 @@ export function AccountTab({
   // Unlink safety: must have at least 2 linked methods to unlink any one
   const linkedCount =
     (walletAddress ? 1 : 0) +
-    (googleIdentity ? 1 : 0) +
-    (gitHubIdentity ? 1 : 0);
+    (oauth.google.identity ? 1 : 0) +
+    (oauth.github.identity ? 1 : 0);
   const canUnlink = linkedCount >= 2;
 
   // Wallet-first accounts (synthetic email) cannot recover through the email
@@ -500,7 +384,8 @@ export function AccountTab({
   // up front. Real-email accounts get the opposite message: unlinking is
   // safe, the bridge matches by email.
   const isSyntheticEmail = isWalletPlaceholderEmail(accountEmail);
-  const oauthCount = (googleIdentity ? 1 : 0) + (gitHubIdentity ? 1 : 0);
+  const oauthCount =
+    (oauth.google.identity ? 1 : 0) + (oauth.github.identity ? 1 : 0);
   const soleOauthLocked = isSyntheticEmail && oauthCount === 1;
 
   // The wallet row only claims "embedded" when the Dynamic session's Solana
@@ -508,6 +393,19 @@ export function AccountTab({
   // also has a Dynamic session must keep the plain permanent copy.
   const isEmbeddedWallet =
     walletAddress !== null && dynamicSession?.solanaAddress === walletAddress;
+
+  const usedViaDynamic = (provider: OAuthProvider): boolean =>
+    provider === "google"
+      ? Boolean(dynamicSession?.hasGoogle)
+      : Boolean(dynamicSession?.hasGithub);
+
+  // The count-vs-lived-experience reconcile (#1077): a learner who signs in
+  // daily with Google through Dynamic reads "at least one sign-in method"
+  // while feeling they already have two. When their Dynamic provider isn't a
+  // Supabase-linked identity yet, the safety hint says so explicitly.
+  const hasUnlinkedDynamicProvider = (["google", "github"] as const).some(
+    (provider) => usedViaDynamic(provider) && !oauth[provider].identity
+  );
 
   return (
     <Card>
@@ -587,114 +485,74 @@ export function AccountTab({
             account UI, so a bespoke graduation card here would duplicate — and
             drift from — instructions the vendor already owns. */}
 
-        {/* Google row */}
-        <div className="set-row">
-          <div className="flex items-center gap-3">
-            <div className="set-row-icon">
-              <GoogleLogo className="h-5 w-5" />
-            </div>
-            <div>
-              <p className="set-row-name">{t("googleAccount")}</p>
-              {/* A Dynamic Google sign-in leaves no Supabase identity, so
-                  without this branch the learner who just used Google reads
-                  "Not Linked" — the row states the Dynamic truth instead, and
-                  the Link button stays: linking adds direct sign-in and a
-                  recovery path. */}
-              <p className="set-row-meta">
-                {googleEmail ??
-                  (dynamicSession?.hasGoogle
-                    ? t("usedForSignInDynamic")
-                    : t("notLinked"))}
-              </p>
-              {!googleIdentity && dynamicSession?.hasGoogle && (
-                <p className="set-row-meta">{t("dynamicLinkHint")}</p>
+        {/* OAuth rows. A Dynamic social sign-in leaves no Supabase identity,
+            so without the `usedViaDynamic` branch the learner who just used
+            that provider reads "Not Linked" — the row states the Dynamic truth
+            instead, and the Link button stays: linking adds direct sign-in and
+            a recovery path. */}
+        {(["google", "github"] as const).map((provider) => {
+          const config = OAUTH_PROVIDERS[provider];
+          const account = oauth[provider];
+          const viaDynamic = usedViaDynamic(provider);
+          return (
+            <div className="set-row" key={provider}>
+              <div className="flex items-center gap-3">
+                <div className="set-row-icon">{PROVIDER_ICONS[provider]}</div>
+                <div>
+                  <p className="set-row-name">{t(config.nameKey)}</p>
+                  <p className="set-row-meta">
+                    {account.email ??
+                      (viaDynamic ? t("usedForSignInDynamic") : t("notLinked"))}
+                  </p>
+                  {!account.identity && viaDynamic && (
+                    <p className="set-row-meta">{t("dynamicLinkHint")}</p>
+                  )}
+                </div>
+              </div>
+              {account.identity ? (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => handleUnlinkOAuth(provider)}
+                  disabled={!canUnlink || soleOauthLocked || isUnlinking}
+                  title={
+                    soleOauthLocked
+                      ? t("cannotUnlinkOnlyRecoveryHint")
+                      : !canUnlink
+                        ? t("cannotUnlinkLastHint")
+                        : undefined
+                  }
+                >
+                  {t("unlink")}
+                </Button>
+              ) : (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => handleLinkOAuth(provider)}
+                  disabled={linkingProvider !== null}
+                >
+                  {linkingProvider === provider && (
+                    <div className="mr-2 h-3.5 w-3.5 animate-spin rounded-full border-2 border-current border-t-transparent" />
+                  )}
+                  {linkingProvider === provider
+                    ? t("linking")
+                    : t(config.linkLabelKey)}
+                </Button>
               )}
             </div>
-          </div>
-          {googleIdentity ? (
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={handleUnlinkGoogle}
-              disabled={!canUnlink || soleOauthLocked || isUnlinking}
-              title={
-                soleOauthLocked
-                  ? t("cannotUnlinkOnlyRecoveryHint")
-                  : !canUnlink
-                    ? t("cannotUnlinkLastHint")
-                    : undefined
-              }
-            >
-              {t("unlink")}
-            </Button>
-          ) : (
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={handleLinkGoogle}
-              disabled={isLinkingGoogle}
-            >
-              {isLinkingGoogle && (
-                <div className="mr-2 h-3.5 w-3.5 animate-spin rounded-full border-2 border-current border-t-transparent" />
-              )}
-              {isLinkingGoogle ? t("linking") : t("linkGoogle")}
-            </Button>
-          )}
-        </div>
+          );
+        })}
 
-        {/* GitHub row */}
-        <div className="set-row">
-          <div className="flex items-center gap-3">
-            <div className="set-row-icon">
-              <GithubLogo className="h-5 w-5" weight="fill" />
-            </div>
-            <div>
-              <p className="set-row-name">{t("githubAccount")}</p>
-              <p className="set-row-meta">
-                {gitHubEmail ??
-                  (dynamicSession?.hasGithub
-                    ? t("usedForSignInDynamic")
-                    : t("notLinked"))}
-              </p>
-              {!gitHubIdentity && dynamicSession?.hasGithub && (
-                <p className="set-row-meta">{t("dynamicLinkHint")}</p>
-              )}
-            </div>
-          </div>
-          {gitHubIdentity ? (
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={handleUnlinkGitHub}
-              disabled={!canUnlink || soleOauthLocked || isUnlinking}
-              title={
-                soleOauthLocked
-                  ? t("cannotUnlinkOnlyRecoveryHint")
-                  : !canUnlink
-                    ? t("cannotUnlinkLastHint")
-                    : undefined
-              }
-            >
-              {t("unlink")}
-            </Button>
-          ) : (
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={handleLinkGitHub}
-              disabled={isLinkingGitHub}
-            >
-              {isLinkingGitHub && (
-                <div className="mr-2 h-3.5 w-3.5 animate-spin rounded-full border-2 border-current border-t-transparent" />
-              )}
-              {isLinkingGitHub ? t("linking") : t("linkGitHub")}
-            </Button>
-          )}
-        </div>
-
-        {/* Safety hint — show when only one provider is linked */}
+        {/* Safety hint — show when only one provider is linked. The Dynamic
+            variant reconciles the count with the learner's lived experience:
+            their social sign-in exists, it just isn't a LINKED method yet. */}
         {linkedCount === 1 && (
-          <p className="text-xs text-text-3">{t("cannotUnlinkLastHint")}</p>
+          <p className="text-xs text-text-3">
+            {hasUnlinkedDynamicProvider
+              ? t("dynamicMethodCountNote")
+              : t("cannotUnlinkLastHint")}
+          </p>
         )}
       </CardContent>
     </Card>

--- a/apps/web/src/components/auth/__tests__/auth-modal.test.tsx
+++ b/apps/web/src/components/auth/__tests__/auth-modal.test.tsx
@@ -1,10 +1,19 @@
 // @vitest-environment jsdom
 import type { ReactElement } from "react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { NextIntlClientProvider } from "next-intl";
 import messages from "@/messages/en.json";
 import { AuthModal } from "../auth-modal";
+
+const dynamicState = vi.hoisted(() => ({
+  enabled: false,
+  redirectMock: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/lib/dynamic/config", () => ({
+  isDynamicEnabled: () => dynamicState.enabled,
+}));
 
 vi.mock("@solana/wallet-adapter-react-ui", () => ({
   useWalletModal: () => ({ setVisible: vi.fn() }),
@@ -15,6 +24,8 @@ vi.mock("@solana/wallet-adapter-react-ui", () => ({
 vi.mock("@dynamic-labs-sdk/client", () => ({
   isDeviceRegistrationRequired: () => false,
   logout: vi.fn(),
+  signInWithSocialRedirect: (...args: unknown[]) =>
+    dynamicState.redirectMock(...args),
 }));
 vi.mock("@dynamic-labs-sdk/react-hooks", () => ({
   useSendEmailOTP: () => ({
@@ -48,6 +59,46 @@ const DEFAULT_TRIGGER = messages.common.signIn;
 
 beforeEach(() => {
   vi.clearAllMocks();
+  dynamicState.enabled = false;
+  dynamicState.redirectMock.mockResolvedValue(undefined);
+});
+
+describe("AuthModal — one error placement (#1077)", () => {
+  it("renders a Dynamic button failure at modal level, not inline under the button", async () => {
+    dynamicState.enabled = true;
+    dynamicState.redirectMock.mockRejectedValueOnce(new Error("no settings"));
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    renderWithIntl(<AuthModal open onOpenChange={() => {}} />);
+    fireEvent.click(
+      screen.getByRole("button", { name: messages.auth.signInWithGoogle })
+    );
+
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent(messages.auth.googleSignInFailed);
+    // Modal-level style (text-sm), the same channel Supabase fallbacks use.
+    expect(alert.className).toContain("text-sm");
+    expect(screen.getAllByRole("alert")).toHaveLength(1);
+  });
+
+  it("clears the modal-level error when a new Dynamic attempt starts", async () => {
+    dynamicState.enabled = true;
+    dynamicState.redirectMock.mockRejectedValueOnce(new Error("no settings"));
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    renderWithIntl(<AuthModal open onOpenChange={() => {}} />);
+    const googleButton = screen.getByRole("button", {
+      name: messages.auth.signInWithGoogle,
+    });
+    fireEvent.click(googleButton);
+    await screen.findByRole("alert");
+
+    // Next attempt resolves (never navigates in jsdom) — the stale error goes.
+    fireEvent.click(googleButton);
+    await waitFor(() =>
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument()
+    );
+  });
 });
 
 describe("AuthModal — controlled mode (#556)", () => {

--- a/apps/web/src/components/auth/__tests__/dynamic-social-sign-in.test.tsx
+++ b/apps/web/src/components/auth/__tests__/dynamic-social-sign-in.test.tsx
@@ -58,7 +58,11 @@ describe.each([
 ])("DynamicSocialSignIn ($provider)", ({ provider, label, failure }) => {
   it("starts the redirect flow back to the current page", async () => {
     renderWithIntl(
-      <DynamicSocialSignIn provider={provider} disabled={false} />
+      <DynamicSocialSignIn
+        provider={provider}
+        disabled={false}
+        onError={vi.fn()}
+      />
     );
     fireEvent.click(screen.getByRole("button", { name: label }));
 
@@ -75,7 +79,11 @@ describe.each([
     userState.current = { userId: "stale-user" };
 
     renderWithIntl(
-      <DynamicSocialSignIn provider={provider} disabled={false} />
+      <DynamicSocialSignIn
+        provider={provider}
+        disabled={false}
+        onError={vi.fn()}
+      />
     );
     fireEvent.click(screen.getByRole("button", { name: label }));
 
@@ -85,15 +93,23 @@ describe.each([
     expect(logoutOrder as number).toBeLessThan(redirectOrder as number);
   });
 
-  it("surfaces a translated error when the redirect cannot start", async () => {
+  it("lifts a translated error to onError when the redirect cannot start (#1077: the parent owns the one error placement)", async () => {
     redirectMock.mockRejectedValueOnce(new Error("no project settings"));
     vi.spyOn(console, "error").mockImplementation(() => {});
+    const onError = vi.fn();
 
     renderWithIntl(
-      <DynamicSocialSignIn provider={provider} disabled={false} />
+      <DynamicSocialSignIn
+        provider={provider}
+        disabled={false}
+        onError={onError}
+      />
     );
     fireEvent.click(screen.getByRole("button", { name: label }));
 
-    expect(await screen.findByRole("alert")).toHaveTextContent(failure);
+    // Cleared at click time, then the failure — and NO inline alert of its own.
+    expect(onError).toHaveBeenCalledWith(null);
+    await waitFor(() => expect(onError).toHaveBeenCalledWith(failure));
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/auth/auth-modal.tsx
+++ b/apps/web/src/components/auth/auth-modal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { forwardRef, useState, type ComponentProps } from "react";
 import { useTranslations } from "next-intl";
 import { useWalletModal } from "@solana/wallet-adapter-react-ui";
 import { GithubLogo } from "@phosphor-icons/react";
@@ -41,6 +41,37 @@ interface AuthModalProps {
   onLater?: () => void;
 }
 
+/**
+ * The button that opens the auth modal, with the social-return spinner built
+ * in: while the Google/GitHub return handshake runs, the button shows
+ * "Signing in…" and disables itself. AuthModal's default trigger; also for
+ * custom triggers (the landing hero) that hand-copied this markup before
+ * #1077. Forwards ref and props so it works under `DialogTrigger asChild`.
+ */
+export const AuthTriggerButton = forwardRef<
+  HTMLButtonElement,
+  ComponentProps<typeof Button> & { label: string }
+>(function AuthTriggerButton({ label, disabled, ...props }, ref) {
+  const t = useTranslations("auth");
+  const socialReturnPending = useSocialReturnPending();
+
+  return (
+    <Button ref={ref} disabled={disabled || socialReturnPending} {...props}>
+      {socialReturnPending ? (
+        <span className="inline-flex items-center gap-2">
+          <span
+            className="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent"
+            aria-hidden="true"
+          />
+          {t("signingIn")}
+        </span>
+      ) : (
+        label
+      )}
+    </Button>
+  );
+});
+
 export function AuthModal({
   trigger,
   open: controlledOpen,
@@ -67,10 +98,6 @@ export function AuthModal({
   // cannot be conditional, so the gate is a component boundary instead:
   // DynamicSocialSignIn owns the hooks and mounts only when Dynamic is enabled.
   const dynamicEnabled = isDynamicEnabled();
-  // While the Google-return handshake runs, the trigger button carries the
-  // loading state — the alternative was a full-screen overlay, and the owner
-  // preferred the button.
-  const socialReturnPending = useSocialReturnPending();
   const { setVisible } = useWalletModal();
 
   // Return the learner to the page they signed in from (#619 review): the OAuth
@@ -156,20 +183,11 @@ export function AuthModal({
     >
       {(trigger !== undefined || !isControlled) && (
         <DialogTrigger asChild>
+          {/* While the Google-return handshake runs, the trigger button
+              carries the loading state — the alternative was a full-screen
+              overlay, and the owner preferred the button. */}
           {trigger ?? (
-            <Button variant="push" disabled={socialReturnPending}>
-              {socialReturnPending ? (
-                <span className="inline-flex items-center gap-2">
-                  <span
-                    className="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent"
-                    aria-hidden="true"
-                  />
-                  {t("signingIn")}
-                </span>
-              ) : (
-                tCommon("signIn")
-              )}
-            </Button>
+            <AuthTriggerButton variant="push" label={tCommon("signIn")} />
           )}
         </DialogTrigger>
       )}
@@ -214,6 +232,7 @@ export function AuthModal({
             <DynamicSocialSignIn
               provider="google"
               disabled={loading !== null}
+              onError={setErrorMessage}
             />
           ) : (
             <Button
@@ -239,6 +258,7 @@ export function AuthModal({
             <DynamicSocialSignIn
               provider="github"
               disabled={loading !== null}
+              onError={setErrorMessage}
             />
           ) : (
             <Button

--- a/apps/web/src/components/auth/dynamic-social-sign-in.tsx
+++ b/apps/web/src/components/auth/dynamic-social-sign-in.tsx
@@ -32,7 +32,7 @@ interface ProviderConfig {
   Icon: ComponentType<{ className?: string }>;
   /** auth.* key for the button label. */
   labelKey: string;
-  /** auth.* key for the inline redirect-failure message. */
+  /** auth.* key for the redirect-failure message (rendered by the parent). */
   errorKey: string;
 }
 
@@ -52,19 +52,26 @@ const PROVIDERS: Record<DynamicSocialProvider, ProviderConfig> = {
 export function DynamicSocialSignIn({
   provider,
   disabled,
+  onError,
 }: {
   provider: DynamicSocialProvider;
   disabled: boolean;
+  /**
+   * Error channel (#1077): the parent renders the failure message where every
+   * other sign-in error already renders (the modal-level `role="alert"`), so
+   * Dynamic and Supabase-fallback errors share one placement and size.
+   * Called with `null` when a new attempt starts.
+   */
+  onError: (message: string | null) => void;
 }) {
   const t = useTranslations("auth");
   const [starting, setStarting] = useState(false);
-  const [error, setError] = useState<string | null>(null);
   const { data: dynamicUser } = useUser();
   const { Icon, labelKey, errorKey } = PROVIDERS[provider];
 
   const handleClick = async () => {
     setStarting(true);
-    setError(null);
+    onError(null);
     trackEvent("auth_method_selected", { method: `dynamic_${provider}` });
     try {
       // Same stale-session hazard the email form guards against, with a
@@ -81,34 +88,27 @@ export function DynamicSocialSignIn({
       });
     } catch (err) {
       console.error(`[DynamicSocialSignIn:${provider}] redirect failed:`, err);
-      setError(t(errorKey));
+      onError(t(errorKey));
       setStarting(false);
     }
   };
 
   return (
-    <div className="space-y-1.5">
-      <Button
-        variant="outline"
-        className="h-12 w-full gap-3 text-sm font-medium"
-        disabled={disabled || starting}
-        onClick={handleClick}
-      >
-        {starting ? (
-          <div
-            className="h-5 w-5 animate-spin rounded-full border-2 border-current border-t-transparent"
-            aria-hidden="true"
-          />
-        ) : (
-          <Icon className="h-5 w-5 shrink-0" />
-        )}
-        {starting ? t("connecting") : t(labelKey)}
-      </Button>
-      {error && (
-        <p className="text-center text-xs text-danger" role="alert">
-          {error}
-        </p>
+    <Button
+      variant="outline"
+      className="h-12 w-full gap-3 text-sm font-medium"
+      disabled={disabled || starting}
+      onClick={handleClick}
+    >
+      {starting ? (
+        <div
+          className="h-5 w-5 animate-spin rounded-full border-2 border-current border-t-transparent"
+          aria-hidden="true"
+        />
+      ) : (
+        <Icon className="h-5 w-5 shrink-0" />
       )}
-    </div>
+      {starting ? t("connecting") : t(labelKey)}
+    </Button>
   );
 }

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -696,6 +696,7 @@
     "walletEmbeddedDynamic": "Embedded wallet (Dynamic) — created with your social sign-in · Permanent",
     "usedForSignInDynamic": "Used for sign-in (via Dynamic)",
     "dynamicLinkHint": "Linking also lets you sign in directly and strengthens account recovery.",
+    "dynamicMethodCountNote": "You need at least one linked sign-in method. Your social sign-in via Dynamic doesn't count as a linked method until you link it above.",
     "dangerZone": "Danger zone",
     "deleteAccountTitle": "Delete account",
     "deleteAccountDescription": "Request permanent deletion of your account. Your profile is anonymized and hidden, and you are signed out. This cannot be undone.",

--- a/apps/web/src/messages/es.json
+++ b/apps/web/src/messages/es.json
@@ -696,6 +696,7 @@
     "walletEmbeddedDynamic": "Billetera integrada (Dynamic) — creada con tu inicio de sesión social · Permanente",
     "usedForSignInDynamic": "Usada para iniciar sesión (vía Dynamic)",
     "dynamicLinkHint": "Vincular también te permite iniciar sesión directamente y refuerza la recuperación de tu cuenta.",
+    "dynamicMethodCountNote": "Necesitas al menos un método de inicio de sesión vinculado. Tu inicio de sesión social vía Dynamic no cuenta como método vinculado hasta que lo vincules arriba.",
     "dangerZone": "Zona de peligro",
     "deleteAccountTitle": "Eliminar cuenta",
     "deleteAccountDescription": "Solicita la eliminación permanente de tu cuenta. Tu perfil se anonimiza y se oculta, y se cierra tu sesión. Esto no se puede deshacer.",

--- a/apps/web/src/messages/pt-BR.json
+++ b/apps/web/src/messages/pt-BR.json
@@ -696,6 +696,7 @@
     "walletEmbeddedDynamic": "Carteira embutida (Dynamic) — criada com seu login social · Permanente",
     "usedForSignInDynamic": "Usada para entrar (via Dynamic)",
     "dynamicLinkHint": "Vincular também permite entrar diretamente e fortalece a recuperação da sua conta.",
+    "dynamicMethodCountNote": "Você precisa de pelo menos um método de login vinculado. Seu login social via Dynamic não conta como método vinculado até você vinculá-lo acima.",
     "dangerZone": "Zona de perigo",
     "deleteAccountTitle": "Excluir conta",
     "deleteAccountDescription": "Solicite a exclusão permanente da sua conta. Seu perfil é anonimizado e ocultado, e você é desconectado. Isso não pode ser desfeito.",

--- a/docs/AUTH-FLOWS.md
+++ b/docs/AUTH-FLOWS.md
@@ -32,11 +32,15 @@ off. One soft bend: after an OAuth _link_, the settings page syncs `profiles.goo
 ```
 
 The three session-minting routes (`/api/auth/wallet`, `/api/auth/dynamic`,
-`/api/auth/callback`) share three post-login rituals: tombstone refusal
+`/api/auth/callback`) share four post-login rituals: tombstone refusal
 (`src/lib/auth/account-status.ts`, `profiles.deleted_at`; fails OPEN on query error so
 a Supabase blip can't lock everyone out), replacement of the `user_xxxxxxxx`
-placeholder username, and a fire-and-forget `retryPendingOnchainActions` drain. Add a
-new way in, add all three. The middleware is not a fourth chokepoint — it mints
+placeholder username, a fire-and-forget `retryPendingOnchainActions` drain, and — on
+the two rails that carry a provider photo (`/api/auth/dynamic` and
+`/api/auth/callback`, #1063) — avatar adoption: the provider avatar is written on
+FIRST login only, when `profiles.avatar_url` is null (owner ruling 2026-08-19). Once
+any avatar exists — provider photo or custom upload — no sign-in overwrites it. Add a
+new way in, add all of them. The middleware is not another chokepoint — it mints
 nothing; it re-runs the tombstone check per request as a backstop, and that is all.
 
 ## 1. Ways in — the auth modal
@@ -106,9 +110,9 @@ addresses). **Dynamic off** falls back to Supabase OAuth and returns through
 `exchangeCodeForSession(code)`, cookies set on the redirect response, `next` param
 re-sanitized server-side (`sanitizeRedirect`: single leading slash, no `//`, no `\`,
 no `:` — kills protocol-relative, Windows-relative, and scheme injection). Also
-refreshes the avatar from any OAuth provider's `user_metadata.avatar_url` on each
-login (provider CDN URLs rotate) unless the stored avatar is a Supabase Storage
-upload — Google and GitHub alike, despite living in this callback.
+performs the avatar-adoption ritual (see the shared-rituals list above): adopts the
+provider's `user_metadata.avatar_url` on FIRST login only — Google and GitHub alike,
+despite living in this callback.
 
 ## 2. DynamicAuthHandler
 


### PR DESCRIPTION
A learner who signs in daily via Dynamic-Google saw Google as "Not Linked" in settings; the account tab now reconciles the method-count hint with that lived experience, on top of the #1059 row copy. The copy-pasted Google/GitHub link/unlink handlers, the post-redirect sync effects, and the duplicated wallet-link path collapse into parameterized helpers, and the landing hero reuses the auth modal's own trigger button instead of hand-copied spinner markup. Dynamic sign-in errors now surface through the modal-level role="alert" channel instead of an inline text-xs variant, and AUTH-FLOWS.md documents avatar adoption as the fourth shared ritual — first-login-only per the 2026-08-19 ruling. Presentation and dedup only; no auth behavior changes.

Closes #1077