### PR TITLE
refactor: dedupe the 10 route loading states into one shared component

### DIFF
--- a/apps/web/src/app/[locale]/(platform)/community/[category-slug]/[thread-slug]/loading.tsx
+++ b/apps/web/src/app/[locale]/(platform)/community/[category-slug]/[thread-slug]/loading.tsx
@@ -1,17 +1,2 @@
-import { getTranslations } from "next-intl/server";
-import { Spinner } from "@/components/ui/spinner";
-
-// Route loading state (#1092) — see (platform)/loading.tsx.
-export default async function ThreadLoading() {
-  const t = await getTranslations("common");
-  return (
-    <div
-      role="status"
-      aria-busy="true"
-      className="flex items-center justify-center py-20"
-    >
-      <Spinner />
-      <span className="sr-only">{t("loading")}</span>
-    </div>
-  );
-}
+// Segment marker for Next instant loading + prefetch (#1092); UI lives in route-loading.
+export { default } from "@/components/ui/route-loading";

--- a/apps/web/src/app/[locale]/(platform)/community/[category-slug]/loading.tsx
+++ b/apps/web/src/app/[locale]/(platform)/community/[category-slug]/loading.tsx
@@ -1,17 +1,2 @@
-import { getTranslations } from "next-intl/server";
-import { Spinner } from "@/components/ui/spinner";
-
-// Route loading state (#1092) — see (platform)/loading.tsx.
-export default async function CategoryLoading() {
-  const t = await getTranslations("common");
-  return (
-    <div
-      role="status"
-      aria-busy="true"
-      className="flex items-center justify-center py-20"
-    >
-      <Spinner />
-      <span className="sr-only">{t("loading")}</span>
-    </div>
-  );
-}
+// Segment marker for Next instant loading + prefetch (#1092); UI lives in route-loading.
+export { default } from "@/components/ui/route-loading";

--- a/apps/web/src/app/[locale]/(platform)/community/loading.tsx
+++ b/apps/web/src/app/[locale]/(platform)/community/loading.tsx
@@ -1,17 +1,2 @@
-import { getTranslations } from "next-intl/server";
-import { Spinner } from "@/components/ui/spinner";
-
-// Route loading state (#1092) — see (platform)/loading.tsx.
-export default async function CommunityLoading() {
-  const t = await getTranslations("common");
-  return (
-    <div
-      role="status"
-      aria-busy="true"
-      className="flex items-center justify-center py-20"
-    >
-      <Spinner />
-      <span className="sr-only">{t("loading")}</span>
-    </div>
-  );
-}
+// Segment marker for Next instant loading + prefetch (#1092); UI lives in route-loading.
+export { default } from "@/components/ui/route-loading";

--- a/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/loading.tsx
+++ b/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/loading.tsx
@@ -1,17 +1,2 @@
-import { getTranslations } from "next-intl/server";
-import { Spinner } from "@/components/ui/spinner";
-
-// Route loading state (#1092) — see (platform)/loading.tsx.
-export default async function LessonLoading() {
-  const t = await getTranslations("common");
-  return (
-    <div
-      role="status"
-      aria-busy="true"
-      className="flex items-center justify-center py-20"
-    >
-      <Spinner />
-      <span className="sr-only">{t("loading")}</span>
-    </div>
-  );
-}
+// Segment marker for Next instant loading + prefetch (#1092); UI lives in route-loading.
+export { default } from "@/components/ui/route-loading";

--- a/apps/web/src/app/[locale]/(platform)/courses/[slug]/loading.tsx
+++ b/apps/web/src/app/[locale]/(platform)/courses/[slug]/loading.tsx
@@ -1,17 +1,2 @@
-import { getTranslations } from "next-intl/server";
-import { Spinner } from "@/components/ui/spinner";
-
-// Route loading state (#1092) — see (platform)/loading.tsx.
-export default async function CourseDetailLoading() {
-  const t = await getTranslations("common");
-  return (
-    <div
-      role="status"
-      aria-busy="true"
-      className="flex items-center justify-center py-20"
-    >
-      <Spinner />
-      <span className="sr-only">{t("loading")}</span>
-    </div>
-  );
-}
+// Segment marker for Next instant loading + prefetch (#1092); UI lives in route-loading.
+export { default } from "@/components/ui/route-loading";

--- a/apps/web/src/app/[locale]/(platform)/courses/loading.tsx
+++ b/apps/web/src/app/[locale]/(platform)/courses/loading.tsx
@@ -1,17 +1,2 @@
-import { getTranslations } from "next-intl/server";
-import { Spinner } from "@/components/ui/spinner";
-
-// Route loading state (#1092) — see (platform)/loading.tsx.
-export default async function CoursesLoading() {
-  const t = await getTranslations("common");
-  return (
-    <div
-      role="status"
-      aria-busy="true"
-      className="flex items-center justify-center py-20"
-    >
-      <Spinner />
-      <span className="sr-only">{t("loading")}</span>
-    </div>
-  );
-}
+// Segment marker for Next instant loading + prefetch (#1092); UI lives in route-loading.
+export { default } from "@/components/ui/route-loading";

