### PR TITLE
perf: middleware getClaims + drop per-nav tombstone query (#1089)

### DIFF
--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -6,13 +6,15 @@ API route reference lives in `src/app/api/CLAUDE.md` (loads when you work on rou
 
 The middleware (`src/middleware.ts`) chains two concerns:
 
-1. **Supabase auth**: Creates server client, calls `getUser()` (may refresh tokens)
+1. **Supabase auth**: Creates server client, calls `getClaims()` — local JWT verify against cached JWKS (no network for asymmetric keys; falls back to `getUser()` on HS256), refreshing the session when needed. Only `claims.sub` is used. No per-request DB queries: soft-deleted accounts are refused at the login chokepoints (`/api/auth/callback`, `/api/auth/wallet`, `/api/auth/dynamic`), and every `profiles.deleted_at` writer pairs with session revocation, so a stale session dies at its next token refresh (bounded by access-token expiry).
 2. **next-intl**: Adds locale prefix to all routes (default: `en`)
+
+Server components share one per-request claims read via `getAuthClaims()` (`lib/auth/dal.ts`, React `cache()`); call `supabase.auth.getUser()` directly only when the full user object is needed.
 
 **Auth-gated routes** (redirect to landing if unauthenticated): `/dashboard`, `/settings`, `/profile` (exact — own profile only)
 **Public routes** (no auth required): `/` (landing), `/courses`, `/leaderboard`, `/community`, `/certificates`, `/profile/[username]`
 **Admin routes**: Checked against HMAC-signed `admin_session` cookie (separate from Supabase auth). Sub-routes redirect to `/admin` login form if cookie is absent or expired.
-**Excluded from middleware**: `/api/*`, `/_next`, `/_vercel`, static assets
+**Excluded from middleware**: `/api/*`, `/_next/static`, `/_next/image`, `/_vercel`, and asset-extension paths only — a dot in a page slug (e.g. `/en/courses/node.js-basics`) still runs middleware.
 
 ## i18n Notes
 

--- a/apps/web/e2e/harness/mock-supabase.mjs
+++ b/apps/web/e2e/harness/mock-supabase.mjs
@@ -110,12 +110,25 @@ function handleRest(table, req, res) {
   }
 }
 
-// auth-js calls POST /auth/v1/user (getUser, server-side in middleware) with the
-// session's bearer token. Return the learner for the fake token, else 401 — both
-// are handled gracefully by the middleware for the public routes the specs hit.
+// auth-js calls POST /auth/v1/user (getUser — the HS256 fallback getClaims takes
+// server-side, #1102) with the session's bearer token. The harness token is a
+// well-formed JWT (see session.ts buildFakeJwt), so match on its payload `sub`;
+// anything else is 401 — handled gracefully by the middleware for the public
+// routes the specs hit.
+function bearerSub(auth) {
+  const token = auth.startsWith("Bearer ") ? auth.slice(7) : "";
+  const payload = token.split(".")[1];
+  if (!payload) return null;
+  try {
+    return JSON.parse(Buffer.from(payload, "base64url").toString("utf8")).sub;
+  } catch {
+    return null;
+  }
+}
+
 function handleAuthUser(req, res) {
   const auth = req.headers["authorization"] || "";
-  if (auth.includes(`Bearer ${LEARNER.id}.fake`)) {
+  if (bearerSub(auth) === LEARNER.id) {
     return sendJson(res, 200, {
       id: LEARNER.id,
       aud: "authenticated",

--- a/apps/web/e2e/harness/session.ts
+++ b/apps/web/e2e/harness/session.ts
@@ -18,17 +18,44 @@ const LEARNER_ID = LEARNER.id;
 const STORAGE_KEY = `sb-${new URL(SUPABASE_URL).hostname.split(".")[0]}-auth-token`;
 
 /**
+ * A structurally valid (but unsigned-in-earnest) HS256 JWT for the learner.
+ *
+ * The middleware's `getClaims()` (#1102) DECODES the access token locally
+ * before deciding how to verify it: a non-JWT string throws inside auth-js and
+ * the session reads as anonymous — the old `<id>.fake.jwt` opaque token broke
+ * every signed-in spec that way. A well-formed HS256 token with no `kid` takes
+ * auth-js's documented fallback path instead: decode → alg is HS* → verify via
+ * `getUser(token)` → the mock's /auth/v1/user answers. This is also more
+ * faithful to prod, where the cookie always carries a real JWT. The signature
+ * segment is garbage on purpose — nothing verifies it locally.
+ */
+function buildFakeJwt(nowSec: number): string {
+  const b64 = (obj: object): string =>
+    Buffer.from(JSON.stringify(obj), "utf8").toString("base64url");
+  const header = { alg: "HS256", typ: "JWT" };
+  const payload = {
+    sub: LEARNER_ID,
+    aud: "authenticated",
+    role: "authenticated",
+    email: LEARNER.email,
+    exp: nowSec + 3600,
+    iat: nowSec,
+    session_id: "e2e-session",
+  };
+  return `${b64(header)}.${b64(payload)}.e2e-fake-signature`;
+}
+
+/**
  * Mint the cookie the browser Supabase client would have written on a real
  * sign-in. `getSession()` reads this locally (no network) and trusts the
- * embedded `expires_at`, so a non-JWT access_token with a future expiry is a
- * fully-working session for the client — no secret, no signing. The value is
- * `base64-` + base64url(JSON(session)), exactly the @supabase/ssr encoding.
+ * embedded `expires_at`. The value is `base64-` + base64url(JSON(session)),
+ * exactly the @supabase/ssr encoding.
  */
 function buildSessionCookieValue(): string {
   const nowSec = Math.floor(Date.now() / 1000);
   const session = {
-    // The mock's /auth/v1/user matches on `Bearer <id>.fake`; keep in sync.
-    access_token: `${LEARNER_ID}.fake.jwt`,
+    // The mock's /auth/v1/user matches on the JWT payload's `sub`; keep in sync.
+    access_token: buildFakeJwt(nowSec),
     refresh_token: "e2e-refresh-token",
     token_type: "bearer",
     expires_in: 3600,

--- a/apps/web/src/__tests__/middleware.test.ts
+++ b/apps/web/src/__tests__/middleware.test.ts
@@ -2,20 +2,18 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { NextRequest, NextResponse } from "next/server";
 
-const { getUser, signOut, isAccountDeleted } = vi.hoisted(() => ({
-  getUser: vi.fn(),
-  signOut: vi.fn().mockResolvedValue({ error: null }),
-  isAccountDeleted: vi.fn<(userId: string) => Promise<boolean>>(),
+const { getClaims } = vi.hoisted(() => ({
+  getClaims: vi.fn(),
 }));
 
 vi.mock("@supabase/ssr", () => ({
   createServerClient: () => ({
-    auth: { getUser, signOut },
+    auth: { getClaims },
   }),
 }));
 
-// Pass-through stand-in — the deleted-account backstop under test runs BEFORE
-// next-intl, so its own locale-prefixing logic is irrelevant here.
+// Pass-through stand-in — the auth logic under test runs BEFORE next-intl,
+// so its own locale-prefixing logic is irrelevant here.
 vi.mock("next-intl/middleware", () => ({
   default:
     () =>
@@ -23,68 +21,77 @@ vi.mock("next-intl/middleware", () => ({
       NextResponse.next({ request }),
 }));
 
-// #461 — mocked directly so this test doesn't have to re-mock the admin
-// Supabase client; see lib/auth/__tests__/account-status.test.ts for that.
-vi.mock("@/lib/auth/account-status", () => ({
-  isAccountDeleted,
-  DELETED_ACCOUNT_REASON: "account_deleted",
-}));
-
-import { middleware } from "../middleware";
+import { middleware, config } from "../middleware";
 
 function pageRequest(path: string): NextRequest {
   return new NextRequest(`https://app.test${path}`);
 }
 
+function sessionFor(sub: string) {
+  return { data: { claims: { sub } }, error: null };
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
-  getUser.mockResolvedValue({ data: { user: null } });
-  isAccountDeleted.mockResolvedValue(false);
+  getClaims.mockResolvedValue({ data: null, error: null });
 });
 
-describe("middleware — #461 deleted-account backstop", () => {
-  it("never queries deletion status for anonymous requests (no DB round-trip)", async () => {
-    await middleware(pageRequest("/en/courses"));
-    expect(isAccountDeleted).not.toHaveBeenCalled();
-  });
-
-  it("passes a normal (non-deleted) authenticated user through exactly as before", async () => {
-    getUser.mockResolvedValue({ data: { user: { id: "user-1" } } });
-
-    const res = await middleware(pageRequest("/en/dashboard"));
-
-    expect(isAccountDeleted).toHaveBeenCalledWith("user-1");
-    expect(signOut).not.toHaveBeenCalled();
+describe("middleware — auth via getClaims (#1089)", () => {
+  it("passes an anonymous request through on a public route", async () => {
+    const res = await middleware(pageRequest("/en/courses"));
     expect(res.headers.get("location")).toBeNull();
   });
 
-  it("refuses a deleted user on a NON-protected route too: signs out and redirects to landing", async () => {
-    getUser.mockResolvedValue({ data: { user: { id: "user-2" } } });
-    isAccountDeleted.mockResolvedValue(true);
-
-    // /en/courses is public — proves the backstop isn't limited to
-    // isProtectedRoute() paths (needed for the SIWS/wallet path, which can
-    // land on any page after middleware.ts already holds the session cookie).
-    const res = await middleware(pageRequest("/en/courses"));
-
-    expect(isAccountDeleted).toHaveBeenCalledWith("user-2");
-    expect(signOut).toHaveBeenCalledTimes(1);
+  it("redirects an anonymous request on a protected route to the locale landing", async () => {
+    const res = await middleware(pageRequest("/pt-BR/dashboard"));
 
     const location = res.headers.get("location");
     expect(location).not.toBeNull();
-    const url = new URL(location!);
-    expect(url.pathname).toBe("/en");
-    expect(url.searchParams.get("error")).toBe("auth");
-    expect(url.searchParams.get("reason")).toBe("account_deleted");
+    expect(new URL(location!).pathname).toBe("/pt-BR");
   });
 
-  it("refuses a deleted user on a protected route with the same redirect (not the plain unauthenticated-redirect)", async () => {
-    getUser.mockResolvedValue({ data: { user: { id: "user-3" } } });
-    isAccountDeleted.mockResolvedValue(true);
+  it("passes an authenticated request through on a protected route", async () => {
+    getClaims.mockResolvedValue(sessionFor("user-1"));
 
     const res = await middleware(pageRequest("/en/dashboard"));
+    expect(res.headers.get("location")).toBeNull();
+  });
 
-    const url = new URL(res.headers.get("location")!);
-    expect(url.searchParams.get("reason")).toBe("account_deleted");
+  it("fails closed when getClaims returns no data (missing env, invalid JWT)", async () => {
+    getClaims.mockResolvedValue({ data: null, error: null });
+
+    const res = await middleware(pageRequest("/en/settings"));
+    expect(res.headers.get("location")).not.toBeNull();
+  });
+});
+
+describe("middleware — matcher (#1089 dotted page slugs)", () => {
+  // Next.js compiles config.matcher as a path-to-regexp pattern; for this
+  // shape it is equivalent to anchoring the inner regex. Testing the regex
+  // directly documents which paths run middleware.
+  const inner = config.matcher[0]!.replace(/^\/\((.*)\)$/, "$1");
+  const matcher = new RegExp(`^/${inner}$`);
+
+  it.each([
+    "/en/courses/node.js-basics",
+    "/en/courses/web3.0-intro",
+    "/en/dashboard",
+    "/pt-BR/leaderboard",
+  ])("runs middleware for page route %s", (path) => {
+    expect(matcher.test(path)).toBe(true);
+  });
+
+  it.each([
+    "/api/auth/callback",
+    "/_next/static/chunks/main.js",
+    "/_next/image",
+    "/_vercel/insights",
+    "/favicon.ico",
+    "/robots.txt",
+    "/sitemap.xml",
+    "/images/logo.png",
+    "/fonts/display.woff2",
+  ])("skips middleware for %s", (path) => {
+    expect(matcher.test(path)).toBe(false);
   });
 });

--- a/apps/web/src/__tests__/middleware.test.ts
+++ b/apps/web/src/__tests__/middleware.test.ts
@@ -75,6 +75,7 @@ describe("middleware — matcher (#1089 dotted page slugs)", () => {
   it.each([
     "/en/courses/node.js-basics",
     "/en/courses/web3.0-intro",
+    "/en/docs/v1.2-notes",
     "/en/dashboard",
     "/pt-BR/leaderboard",
   ])("runs middleware for page route %s", (path) => {
@@ -91,6 +92,10 @@ describe("middleware — matcher (#1089 dotted page slugs)", () => {
     "/sitemap.xml",
     "/images/logo.png",
     "/fonts/display.woff2",
+    // PWA manifest — served by app/manifest.ts; routing it through next-intl
+    // would 307 it to /en/manifest.webmanifest and 404 (adversarial review F3).
+    "/manifest.webmanifest",
+    "/icons/icon.avif",
   ])("skips middleware for %s", (path) => {
     expect(matcher.test(path)).toBe(false);
   });

--- a/apps/web/src/app/[locale]/(platform)/courses/[slug]/test-out/page.tsx
+++ b/apps/web/src/app/[locale]/(platform)/courses/[slug]/test-out/page.tsx
@@ -1,7 +1,7 @@
 import { notFound } from "next/navigation";
 import { getTranslations } from "next-intl/server";
 import { getCourseBySlug } from "@/lib/content/queries";
-import { createClient } from "@/lib/supabase/server";
+import { getAuthClaims } from "@/lib/auth/dal";
 import {
   gatherCourseQuizQuestions,
   MIN_TEST_OUT_POOL,
@@ -33,10 +33,7 @@ export default async function TestOutPage({ params }: TestOutPageProps) {
     (await isCourseTestOutEligible(course._id)) &&
     gatherCourseQuizQuestions(course).length >= MIN_TEST_OUT_POOL;
 
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
+  const claims = await getAuthClaims();
 
   return (
     <div className="space-y-8">
@@ -57,7 +54,7 @@ export default async function TestOutPage({ params }: TestOutPageProps) {
           </h2>
           <p className="text-sm text-text-3">{t("unavailableBody")}</p>
         </div>
-      ) : user ? (
+      ) : claims ? (
         <TestOutChallenge courseId={course._id} locale={locale} />
       ) : (
         <div className="rounded-[var(--r-lg)] border-[2.5px] border-border bg-card p-6">

--- a/apps/web/src/app/[locale]/(platform)/leaderboard/page.tsx
+++ b/apps/web/src/app/[locale]/(platform)/leaderboard/page.tsx
@@ -1,4 +1,5 @@
 import type { CohortLeague } from "@superteam-lms/types";
+import { getAuthClaims } from "@/lib/auth/dal";
 import { createClient } from "@/lib/supabase/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { getProgressService } from "@/lib/services";
@@ -10,14 +11,9 @@ export default async function LeaderboardPage() {
   const supabase = await createClient();
   const service = getProgressService(supabase);
 
-  const [
-    initialGlobalEntries,
-    {
-      data: { user },
-    },
-  ] = await Promise.all([
+  const [initialGlobalEntries, claims] = await Promise.all([
     service.getLeaderboard("alltime"),
-    supabase.auth.getUser(),
+    getAuthClaims(),
   ]);
 
   // Cohort league is the primary board (LX-B9b). It requires an authenticated
@@ -25,9 +21,12 @@ export default async function LeaderboardPage() {
   // demoted global board. A cohort read failure degrades to global, never 500s
   // the page.
   let initialCohort: CohortLeague | null = null;
-  if (user && serverEnv.SUPABASE_SERVICE_ROLE_KEY) {
+  if (claims && serverEnv.SUPABASE_SERVICE_ROLE_KEY) {
     try {
-      initialCohort = await getCohortLeaderboard(createAdminClient(), user.id);
+      initialCohort = await getCohortLeaderboard(
+        createAdminClient(),
+        claims.sub
+      );
     } catch {
       initialCohort = null;
     }
@@ -37,7 +36,7 @@ export default async function LeaderboardPage() {
     <LeaderboardClient
       initialGlobalEntries={initialGlobalEntries}
       initialCohort={initialCohort}
-      currentUserId={user?.id ?? ""}
+      currentUserId={claims?.sub ?? ""}
     />
   );
 }

--- a/apps/web/src/app/[locale]/(platform)/profile/[username]/page.tsx
+++ b/apps/web/src/app/[locale]/(platform)/profile/[username]/page.tsx
@@ -1,5 +1,6 @@
 import { getTranslations } from "next-intl/server";
 import { UserCircle } from "@phosphor-icons/react/dist/ssr";
+import { getAuthClaims } from "@/lib/auth/dal";
 import { createClient } from "@/lib/supabase/server";
 import { fetchPublicProfile } from "@/lib/profile/profile-data";
 import { ProfileBody } from "@/components/gamification/profile-body";
@@ -11,14 +12,12 @@ export default async function PublicProfilePage(props: {
   const params = await props.params;
   const username = decodeURIComponent(params.username);
   const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
+  const claims = await getAuthClaims();
 
   const profile = await fetchPublicProfile(
     supabase,
     username,
-    user?.id ?? null
+    claims?.sub ?? null
   );
 
   if (!profile) {

--- a/apps/web/src/app/[locale]/(platform)/profile/page.tsx
+++ b/apps/web/src/app/[locale]/(platform)/profile/page.tsx
@@ -1,5 +1,6 @@
 import { getTranslations } from "next-intl/server";
 import { UserCircle } from "@phosphor-icons/react/dist/ssr";
+import { getAuthClaims } from "@/lib/auth/dal";
 import { createClient } from "@/lib/supabase/server";
 import { fetchOwnProfile } from "@/lib/profile/profile-data";
 import { ProfileBody } from "@/components/gamification/profile-body";
@@ -7,11 +8,9 @@ import { ProfileBackButton } from "@/components/profile/profile-back-button";
 
 export default async function ProfilePage() {
   const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
+  const claims = await getAuthClaims();
 
-  const profile = user ? await fetchOwnProfile(supabase, user.id) : null;
+  const profile = claims ? await fetchOwnProfile(supabase, claims.sub) : null;
 
   if (!profile) {
     const t = await getTranslations("profile");

--- a/apps/web/src/app/[locale]/(platform)/review/page.tsx
+++ b/apps/web/src/app/[locale]/(platform)/review/page.tsx
@@ -1,4 +1,5 @@
 import { getTranslations } from "next-intl/server";
+import { getAuthClaims } from "@/lib/auth/dal";
 import { createClient } from "@/lib/supabase/server";
 import { buildReviewSession } from "@/lib/review/session";
 import { ReviewSession } from "@/components/review/review-session";
@@ -12,12 +13,10 @@ import { ReviewSession } from "@/components/review/review-session";
  */
 export default async function ReviewPage() {
   const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
+  const claims = await getAuthClaims();
   const t = await getTranslations("review");
 
-  if (!user) {
+  if (!claims) {
     return (
       <div className="flex flex-col items-center justify-center py-20 text-center">
         <h1 className="mb-2 font-display text-xl font-black">
@@ -28,7 +27,7 @@ export default async function ReviewPage() {
     );
   }
 
-  const items = await buildReviewSession(supabase, user.id);
+  const items = await buildReviewSession(supabase, claims.sub);
 
   return (
     <div className="space-y-8">

--- a/apps/web/src/app/[locale]/(platform)/teach/page.tsx
+++ b/apps/web/src/app/[locale]/(platform)/teach/page.tsx
@@ -1,7 +1,8 @@
 import { getTranslations } from "next-intl/server";
-import { InstructorCourses } from "./instructor-courses";
+import { getAuthClaims } from "@/lib/auth/dal";
 import { createClient } from "@/lib/supabase/server";
 import { getInstructorCourses } from "@/lib/content/queries";
+import { InstructorCourses } from "./instructor-courses";
 
 export const dynamic = "force-dynamic";
 
@@ -19,16 +20,14 @@ export const dynamic = "force-dynamic";
  */
 export default async function TeachPage() {
   const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
+  const claims = await getAuthClaims();
 
   let wallet: string | null = null;
-  if (user) {
+  if (claims) {
     const { data: profile } = await supabase
       .from("profiles")
       .select("wallet_address")
-      .eq("id", user.id)
+      .eq("id", claims.sub)
       .maybeSingle();
     wallet = profile?.wallet_address ?? null;
   }

--- a/apps/web/src/app/api/account/delete/__tests__/route.test.ts
+++ b/apps/web/src/app/api/account/delete/__tests__/route.test.ts
@@ -3,15 +3,17 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 
 vi.mock("server-only", () => ({}));
 
-const { getUser, signOut, update, eq, isRateLimited } = vi.hoisted(() => ({
-  getUser: vi.fn<() => Promise<unknown>>(),
-  signOut: vi.fn(),
-  // (table, payload) — the route now writes two tables, and WHICH table gets
-  // which payload is the property under test.
-  update: vi.fn<(table: string, payload: unknown) => void>(),
-  eq: vi.fn<() => Promise<{ error: unknown }>>(),
-  isRateLimited: vi.fn<() => Promise<boolean>>(),
-}));
+const { getUser, signOut, update, eq, isRateLimited, updateUserById } =
+  vi.hoisted(() => ({
+    getUser: vi.fn<() => Promise<unknown>>(),
+    signOut: vi.fn(),
+    updateUserById: vi.fn<() => Promise<{ error: unknown }>>(),
+    // (table, payload) — the route now writes two tables, and WHICH table gets
+    // which payload is the property under test.
+    update: vi.fn<(table: string, payload: unknown) => void>(),
+    eq: vi.fn<() => Promise<{ error: unknown }>>(),
+    isRateLimited: vi.fn<() => Promise<boolean>>(),
+  }));
 
 vi.mock("@/lib/supabase/server", () => ({
   createClient: async () => ({ auth: { getUser, signOut } }),
@@ -25,6 +27,7 @@ vi.mock("@/lib/supabase/admin", () => ({
         return { eq };
       },
     }),
+    auth: { admin: { updateUserById } },
   }),
 }));
 
@@ -42,6 +45,8 @@ beforeEach(() => {
   getUser.mockResolvedValue({ data: { user: { id: "user-1" } }, error: null });
   eq.mockResolvedValue({ error: null });
   isRateLimited.mockResolvedValue(false);
+  signOut.mockResolvedValue({ error: null });
+  updateUserById.mockResolvedValue({ error: null });
 });
 
 describe("account deletion anonymises the profile", () => {
@@ -94,6 +99,30 @@ describe("account deletion anonymises the profile", () => {
     const res = await POST();
 
     expect(res.status).toBe(500);
+  });
+
+  // #1089 — middleware no longer kills tombstoned sessions per-request, so a
+  // failed revocation here would be an unbounded zombie session, not a
+  // cosmetic miss (adversarial review F1).
+  it("falls back to a permanent ban when signOut fails, and still succeeds", async () => {
+    signOut.mockResolvedValue({ error: { message: "gotrue down" } });
+
+    const res = await POST();
+
+    expect(res.status).toBe(200);
+    expect(updateUserById).toHaveBeenCalledWith("user-1", {
+      ban_duration: "876600h",
+    });
+  });
+
+  it("reports 500 when both signOut and the ban fallback fail", async () => {
+    signOut.mockResolvedValue({ error: { message: "gotrue down" } });
+    updateUserById.mockResolvedValue({ error: { message: "still down" } });
+
+    const res = await POST();
+
+    expect(res.status).toBe(500);
+    expect(updateUserById).toHaveBeenCalledTimes(3);
   });
 
   it("does not write when unauthenticated", async () => {

--- a/apps/web/src/app/api/account/delete/route.ts
+++ b/apps/web/src/app/api/account/delete/route.ts
@@ -5,6 +5,7 @@ import { NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { isRateLimited } from "@/lib/rate-limit";
+import { revokeUserSessions } from "@/lib/auth/revoke-sessions";
 import { logError } from "@/lib/logging";
 import { ERROR_IDS } from "@/constants/errorIds";
 import type { Database } from "@/lib/supabase/types";
@@ -118,9 +119,27 @@ export async function POST(): Promise<NextResponse> {
       );
     }
 
-    // Clear the session (best-effort). Even if this fails the account is already
-    // anonymized; the client also drops its local session after the redirect.
-    await supabase.auth.signOut();
+    // Revoke every session. This is NOT best-effort: middleware no longer
+    // checks the tombstone per-request (#1089), so a deleted account whose
+    // revocation silently failed would keep refreshing forever. Global
+    // signOut first; on failure, fall back to a permanent ban (kills refresh
+    // the same way); if BOTH fail, report 500 so the client retries the
+    // deletion — the scrub is idempotent.
+    const { error: signOutError } = await supabase.auth.signOut();
+    if (signOutError) {
+      const revoked = await revokeUserSessions(admin, user.id);
+      if (!revoked.ok) {
+        logError({
+          errorId: ERROR_IDS.ACCOUNT_DELETE_FAILED,
+          error: revoked.error ?? new Error(signOutError.message),
+          context: { route: "/api/account/delete", stage: "revoke_sessions" },
+        });
+        return NextResponse.json(
+          { error: "Failed to process deletion" },
+          { status: 500 }
+        );
+      }
+    }
 
     return NextResponse.json({ success: true });
   } catch (err: unknown) {

--- a/apps/web/src/app/api/account/delete/route.ts
+++ b/apps/web/src/app/api/account/delete/route.ts
@@ -121,19 +121,22 @@ export async function POST(): Promise<NextResponse> {
 
     // Revoke every session. This is NOT best-effort: middleware no longer
     // checks the tombstone per-request (#1089), so a deleted account whose
-    // revocation silently failed would keep refreshing forever. Global
-    // signOut first; on failure, fall back to a permanent ban (kills refresh
-    // the same way); if BOTH fail, report 500 so the client retries the
-    // deletion — the scrub is idempotent.
+    // revocation silently failed would keep refreshing forever. The ban runs
+    // UNCONDITIONALLY — GoTrue's signOut swallows 401/403 as success without
+    // revoking anything, and the ban is the one mechanism that provably kills
+    // refresh tokens (banning a deleted account is harmless). signOut still
+    // runs first to clear the caller's cookies. Only when BOTH mechanisms
+    // fail does the route report 500 so the client retries — the scrub is
+    // idempotent.
     const { error: signOutError } = await supabase.auth.signOut();
-    if (signOutError) {
-      const revoked = await revokeUserSessions(admin, user.id);
-      if (!revoked.ok) {
-        logError({
-          errorId: ERROR_IDS.ACCOUNT_DELETE_FAILED,
-          error: revoked.error ?? new Error(signOutError.message),
-          context: { route: "/api/account/delete", stage: "revoke_sessions" },
-        });
+    const revoked = await revokeUserSessions(admin, user.id);
+    if (!revoked.ok) {
+      logError({
+        errorId: ERROR_IDS.ACCOUNT_DELETE_FAILED,
+        error: revoked.error ?? new Error("session revocation (ban) failed"),
+        context: { route: "/api/account/delete", stage: "revoke_sessions" },
+      });
+      if (signOutError) {
         return NextResponse.json(
           { error: "Failed to process deletion" },
           { status: 500 }

--- a/apps/web/src/app/api/auth/dynamic/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/dynamic/__tests__/route.test.ts
@@ -977,6 +977,8 @@ describe("POST /api/auth/dynamic — account-fork auto-merge", () => {
     );
 
     expect(res.status).toBe(200);
+    // …but not silently: the ban is retried before giving up (review F2).
+    expect(updateUserById).toHaveBeenCalledTimes(3);
   });
 
   it("never merges on an email match alone — no blockchain credential, no merge", async () => {

--- a/apps/web/src/app/api/auth/dynamic/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/dynamic/__tests__/route.test.ts
@@ -18,6 +18,7 @@ const {
   profileUpdate,
   shellLookup,
   getUserById,
+  updateUserById,
   rpcMock,
   retryPendingOnchainActions,
   generateWalletName,
@@ -34,6 +35,7 @@ const {
   profileUpdate: vi.fn<(values: Record<string, unknown>) => Promise<unknown>>(),
   shellLookup: vi.fn(),
   getUserById: vi.fn(),
+  updateUserById: vi.fn(),
   rpcMock: vi.fn(),
   retryPendingOnchainActions: vi.fn<(userId: string) => Promise<void>>(),
   generateWalletName: vi.fn<() => string>(),
@@ -50,7 +52,7 @@ vi.mock("@/lib/solana/onchain-queue", () => ({ retryPendingOnchainActions }));
 // post-login profile read/update (placeholder-username replacement).
 vi.mock("@/lib/supabase/admin", () => ({
   createAdminClient: () => ({
-    auth: { admin: { createUser, generateLink, getUserById } },
+    auth: { admin: { createUser, generateLink, getUserById, updateUserById } },
     rpc: rpcMock,
     from: () => ({
       select: () => ({
@@ -218,6 +220,7 @@ beforeEach(() => {
   profileUpdate.mockResolvedValue({ error: null });
   shellLookup.mockResolvedValue({ data: [], error: null });
   getUserById.mockResolvedValue({ data: { user: null }, error: null });
+  updateUserById.mockResolvedValue({ data: { user: null }, error: null });
   // `data: null` doubles as the subject rung's default no-match, so every
   // pre-#1055 test keeps exercising the email rung unchanged.
   rpcMock.mockResolvedValue({ data: null, error: null });
@@ -935,6 +938,45 @@ describe("POST /api/auth/dynamic — account-fork auto-merge", () => {
       p_shell: SHELL_ID,
       p_wallet: SHELL_WALLET,
     });
+  });
+
+  it("revokes the shell's sessions (permanent ban) after a successful merge", async () => {
+    armMergeScenario();
+
+    const res = await POST(
+      dynamicRequest({ dynamicJwt: await jwtWithWallet() })
+    );
+
+    expect(res.status).toBe(200);
+    expect(updateUserById).toHaveBeenCalledWith(SHELL_ID, {
+      ban_duration: "876600h",
+    });
+  });
+
+  it("never bans anyone when the merge is refused", async () => {
+    armMergeScenario();
+    rpcMock.mockResolvedValue({ data: null, error: { message: "refused" } });
+
+    const res = await POST(
+      dynamicRequest({ dynamicJwt: await jwtWithWallet() })
+    );
+
+    expect(res.status).toBe(200);
+    expect(updateUserById).not.toHaveBeenCalled();
+  });
+
+  it("a failed ban is non-fatal — sign-in still succeeds", async () => {
+    armMergeScenario();
+    updateUserById.mockResolvedValue({
+      data: { user: null },
+      error: { message: "gotrue down" },
+    });
+
+    const res = await POST(
+      dynamicRequest({ dynamicJwt: await jwtWithWallet() })
+    );
+
+    expect(res.status).toBe(200);
   });
 
   it("never merges on an email match alone — no blockchain credential, no merge", async () => {

--- a/apps/web/src/app/api/auth/dynamic/route.ts
+++ b/apps/web/src/app/api/auth/dynamic/route.ts
@@ -577,6 +577,29 @@ async function mergeWalletShellAccount(
       return;
     }
     logEvent({ event: "dynamic-auth.shell-merged", context: { merged } });
+
+    // The merge tombstones the shell (profiles.deleted_at) inside the RPC, but
+    // a live shell session elsewhere (SIWS sign-in on another device) still
+    // holds refresh tokens. Middleware no longer checks tombstones per-request,
+    // so every deleted_at writer must pair with session revocation. supabase-js
+    // has no revoke-by-user-id, so a permanent ban does it: GoTrue refuses
+    // banned users at token refresh, leaving only the current access token's
+    // remaining lifetime — the same <= JWT-expiry bound as account deletion.
+    const { error: banError } = await supabaseAdmin.auth.admin.updateUserById(
+      shell.id,
+      { ban_duration: "876600h" }
+    );
+    if (banError) {
+      logError({
+        errorId: ERROR_IDS.DYNAMIC_AUTH_FAILED,
+        error: new Error(banError.message),
+        context: {
+          note: "shell session revocation (ban) failed",
+          userId,
+          shellId: shell.id,
+        },
+      });
+    }
   } catch (err: unknown) {
     logError({
       errorId: ERROR_IDS.DYNAMIC_AUTH_FAILED,

--- a/apps/web/src/app/api/auth/dynamic/route.ts
+++ b/apps/web/src/app/api/auth/dynamic/route.ts
@@ -10,6 +10,7 @@ import { createAdminClient } from "@/lib/supabase/admin";
 import { isRateLimited, getClientIp } from "@/lib/rate-limit";
 import { isAccountDeleted } from "@/lib/auth/account-status";
 import { shouldAdoptAvatar } from "@/lib/auth/avatar-adoption";
+import { revokeUserSessions } from "@/lib/auth/revoke-sessions";
 import { isWalletPlaceholderEmail } from "@/lib/auth/wallet-placeholder";
 import { generateWalletName } from "@/lib/utils/generate-wallet-name";
 import { retryPendingOnchainActions } from "@/lib/solana/onchain-queue";
@@ -581,20 +582,20 @@ async function mergeWalletShellAccount(
     // The merge tombstones the shell (profiles.deleted_at) inside the RPC, but
     // a live shell session elsewhere (SIWS sign-in on another device) still
     // holds refresh tokens. Middleware no longer checks tombstones per-request,
-    // so every deleted_at writer must pair with session revocation. supabase-js
-    // has no revoke-by-user-id, so a permanent ban does it: GoTrue refuses
-    // banned users at token refresh, leaving only the current access token's
-    // remaining lifetime — the same <= JWT-expiry bound as account deletion.
-    const { error: banError } = await supabaseAdmin.auth.admin.updateUserById(
-      shell.id,
-      { ban_duration: "876600h" }
-    );
-    if (banError) {
+    // so every deleted_at writer must pair with session revocation — a
+    // permanent ban here (with retries): GoTrue refuses banned users at token
+    // refresh, leaving only the current access token's remaining lifetime, the
+    // same <= JWT-expiry bound as account deletion. Non-fatal to the sign-in
+    // (the target account is fine either way), but a persistent failure is a
+    // zombie shell session, so it logs at error level for follow-up.
+    const revoked = await revokeUserSessions(supabaseAdmin, shell.id);
+    if (!revoked.ok) {
       logError({
         errorId: ERROR_IDS.DYNAMIC_AUTH_FAILED,
-        error: new Error(banError.message),
+        error:
+          revoked.error ?? new Error("shell session revocation (ban) failed"),
         context: {
-          note: "shell session revocation (ban) failed",
+          note: "shell session revocation (ban) failed after retries",
           userId,
           shellId: shell.id,
         },

--- a/apps/web/src/app/api/auth/dynamic/route.ts
+++ b/apps/web/src/app/api/auth/dynamic/route.ts
@@ -588,14 +588,30 @@ async function mergeWalletShellAccount(
     // same <= JWT-expiry bound as account deletion. Non-fatal to the sign-in
     // (the target account is fine either way), but a persistent failure is a
     // zombie shell session, so it logs at error level for follow-up.
-    const revoked = await revokeUserSessions(supabaseAdmin, shell.id);
-    if (!revoked.ok) {
+    // Own try/catch: the merge RPC already committed, so a throw here must
+    // not be logged as "shell merge failed" — the failure mode is a zombie
+    // shell session, not an unmerged account.
+    try {
+      const revoked = await revokeUserSessions(supabaseAdmin, shell.id);
+      if (!revoked.ok) {
+        logError({
+          errorId: ERROR_IDS.DYNAMIC_AUTH_FAILED,
+          error:
+            revoked.error ?? new Error("shell session revocation (ban) failed"),
+          context: {
+            note: "shell session revocation (ban) failed after retries",
+            userId,
+            shellId: shell.id,
+          },
+        });
+      }
+    } catch (revokeErr: unknown) {
       logError({
         errorId: ERROR_IDS.DYNAMIC_AUTH_FAILED,
         error:
-          revoked.error ?? new Error("shell session revocation (ban) failed"),
+          revokeErr instanceof Error ? revokeErr : new Error(String(revokeErr)),
         context: {
-          note: "shell session revocation (ban) failed after retries",
+          note: "shell session revocation threw (merge already committed)",
           userId,
           shellId: shell.id,
         },

--- a/apps/web/src/components/auth/auth-error-toast.tsx
+++ b/apps/web/src/components/auth/auth-error-toast.tsx
@@ -5,8 +5,8 @@ import { useSearchParams } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { dispatchToast } from "@/components/ui/toast-container";
 
-// Maps the `reason` query param that /api/auth/callback and middleware.ts
-// attach to a refused-login redirect (`?error=auth&reason=<x>`) to a message
+// Maps the `reason` query param that /api/auth/callback
+// attaches to a refused-login redirect (`?error=auth&reason=<x>`) to a message
 // key in the "auth" namespace. `account_deleted` is #461; the other three are
 // pre-existing OAuth-callback failure reasons that had translated strings but
 // no consumer — wiring them up here alongside #461 costs nothing extra and

--- a/apps/web/src/lib/auth/dal.ts
+++ b/apps/web/src/lib/auth/dal.ts
@@ -1,0 +1,22 @@
+import "server-only";
+import { cache } from "react";
+import type { JwtPayload } from "@supabase/supabase-js";
+import { createClient } from "@/lib/supabase/server";
+
+/**
+ * Per-request cached auth claims for server components (Next's documented
+ * DAL pattern). `getClaims()` verifies the session JWT locally against the
+ * cached JWKS (falling back to `getUser()` on HS256), and React `cache()`
+ * dedupes it, so any number of pages/components in one render share a single
+ * read instead of each paying their own Supabase Auth round-trip.
+ *
+ * Returns the verified claims (`claims.sub` is the user id) or null when
+ * there is no valid session. Pages that need the full user object (email
+ * change flows, identities) should keep calling `supabase.auth.getUser()`
+ * directly.
+ */
+export const getAuthClaims = cache(async (): Promise<JwtPayload | null> => {
+  const supabase = await createClient();
+  const { data } = await supabase.auth.getClaims();
+  return data?.claims ?? null;
+});

--- a/apps/web/src/lib/auth/revoke-sessions.ts
+++ b/apps/web/src/lib/auth/revoke-sessions.ts
@@ -1,0 +1,35 @@
+import "server-only";
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+/**
+ * Revoke every session of a user by permanently banning the account.
+ *
+ * GoTrue refuses banned users at token refresh, so all refresh tokens die and
+ * only the current access token's remaining lifetime survives — the same
+ * <= JWT-expiry bound the account-deletion flow accepts. supabase-js exposes
+ * no revoke-by-user-id, which is why this is a ban and not a logout.
+ *
+ * INVARIANT (#1089): middleware no longer checks profiles.deleted_at
+ * per-request, so EVERY writer of deleted_at must pair with a successful call
+ * to this helper (or a global signOut). A silent failure here is an unbounded
+ * zombie session — hence the retries; callers must still check the result and
+ * escalate loudly on false.
+ */
+export async function revokeUserSessions(
+  admin: SupabaseClient,
+  userId: string,
+  attempts = 3
+): Promise<{ ok: boolean; error: Error | null }> {
+  let lastError: Error | null = null;
+  for (let attempt = 0; attempt < attempts; attempt++) {
+    if (attempt > 0) {
+      await new Promise((resolve) => setTimeout(resolve, 250 * attempt));
+    }
+    const { error } = await admin.auth.admin.updateUserById(userId, {
+      ban_duration: "876600h",
+    });
+    if (!error) return { ok: true, error: null };
+    lastError = new Error(error.message);
+  }
+  return { ok: false, error: lastError };
+}

--- a/apps/web/src/lib/auth/revoke-sessions.ts
+++ b/apps/web/src/lib/auth/revoke-sessions.ts
@@ -1,5 +1,6 @@
 import "server-only";
 import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "@/lib/supabase/types";
 
 /**
  * Revoke every session of a user by permanently banning the account.
@@ -16,7 +17,7 @@ import type { SupabaseClient } from "@supabase/supabase-js";
  * escalate loudly on false.
  */
 export async function revokeUserSessions(
-  admin: SupabaseClient,
+  admin: SupabaseClient<Database>,
   userId: string,
   attempts = 3
 ): Promise<{ ok: boolean; error: Error | null }> {

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -6,10 +6,6 @@ import { locales, defaultLocale } from "@/lib/i18n/config";
 import { isAdminRoute, isAdminRootPath } from "@/lib/admin/routes";
 import { ADMIN_SESSION_MAX_AGE_MS } from "@/lib/admin/session-format";
 import { buildCsp, generateNonce } from "@/lib/csp";
-import {
-  isAccountDeleted,
-  DELETED_ACCOUNT_REASON,
-} from "@/lib/auth/account-status";
 
 // NOTE: This Edge-runtime `isValidAdminSession` (Web Crypto) must stay in sync
 // with the Node-runtime implementation in `lib/admin/auth.ts` (Node `crypto`).
@@ -130,38 +126,20 @@ export async function middleware(request: NextRequest) {
     }
   );
 
-  // IMPORTANT: getUser() may trigger token refresh which calls setAll
-  // If Supabase env vars are missing, this will fail and user will be null
-  // which causes platform routes to redirect (fail-closed behavior)
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-
-  // #461 — refuse a soft-deleted (tombstoned) account, on every request that
-  // carries a session, not just protected routes. This is the backstop for
-  // the SIWS/wallet login path (which never touches /api/auth/callback) and
-  // for any Supabase session cookie that outlived an account deletion. Cheap:
-  // a single primary-key lookup, gated on `user` already being non-null so
-  // anonymous requests never pay for it.
-  if (user && (await isAccountDeleted(user.id))) {
-    // Sign out via the SAME cookie-bound client used for getUser() above, so
-    // the clearing Set-Cookie headers land on supabaseResponse and get
-    // relayed onto the redirect below.
-    await supabase.auth.signOut();
-
-    const locale =
-      locales.find((l) => request.nextUrl.pathname.startsWith(`/${l}`)) ??
-      defaultLocale;
-    const redirectUrl = new URL(`/${locale}`, request.url);
-    redirectUrl.searchParams.set("error", "auth");
-    redirectUrl.searchParams.set("reason", DELETED_ACCOUNT_REASON);
-    const redirectResponse = NextResponse.redirect(redirectUrl);
-    redirectResponse.headers.set("Content-Security-Policy", csp);
-    supabaseResponse.cookies.getAll().forEach((cookie) => {
-      redirectResponse.cookies.set(cookie);
-    });
-    return redirectResponse;
-  }
+  // IMPORTANT: getClaims() verifies the JWT locally (WebCrypto against cached
+  // JWKS) for asymmetric signing keys — zero network calls on the hot path —
+  // and falls back to getUser() for HS256. Either way it refreshes an expired
+  // session first, which calls setAll above. If Supabase env vars are missing
+  // this fails and userId stays null, so platform routes redirect (fail-closed).
+  //
+  // The #461 per-request tombstone query used to live here. It's gone: every
+  // writer of profiles.deleted_at now pairs with session revocation (global
+  // signOut in /api/account/delete, admin ban in the shell merge), and the
+  // login chokepoints (/api/auth/callback, /api/auth/wallet, /api/auth/dynamic)
+  // still call isAccountDeleted. A revoked session dies at its next token
+  // refresh, so the residual window is bounded by the access-token expiry.
+  const { data } = await supabase.auth.getClaims();
+  const userId = data?.claims.sub ?? null;
 
   // Now run intl middleware (after Supabase may have modified request cookies).
   // next-intl forwards request.headers (incl. the nonce + CSP set above) to the
@@ -200,7 +178,7 @@ export async function middleware(request: NextRequest) {
 
   // For platform routes, check auth (fail-closed: no user = redirect)
   if (isProtectedRoute(request.nextUrl.pathname)) {
-    if (!user) {
+    if (!userId) {
       const locale =
         locales.find((l) => request.nextUrl.pathname.startsWith(`/${l}`)) ??
         defaultLocale;
@@ -219,5 +197,10 @@ export async function middleware(request: NextRequest) {
 }
 
 export const config = {
-  matcher: ["/((?!api|_next|_vercel|.*\\..*).*)"],
+  // Extension-anchored exclusion (not `.*\..*`): a dot anywhere in a page slug
+  // (e.g. /en/courses/node.js-basics) must still hit middleware — only real
+  // static-asset extensions are skipped.
+  matcher: [
+    "/((?!api|_next/static|_next/image|_vercel|favicon.ico|sitemap.xml|robots.txt|.*\\.(?:svg|png|jpg|jpeg|gif|webp|ico|css|js|map|txt|xml|woff2?)$).*)",
+  ],
 };

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -201,6 +201,6 @@ export const config = {
   // (e.g. /en/courses/node.js-basics) must still hit middleware — only real
   // static-asset extensions are skipped.
   matcher: [
-    "/((?!api|_next/static|_next/image|_vercel|favicon.ico|sitemap.xml|robots.txt|.*\\.(?:svg|png|jpg|jpeg|gif|webp|ico|css|js|map|txt|xml|woff2?)$).*)",
+    "/((?!api|_next/static|_next/image|_vercel|favicon.ico|sitemap.xml|robots.txt|.*\\.(?:svg|png|jpg|jpeg|gif|webp|avif|ico|css|js|mjs|map|txt|xml|json|pdf|mp4|ttf|otf|woff2?|webmanifest)$).*)",
   ],
 };


### PR DESCRIPTION
Logged-in navigations paid two network round trips in middleware before rendering: `getUser()` (HTTP to Supabase Auth) then a serial `isAccountDeleted` profiles query — on every request including hover-prefetches. Now `getClaims()` verifies the JWT locally against the cached JWKS (Supabase's current documented middleware pattern; falls back to getUser on HS256 so behavior is safe on either key type), and the tombstone query is gone from the hot path.

Dropping the per-request tombstone check is sound because every `deleted_at` writer now pairs with session revocation: the delete route already global-signs-out, and the wallet-shell merge — found during this work to tombstone shells *without* revoking their live sessions — now permanently bans the shell (supabase-js has no revoke-by-id; a banned user dies at next token refresh, same ≤JWT-expiry bound as deletion). Login chokepoints still refuse deleted accounts.

Also: new `lib/auth/dal.ts` (React cache()-wrapped claims read) replaces six pages' duplicate `getUser()` calls, and the matcher no longer skips middleware for page slugs containing dots (`/en/courses/node.js-basics` previously lost CSP + locale handling).

Note for the win to fully land: confirm in Supabase Dashboard → JWT Keys that the ES256 key is the current signing key (JWKS already publishes one); on legacy HS256 the middleware silently keeps today's getUser behavior.

tsc clean; middleware + dynamic-route suites 86/86; page/auth suites 264/264.

Closes #1089