### PR TITLE
ux: route loading states (#1092)

### DIFF
--- a/apps/web/src/app/[locale]/(platform)/community/[category-slug]/[thread-slug]/loading.tsx
+++ b/apps/web/src/app/[locale]/(platform)/community/[category-slug]/[thread-slug]/loading.tsx
@@ -1,0 +1,17 @@
+import { getTranslations } from "next-intl/server";
+import { Spinner } from "@/components/ui/spinner";
+
+// Route loading state (#1092) — see (platform)/loading.tsx.
+export default async function ThreadLoading() {
+  const t = await getTranslations("common");
+  return (
+    <div
+      role="status"
+      aria-busy="true"
+      className="flex items-center justify-center py-20"
+    >
+      <Spinner />
+      <span className="sr-only">{t("loading")}</span>
+    </div>
+  );
+}

--- a/apps/web/src/app/[locale]/(platform)/community/[category-slug]/loading.tsx
+++ b/apps/web/src/app/[locale]/(platform)/community/[category-slug]/loading.tsx
@@ -1,0 +1,17 @@
+import { getTranslations } from "next-intl/server";
+import { Spinner } from "@/components/ui/spinner";
+
+// Route loading state (#1092) — see (platform)/loading.tsx.
+export default async function CategoryLoading() {
+  const t = await getTranslations("common");
+  return (
+    <div
+      role="status"
+      aria-busy="true"
+      className="flex items-center justify-center py-20"
+    >
+      <Spinner />
+      <span className="sr-only">{t("loading")}</span>
+    </div>
+  );
+}

--- a/apps/web/src/app/[locale]/(platform)/community/loading.tsx
+++ b/apps/web/src/app/[locale]/(platform)/community/loading.tsx
@@ -1,0 +1,17 @@
+import { getTranslations } from "next-intl/server";
+import { Spinner } from "@/components/ui/spinner";
+
+// Route loading state (#1092) — see (platform)/loading.tsx.
+export default async function CommunityLoading() {
+  const t = await getTranslations("common");
+  return (
+    <div
+      role="status"
+      aria-busy="true"
+      className="flex items-center justify-center py-20"
+    >
+      <Spinner />
+      <span className="sr-only">{t("loading")}</span>
+    </div>
+  );
+}

--- a/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/loading.tsx
+++ b/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/loading.tsx
@@ -1,0 +1,17 @@
+import { getTranslations } from "next-intl/server";
+import { Spinner } from "@/components/ui/spinner";
+
+// Route loading state (#1092) — see (platform)/loading.tsx.
+export default async function LessonLoading() {
+  const t = await getTranslations("common");
+  return (
+    <div
+      role="status"
+      aria-busy="true"
+      className="flex items-center justify-center py-20"
+    >
+      <Spinner />
+      <span className="sr-only">{t("loading")}</span>
+    </div>
+  );
+}

--- a/apps/web/src/app/[locale]/(platform)/courses/[slug]/loading.tsx
+++ b/apps/web/src/app/[locale]/(platform)/courses/[slug]/loading.tsx
@@ -1,0 +1,17 @@
+import { getTranslations } from "next-intl/server";
+import { Spinner } from "@/components/ui/spinner";
+
+// Route loading state (#1092) — see (platform)/loading.tsx.
+export default async function CourseDetailLoading() {
+  const t = await getTranslations("common");
+  return (
+    <div
+      role="status"
+      aria-busy="true"
+      className="flex items-center justify-center py-20"
+    >
+      <Spinner />
+      <span className="sr-only">{t("loading")}</span>
+    </div>
+  );
+}

--- a/apps/web/src/app/[locale]/(platform)/courses/loading.tsx
+++ b/apps/web/src/app/[locale]/(platform)/courses/loading.tsx
@@ -1,0 +1,17 @@
+import { getTranslations } from "next-intl/server";
+import { Spinner } from "@/components/ui/spinner";
+
+// Route loading state (#1092) — see (platform)/loading.tsx.
+export default async function CoursesLoading() {
+  const t = await getTranslations("common");
+  return (
+    <div
+      role="status"
+      aria-busy="true"
+      className="flex items-center justify-center py-20"
+    >
+      <Spinner />
+      <span className="sr-only">{t("loading")}</span>
+    </div>
+  );
+}

--- a/apps/web/src/app/[locale]/(platform)/dashboard/loading.tsx
+++ b/apps/web/src/app/[locale]/(platform)/dashboard/loading.tsx
@@ -1,0 +1,17 @@
+import { getTranslations } from "next-intl/server";
+import { Spinner } from "@/components/ui/spinner";
+
+// Route loading state (#1092) — see (platform)/loading.tsx.
+export default async function DashboardLoading() {
+  const t = await getTranslations("common");
+  return (
+    <div
+      role="status"
+      aria-busy="true"
+      className="flex items-center justify-center py-20"
+    >
+      <Spinner />
+      <span className="sr-only">{t("loading")}</span>
+    </div>
+  );
+}

--- a/apps/web/src/app/[locale]/(platform)/leaderboard/loading.tsx
+++ b/apps/web/src/app/[locale]/(platform)/leaderboard/loading.tsx
@@ -1,0 +1,17 @@
+import { getTranslations } from "next-intl/server";
+import { Spinner } from "@/components/ui/spinner";
+
+// Route loading state (#1092) — see (platform)/loading.tsx.
+export default async function LeaderboardLoading() {
+  const t = await getTranslations("common");
+  return (
+    <div
+      role="status"
+      aria-busy="true"
+      className="flex items-center justify-center py-20"
+    >
+      <Spinner />
+      <span className="sr-only">{t("loading")}</span>
+    </div>
+  );
+}

--- a/apps/web/src/app/[locale]/(platform)/loading.tsx
+++ b/apps/web/src/app/[locale]/(platform)/loading.tsx
@@ -1,0 +1,19 @@
+import { getTranslations } from "next-intl/server";
+import { Spinner } from "@/components/ui/spinner";
+
+// Route loading state (#1092) — gives the router a prefetchable shell so
+// navigation commits instantly instead of freezing on the previous page.
+// Owner decision: the app's standard spinner, not skeletons.
+export default async function PlatformLoading() {
+  const t = await getTranslations("common");
+  return (
+    <div
+      role="status"
+      aria-busy="true"
+      className="flex items-center justify-center py-20"
+    >
+      <Spinner />
+      <span className="sr-only">{t("loading")}</span>
+    </div>
+  );
+}

--- a/apps/web/src/app/[locale]/(platform)/profile/loading.tsx
+++ b/apps/web/src/app/[locale]/(platform)/profile/loading.tsx
@@ -1,0 +1,17 @@
+import { getTranslations } from "next-intl/server";
+import { Spinner } from "@/components/ui/spinner";
+
+// Route loading state (#1092) — see (platform)/loading.tsx.
+export default async function ProfileLoading() {
+  const t = await getTranslations("common");
+  return (
+    <div
+      role="status"
+      aria-busy="true"
+      className="flex items-center justify-center py-20"
+    >
+      <Spinner />
+      <span className="sr-only">{t("loading")}</span>
+    </div>
+  );
+}

--- a/apps/web/src/components/ui/spinner.tsx
+++ b/apps/web/src/components/ui/spinner.tsx
@@ -1,0 +1,8 @@
+import { cn } from "@/lib/utils";
+
+/** The app's standard ring spinner (.sol-spinner in globals.css) — the same
+ * element rendered inline across leaderboard, dashboard, settings, etc.
+ * Decorative: pair it with a sr-only label in the caller. */
+export function Spinner({ className }: { className?: string }) {
+  return <div aria-hidden="true" className={cn("sol-spinner", className)} />;
+}


### PR DESCRIPTION
Adds loading.tsx to every platform route (courses, course detail, lesson, leaderboard, community + children, dashboard, profile, plus a group-level catch-all). Two wins: navigations show feedback instantly instead of freezing on the previous page, and dynamic routes become prefetchable (Next only prefetches up to the first loading boundary — without one, nothing usable is prefetched).

Owner chose spinners over skeletons: each file renders the app's existing `.sol-spinner` ring via a small shared `Spinner` component, with `role="status"` and a sr-only translated label (`common.loading`, present in all 3 locales).

Closes #1092