--- a/apps/web/src/app/[locale]/(platform)/dashboard/loading.tsx
+++ b/apps/web/src/app/[locale]/(platform)/dashboard/loading.tsx
@@ -1,17 +1,2 @@
-import { getTranslations } from "next-intl/server";
-import { Spinner } from "@/components/ui/spinner";
-
-// Route loading state (#1092) — see (platform)/loading.tsx.
-export default async function DashboardLoading() {
-  const t = await getTranslations("common");
-  return (
-    <div
-      role="status"
-      aria-busy="true"
-      className="flex items-center justify-center py-20"
-    >
-      <Spinner />
-      <span className="sr-only">{t("loading")}</span>
-    </div>
-  );
-}
+// Segment marker for Next instant loading + prefetch (#1092); UI lives in route-loading.
+export { default } from "@/components/ui/route-loading";

--- a/apps/web/src/app/[locale]/(platform)/leaderboard/loading.tsx
+++ b/apps/web/src/app/[locale]/(platform)/leaderboard/loading.tsx
@@ -1,17 +1,2 @@
-import { getTranslations } from "next-intl/server";
-import { Spinner } from "@/components/ui/spinner";
-
-// Route loading state (#1092) — see (platform)/loading.tsx.
-export default async function LeaderboardLoading() {
-  const t = await getTranslations("common");
-  return (
-    <div
-      role="status"
-      aria-busy="true"
-      className="flex items-center justify-center py-20"
-    >
-      <Spinner />
-      <span className="sr-only">{t("loading")}</span>
-    </div>
-  );
-}
+// Segment marker for Next instant loading + prefetch (#1092); UI lives in route-loading.
+export { default } from "@/components/ui/route-loading";

--- a/apps/web/src/app/[locale]/(platform)/loading.tsx
+++ b/apps/web/src/app/[locale]/(platform)/loading.tsx
@@ -1,19 +1,2 @@
-import { getTranslations } from "next-intl/server";
-import { Spinner } from "@/components/ui/spinner";
-
-// Route loading state (#1092) — gives the router a prefetchable shell so
-// navigation commits instantly instead of freezing on the previous page.
-// Owner decision: the app's standard spinner, not skeletons.
-export default async function PlatformLoading() {
-  const t = await getTranslations("common");
-  return (
-    <div
-      role="status"
-      aria-busy="true"
-      className="flex items-center justify-center py-20"
-    >
-      <Spinner />
-      <span className="sr-only">{t("loading")}</span>
-    </div>
-  );
-}
+// Segment marker for Next instant loading + prefetch (#1092); UI lives in route-loading.
+export { default } from "@/components/ui/route-loading";

--- a/apps/web/src/app/[locale]/(platform)/profile/loading.tsx
+++ b/apps/web/src/app/[locale]/(platform)/profile/loading.tsx
@@ -1,17 +1,2 @@
-import { getTranslations } from "next-intl/server";
-import { Spinner } from "@/components/ui/spinner";
-
-// Route loading state (#1092) — see (platform)/loading.tsx.
-export default async function ProfileLoading() {
-  const t = await getTranslations("common");
-  return (
-    <div
-      role="status"
-      aria-busy="true"
-      className="flex items-center justify-center py-20"
-    >
-      <Spinner />
-      <span className="sr-only">{t("loading")}</span>
-    </div>
-  );
-}
+// Segment marker for Next instant loading + prefetch (#1092); UI lives in route-loading.
+export { default } from "@/components/ui/route-loading";

--- a/apps/web/src/components/ui/route-loading.tsx
+++ b/apps/web/src/components/ui/route-loading.tsx
@@ -1,0 +1,21 @@
+import { getTranslations } from "next-intl/server";
+import { Spinner } from "@/components/ui/spinner";
+
+// The shared route loading state (#1092) — every loading.tsx re-exports this
+// as its default. The file-per-route boilerplate exists only because Next
+// keys instant loading states (and dynamic-route prefetching) on a loading.tsx
+// being physically present in the segment; the UI is one pattern on purpose.
+// Owner decision: the app's standard spinner, not skeletons.
+export default async function RouteLoading() {
+  const t = await getTranslations("common");
+  return (
+    <div
+      role="status"
+      aria-busy="true"
+      className="flex items-center justify-center py-20"
+    >
+      <Spinner />
+      <span className="sr-only">{t("loading")}</span>
+    </div>
+  );
+}


### PR DESCRIPTION
Claude's #1100 review flagged the 10 loading.tsx files as identical modulo function name. The per-segment file is only Next's marker for instant loading states + dynamic-route prefetch, so the UI moves to a single RouteLoading that each file re-exports as default — ~140 lines gone, no drift surface. No behavior change.