### PR TITLE
feat(qa): add the academy-qa skill — periodic two-lens platform audit

### DIFF
--- a/.claude/skills/academy-qa/SKILL.md
+++ b/.claude/skills/academy-qa/SKILL.md
@@ -1,0 +1,166 @@
+---
+name: academy-qa
+description: Periodic quality audit of the Superteam Academy platform through two lenses at once — a learner using the app (UX friction + content quality) and a hiring company deciding whether an Academy credential is real evidence a candidate knows Solana. Produces a dated, prioritised report in docs/qa-reports/ that diffs against the previous run. Use this whenever the user asks to QA/audit/review the platform or the courses, wants student or learner feedback, questions whether the credentials are credible or gameable, asks "is this good enough to show an employer", wants to know what to improve next, or asks for a periodic/quarterly platform review — even if they don't say the words "QA" or "audit".
+user-invocable: true
+---
+
+# Academy QA — two lenses, one report
+
+## Why two lenses
+
+The platform makes two promises, to two different parties, and it only works if
+both hold:
+
+- **To the learner**: spend your evenings here and you will actually learn to
+  build on Solana.
+- **To the employer**: this credential means the person holding it knows what it
+  says they know.
+
+These fail independently and for different reasons. A course can be delightful
+to use and still be worthless as hiring signal (everything guessable, nothing
+verifiable). A course can be rigorous and still lose every learner at signup.
+Auditing only one lens is how a platform ends up excellent at the thing nobody
+was complaining about.
+
+So every run produces findings from both, in one report, prioritised together —
+because engineering time is one budget.
+
+## Run it in this order
+
+1. **Read the last report** — `ls docs/qa-reports/` and read the most recent.
+   You are continuing an argument, not starting one. It tells you what was
+   already reported (don't re-litigate), what was promised, and what to rotate
+   into scope this time.
+2. **Pick an evidence mode** (below). Prefer a running app.
+3. **Choose scope** — which courses and which flows. With few courses, cover
+   all; as the catalogue grows, cover the entry courses every time and rotate
+   the rest, using the last report to see what's overdue.
+4. **Run the student pass** → read `student-pass.md`.
+5. **Run the employer pass** → read `employer-pass.md`.
+6. **Write the report** → use `report-template.md`, save to
+   `docs/qa-reports/YYYY-MM-DD.md`.
+7. **Offer the follow-through** — ask whether to open issues or PRs for the P0/P1
+   findings. A report nobody acts on was a waste of everyone's time.
+
+`platform-map.md` says where everything lives — read it early so you spend your
+time evaluating rather than rediscovering the codebase.
+
+## Evidence modes
+
+Pick the richest one available and say in the report which you used, because it
+bounds what the findings are worth.
+
+- **A — Running app (best).** Local dev (`pnpm dev` in `apps/web`) or a preview
+  deployment. Drive it with Playwright (Chromium is preinstalled; see
+  `platform-map.md`). This is the only mode that catches what learners actually
+  hit: layout breakage, dead ends, slow pages, broken flows.
+- **B — Production, read-only.** Real content, real data, real performance. Good
+  for UX truth when you can't run the app.
+- **C — Code + content bundle only.** Always possible, needs no credentials.
+  Content quality, wording, i18n coverage, and much of the cheat-resistance
+  surface are all auditable statically by reading what the server sends.
+
+**Safety line.** Against production, behave like a learner and nothing more:
+browse, and if you sign in, use a dedicated test account. Never run admin
+actions, never trigger on-chain writes (they cost real SOL and are often
+irreversible), never touch another user's data, and never write to the
+production database. Anything that mutates state — completing lessons via the
+API, testing bypasses, minting — belongs in local or a preview environment.
+If you can only reach production, say so and mark those checks "not verified"
+rather than doing them anyway.
+
+## What makes a finding worth writing down
+
+The failure mode of a platform audit is a long list of things that could be said
+about any website. "Improve onboarding", "add more tests", "consider better
+error messages" — all true, all useless, all indistinguishable from having done
+no work. Aim for the opposite: a short list a developer can act on this
+afternoon without asking you a single follow-up question.
+
+Every finding carries four things:
+
+- **Evidence** — where you saw it. A URL, a `file.ts:42`, a lesson slug, a
+  quoted sentence from the content, a screenshot. If you can't point at it, you
+  didn't find it.
+- **The user consequence** — what a real person experiences. Not "the button is
+  misaligned" but "on a 375px phone the Enrol button sits under the fold, so a
+  learner who taps through from the QR code sees a course page with no obvious
+  way in".
+- **Severity** — P0/P1/P2/P3, defined below.
+- **A concrete fix** — the change you'd make. Naming the file is better than
+  naming the feeling.
+
+Two habits that keep a report honest:
+
+- **Quote the content you're critiquing.** "Lesson 3's quiz is weak" is an
+  opinion; quoting the question and showing that the correct answer is the only
+  one that is grammatically plausible is a finding.
+- **Keep a "not checked" list.** Every audit has gaps — no test wallet, couldn't
+  run the app, didn't cover the community forum. Writing them down is what makes
+  the rest of the report trustworthy, and it seeds the next run's scope.
+
+Prefer eight sharp findings to forty mushy ones. If a section has nothing real
+in it, say so — "no P0/P1 issues found in the enrolment flow" is a genuine
+result and reads as confidence, not laziness.
+
+## Severity
+
+Severity is about consequence, not effort:
+
+- **P0** — A learner is blocked, or the credential's meaning is broken. Enrolment
+  fails; lessons can be completed without doing them; a credential can be
+  obtained by someone who knows nothing; content teaches something factually
+  wrong about Solana.
+- **P1** — Materially loses learners or materially weakens the hiring signal.
+  A confusing signup that costs most drop-offs; quizzes passable by guessing;
+  a credential an employer can't verify; badly machine-translated PT-BR on the
+  primary audience's happy path.
+- **P2** — Real friction or a real weakness, survivable. Confusing copy, a rough
+  mobile layout, a shallow module, a missing "what next".
+- **P3** — Polish. Worth listing so it can be batched.
+
+Note who each finding hits — all learners, mobile only, PT-BR speakers, wallet
+users vs email users. A P2 that hits everyone often beats a P1 that hits a
+sliver, and the report should let a reader make that call.
+
+## The scorecard
+
+The report opens with a small scorecard, 1–5 per dimension, because the value of
+a periodic audit is the _trend_: this only means something when compared with
+the previous run. Score honestly and hold the anchors steady between runs —
+a scorecard that drifts upward because the auditor got friendlier measures
+nothing.
+
+Anchors: **1** broken · **2** significant gaps · **3** works, unremarkable ·
+**4** good, minor gaps · **5** genuinely strong.
+
+**Learner:** onboarding clarity · lesson quality · content accuracy & currency ·
+localisation quality · mobile experience · reasons to come back
+**Employer:** verifiability · cheat resistance · job relevance · depth &
+coverage · currency of tooling
+
+Every score needs one sentence of justification and, if it moved, why. A score
+with no sentence is a number someone made up.
+
+## Both bottom lines
+
+Findings are inputs; a decision is the output. The report states two verdicts
+plainly, each with the one change that would most move it:
+
+- **Learner**: would you recommend this to a friend starting Solana today?
+  _Yes / Yes, with caveats / Not yet_ — and the caveat that matters most.
+- **Employer**: would you accept this credential in a hiring process?
+  _Strong signal / Weak signal / Screening only / Not acceptable_ — and what
+  would have to be true to move up one tier.
+
+Being straight here is the most useful thing in the document. A hedged verdict
+protects nobody and tells the team nothing.
+
+## Delivering it
+
+Save to `docs/qa-reports/YYYY-MM-DD.md`, then give the user, in chat: the two
+verdicts, the scorecard deltas, and the P0/P1 list — enough to act on without
+opening the file. Offer to turn the top findings into issues or PRs.
+
+If the platform has genuinely improved since the last run, say which findings
+were fixed. Teams need to see the loop close.

--- a/.claude/skills/academy-qa/employer-pass.md
+++ b/.claude/skills/academy-qa/employer-pass.md
@@ -1,0 +1,128 @@
+# The employer pass
+
+You are a hiring engineer at a company that builds on Solana. A candidate's CV
+links a Superteam Academy credential. You have to decide what it is worth —
+whether it moves them forward, and whether you'd defend that decision to your
+team after a bad hire.
+
+This is not a security review. You are not hunting exploits; you are asking the
+question every credential must survive: **could someone hold this without
+knowing the material?** Everything below serves that.
+
+Note the asymmetry that makes this lens uncomfortable and necessary: the
+platform's incentive is for learners to succeed, and an assessment that
+everybody passes is indistinguishable from a certificate mill from the outside.
+Being hard here is the only way the credential ends up meaning something.
+
+## Rules of engagement
+
+Everything that mutates state — completing lessons through the API, probing
+bypasses, minting — happens on **local or a preview deployment**, never
+production. Against production you read, and nothing else. If you can only reach
+production, mark those checks "not verified" and say so rather than doing them
+anyway; a report with honest gaps beats a report that broke something.
+
+## The six questions
+
+### 1. What exactly is being claimed?
+
+Read the credential as an outsider: its on-chain metadata, its public page, its
+name. Does it say what was completed, when, and by whom? Vague claims fail in a
+specific way — "Solana Developer" implies far more than "completed a 40-minute
+micro-course", and the gap between the two is where an employer's trust gets
+spent. Write down, in one sentence, what this credential _actually_ certifies.
+Everything after this is measured against that sentence.
+
+### 2. Can I verify it independently?
+
+The whole point of putting credentials on-chain is that an employer shouldn't
+have to take the platform's word for it. Test that promise: starting from only
+what a candidate would send you (an address, a link, a screenshot), can you
+confirm the credential is genuine, issued by the Academy, for that course, on
+that date — without logging in, and without trusting a page the candidate could
+have faked?
+
+Then the identity join, which is where these systems usually leak: the
+credential binds to a **wallet**, but you're hiring a **person**. Can the
+candidate demonstrate they control it? Could they have been handed it? Note also
+that the credential is soulbound (non-transferable) — that is a real strength
+over a PDF certificate, and the report should say so plainly.
+
+### 3. Could someone get it without knowing the material?
+
+This is the heart of the pass. Work through it concretely:
+
+- **Do the answers reach the browser?** The content bundle carries a `correct`
+  flag on quiz options and `solution` + `tests` on code blocks. Whether those
+  are stripped before the lesson payload is sent to the client is a question of
+  fact, not of intent: check the actual network response (and the RSC payload,
+  not just the visible DOM) for a lesson containing a quiz and a challenge. If
+  a learner with devtools can read the answers, the assessment measures
+  curiosity, not knowledge.
+- **Where is grading done?** Client-side grading can be bypassed by anyone
+  willing to edit a request. Server-side grading is the only kind that counts.
+- **Can completion be written directly?** On local, try marking a lesson
+  complete through the API without doing the work, and see what stops you.
+  Whatever the answer, that's a headline finding either way.
+- **What do unlimited retries imply?** A quiz with instant feedback, no attempt
+  limit, and no question pool is passable by anyone patient enough to cycle
+  options. That is not cheating — it's the design permitting a pass without
+  knowledge, which is the same outcome.
+- **Is the credential gated on genuine completion?** Trace the path from
+  finishing lessons to holding the NFT and find what would have to be true for
+  someone to short-circuit it.
+- **Could the same person hold several accounts?** More relevant to leaderboards
+  and referral rewards than to the credential itself, but note it where the
+  platform pays out.
+
+### 4. Does it map to work I'd actually pay for?
+
+List what a holder demonstrably did, then compare against what a junior Solana
+role requires day one: reading and writing program code, understanding accounts
+and PDAs, wallets and transactions, testing, and shipping to a cluster. Where
+does the coverage genuinely overlap, and where would you still be guessing at
+interview time? Be fair about scale — a short micro-course can prove real
+familiarity and cannot prove engineering judgement, and saying so precisely is
+more useful than either inflating or dismissing it.
+
+### 5. Does it separate strong candidates from weak ones?
+
+A credential everyone earns carries no information. Look for whether the
+assessments have any teeth: are there questions a superficial learner would get
+wrong? Is there anything a candidate could _fail_? If the platform records
+attempts or scores, does an employer ever see them, or only the binary pass? A
+credential that surfaced "completed, 3 attempts, no hints" would be worth
+strictly more than one that surfaced "completed" — note it if the data exists
+but isn't exposed.
+
+### 6. Is it current?
+
+Solana tooling moves fast. A credential that certifies deprecated patterns is
+worse than none, because it produces confident candidates who are behind. Check
+the material against what's current (Anchor version, web3.js vs Kit, tooling)
+and flag anything that would make a candidate look dated in a technical screen.
+
+## Credit what's strong
+
+An audit that only lists problems reads as uncalibrated and gets dismissed
+wholesale. Where the platform genuinely beats the alternatives — soulbound and
+non-transferable, publicly verifiable on-chain, server-gated completion, real
+code execution rather than multiple choice alone — say so, in the same specific
+language you use for the failures. It also tells the team what not to break.
+
+## The verdict
+
+State one tier plainly, and the single change that would most move it up:
+
+- **Strong signal** — I'd fast-track an interview. Verifiable, hard to fake,
+  materially job-relevant.
+- **Weak signal** — A tiebreaker between similar CVs. Real but thin, or fakeable
+  with modest effort.
+- **Screening only** — Evidence of interest and follow-through, not of skill.
+  Useful for a first funnel; proves nothing technical.
+- **Not acceptable** — I would not let this influence a hiring decision:
+  unverifiable, trivially obtainable, or certifying wrong material.
+
+Then finish the sentence that makes the verdict actionable: _"To move from X to
+Y, the platform would need to \_\_\_."_ One change, the highest-leverage one. That
+sentence is usually the most valuable line in the whole report.

--- a/.claude/skills/academy-qa/platform-map.md
+++ b/.claude/skills/academy-qa/platform-map.md
@@ -1,0 +1,122 @@
+# Platform map — where to look
+
+Read this before auditing so you spend the run evaluating rather than
+rediscovering the repo. Treat every path as a starting point, not gospel: the
+platform moves, and part of each run's value is noticing when this map has gone
+stale (say so in the report if it has).
+
+## Learner-facing routes
+
+All app routes are locale-prefixed (`/en`, `/pt-BR`, `/es`) under
+`apps/web/src/app/[locale]/`.
+
+| Surface           | Route                             | Notes                                               |
+| ----------------- | --------------------------------- | --------------------------------------------------- |
+| Landing           | `/`                               | Hero CTA resolves via `lib/courses/entry-lesson.ts` |
+| Onboarding funnel | `/start`                          | Segment/goal intake                                 |
+| Catalogue         | `/courses`                        | Listing, gated (see visibility below)               |
+| Course page       | `/courses/[slug]`                 | Enrol lives here                                    |
+| Lesson            | `/courses/[slug]/lessons/[id]`    | Prose, quizzes, code challenges                     |
+| Dashboard         | `/dashboard`                      | Continue, streaks, quests                           |
+| Leaderboard       | `/leaderboard`                    | League / Global / Referrals boards                  |
+| Credentials       | `/certificates/...`               | The employer-facing artefact                        |
+| Profile           | `/profile`, `/profile/[username]` | Public profile is the shareable one                 |
+| Community         | `/community`                      | Forum                                               |
+| Review            | `/review`                         | Spaced repetition                                   |
+| Settings          | `/settings`                       | Account, links, email consent                       |
+
+Admin (`/admin`) is out of scope for QA runs — it is not a learner or employer
+surface and it triggers on-chain writes.
+
+## Content
+
+Courses ship as a **committed bundle**, compiled from the `solanabr/academy-courses`
+repo pinned by `apps/web/content.lock`:
+
+- `apps/web/src/content/generated/courses.json` — courses, modules, lesson refs
+- `apps/web/src/content/generated/lessons.json` — lesson bodies and blocks
+- `apps/web/src/content/generated/paths.json` — learning paths
+- Read them directly with `node -e` for content audits; do not hand-edit.
+
+Lesson **block types** currently in the bundle: `prose`, `quiz`, `code`.
+
+Shapes worth knowing (`apps/web/src/lib/content/project.ts` is the projector):
+
+- **quiz** → `questions[]` with `prompt`, `options[]`, `multiSelect`,
+  `explanation`. Each option carries a `correct` boolean in the bundle.
+- **code** → `starter`, `solution`, `tests`, `hints`, `language`, `buildType`,
+  `deployable`.
+
+Because the bundle holds answers and solutions, "what reaches the browser" is a
+first-order question for the employer pass — see `employer-pass.md`. The
+projector has both a full (`projectLesson`) and a summary
+(`projectLessonSummary`) shape; which one a given route uses is the thing to
+check, not assume.
+
+## Visibility gates
+
+A course renders publicly only when it is **synced + active** on-chain
+(`lib/content/deployments.ts` → `isSynced`). Beyond that,
+`lib/courses/unlisted.ts` holds courses that are reachable by direct link but
+hidden from the catalogue, landing count, sitemap, recommendations, and the
+landing hero. When a course seems "missing", check both before filing it.
+
+## Server routes that decide what a credential means
+
+Full table in `apps/web/src/app/api/CLAUDE.md`. The ones that matter here:
+
+| Route                             | Why it matters                                                                                                                                            |
+| --------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `/api/lessons/complete`           | The completion write: XP award, auto-finalize, achievements. This is where completion is _gated_ — challenge validation alone does not complete a lesson. |
+| `/api/lessons/validate-challenge` | Server-side challenge check (UX pass/fail)                                                                                                                |
+| `/api/ai/partner/verify`          | Server-side grading of comprehension checks                                                                                                               |
+| `/api/certificates/mint`          | Credential mint + retry queue                                                                                                                             |
+| `/api/certificates/metadata`      | The metadata an explorer/employer resolves                                                                                                                |
+| `/api/enroll/sponsor`             | Platform-sponsored enrolment (learner is read from the session, never the body)                                                                           |
+
+Server-side limits that already exist (verify they hold rather than
+re-proposing them): max 100 XP per lesson completion, max 2000 per generic
+award; level = `floor(sqrt(totalXP / 100))`.
+
+## On-chain layer
+
+XP is a soulbound Token-2022 balance; credentials are Metaplex Core NFTs
+(soulbound via a permanent freeze delegate); enrolment and lesson completion are
+PDAs. Credential metadata is pinned to Arweave via Irys when configured. For the
+employer pass, the relevant question is what an outsider can independently
+verify from an address — see `docs/ARCHITECTURE.md` for the account model.
+
+## Code execution sandbox
+
+Learner code runs in the browser via `new Function()` with a blocked-pattern
+list (`eval`, `Function`, `document`, `window`, `fetch`, `XMLHttpRequest`,
+`import()`), a mock console, no DOM, no network. Relevant to the employer pass
+in one direction only: whether passing a challenge means anything, not whether
+the sandbox is escapable (that's a security review, not a QA run).
+
+## Localisation
+
+Three locales — `en`, `es`, `pt-BR` — in `apps/web/src/messages/`. All three
+files must carry identical key structures or the app throws
+`MISSING_MESSAGE` at runtime. The primary audience is Brazilian, so PT-BR is a
+happy path, not a translation afterthought: audit it as a first-class
+experience, including the course content itself.
+
+## Running the app
+
+```bash
+cd apps/web && pnpm dev        # needs env vars; see apps/web/CLAUDE.md
+```
+
+Chromium is preinstalled for Playwright (`PLAYWRIGHT_BROWSERS_PATH=/opt/pw-browsers`);
+never run `playwright install`. The repo's `run` skill knows how to launch the
+app if you need it. Test the small viewport (≈375px) explicitly — a large share
+of the audience arrives on a phone, often from a QR code at an event.
+
+## Useful existing checks
+
+- `/api/health/schema` — reports DB objects the current release expects but that
+  are missing from the database. A 503 here explains a surprising number of
+  "feature looks broken" symptoms and is worth hitting before filing them.
+- `pnpm test` in `apps/web` — the suite is large and green; if you touch code
+  while investigating, keep it that way.

--- a/.claude/skills/academy-qa/report-template.md
+++ b/.claude/skills/academy-qa/report-template.md
@@ -1,0 +1,130 @@
+# Report template
+
+Save as `docs/qa-reports/YYYY-MM-DD.md`. Keep the section order — the value of a
+periodic report is that two runs can be read side by side, and a reader should
+be able to find the same thing in the same place every time.
+
+Adapt within sections freely. If a section genuinely has nothing in it, write
+"No P0/P1 findings this run" rather than deleting it; an absent section is
+ambiguous (did you check?), an empty one is a result.
+
+---
+
+```markdown
+# Academy QA — YYYY-MM-DD
+
+**Evidence mode:** Running app (local) · Production (read-only) · Static
+**Scope:** courses/flows covered this run
+**Persona:** e.g. Ana — front-end dev, PT-BR, 375px Android
+**Previous report:** YYYY-MM-DD (or "first run")
+
+## Bottom line
+
+**Learner — would I recommend this to a friend starting Solana today?**
+Yes / Yes, with caveats / Not yet — one sentence saying why, naming the
+caveat that matters most.
+
+**Employer — would I accept this credential in a hiring process?**
+Strong signal / Weak signal / Screening only / Not acceptable — one sentence.
+To move up one tier, the platform would need to \_\_\_.
+
+## Scorecard
+
+| Dimension                   | Score | Δ   | Why          |
+| --------------------------- | ----- | --- | ------------ |
+| **Learner**                 |       |     |              |
+| Onboarding clarity          | 3     | +1  | one sentence |
+| Lesson quality              |       |     |              |
+| Content accuracy & currency |       |     |              |
+| Localisation quality        |       |     |              |
+| Mobile experience           |       |     |              |
+| Reasons to come back        |       |     |              |
+| **Employer**                |       |     |              |
+| Verifiability               |       |     |              |
+| Cheat resistance            |       |     |              |
+| Job relevance               |       |     |              |
+| Depth & coverage            |       |     |              |
+| Currency of tooling         |       |     |              |
+
+1 broken · 2 significant gaps · 3 works, unremarkable · 4 good, minor gaps ·
+5 genuinely strong
+
+## Since the last report
+
+**Fixed:** findings from last run that are now resolved (say how you confirmed)
+**Still open:** carried forward, with any change in severity
+**Regressed:** things that were fine and no longer are
+
+_(First run: "No previous report — this run sets the baseline.")_
+
+## Priority list
+
+Both lenses, ranked together — engineering time is one budget.
+
+| #   | Severity | Lens     | Finding  | Who it hits    |
+| --- | -------- | -------- | -------- | -------------- |
+| 1   | P0       | Employer | one line | all candidates |
+| 2   | P1       | Learner  | one line | mobile, PT-BR  |
+
+## Learner findings
+
+Grouped by journey stage. Format each as:
+
+### [Stage] Short title — P1
+
+**What happens:** what a learner experiences, in their terms.
+**Evidence:** URL, `file.ts:42`, lesson slug, quoted content, screenshot.
+**Why it matters:** consequence — drop-off, confusion, lost work.
+**Fix:** the specific change.
+
+**Quit point:** the moment a real learner would most likely stop, and why.
+
+## Employer findings
+
+Same format, grouped by the six questions (what's claimed · verifiability ·
+cheat resistance · job relevance · discrimination · currency).
+
+Include the one-sentence statement of what the credential actually certifies.
+
+## What's strong
+
+Specific things worth protecting — named as precisely as the problems, so the
+team knows what not to break.
+
+## Not checked
+
+What this run could not cover and why (no test wallet, couldn't run the app,
+forum out of scope). This is what makes the rest trustworthy.
+
+## Next run
+
+Scope to rotate in, plus anything this run flagged as worth re-testing once
+fixed.
+```
+
+---
+
+## A worked finding, for calibration
+
+The difference between a report that gets acted on and one that gets skimmed is
+almost entirely in this level of specificity.
+
+**Too vague — don't do this:**
+
+> The quizzes could be more challenging and better test understanding.
+
+**Sharp — do this:**
+
+> ### [Content] Quiz answers are guessable without reading the lesson — P1
+>
+> **What happens:** In `solana-speedrun` lesson 2, the question "What is a
+> keypair?" offers four options where the correct one is the only one longer
+> than four words and the only one that isn't a joke ("a pair of shoes").
+> A learner can score 100% without opening the lesson.
+> **Evidence:** `content/generated/lessons.json`, lesson `lesson-keypairs`,
+> quiz block `q1`; quoted above.
+> **Why it matters:** This is the assessment the credential rests on. An
+> employer who spot-checks it stops trusting the rest.
+> **Fix:** Replace joke distractors with plausible near-misses (e.g. "a public
+> key derived from a seed phrase") so passing requires the distinction the
+> lesson teaches.

--- a/.claude/skills/academy-qa/student-pass.md
+++ b/.claude/skills/academy-qa/student-pass.md
@@ -1,0 +1,108 @@
+# The student pass
+
+You are not inspecting a website. You are a specific person trying to learn
+Solana on a Tuesday night, and you will quit if this is annoying. Everything
+below flows from taking that seriously: findings that come from walking the
+journey in order are the ones that turn out to be real, because friction
+compounds — the signup that is merely mildly confusing becomes fatal when it
+lands right after a lesson that already felt like work.
+
+## Pick a persona, and say which one
+
+Vague personas produce vague feedback ("the UI could be clearer"). Adopt one
+concretely, name it in the report, and rotate across runs so the same blind
+spots don't survive forever:
+
+- **Ana, 24, front-end dev in Recife.** Ships React for a living, has never
+  owned a wallet, heard Solana pays well. Reads English but thinks in
+  Portuguese. On a mid-range Android, on data.
+- **Bruno, 31, backend/Java.** Comfortable with systems, sceptical of crypto,
+  wants to know if this is real engineering before investing weekends. Desktop.
+- **Carla, 19, student at an event booth.** Just scanned a QR code with people
+  waiting behind her. Has four minutes and a phone with 20% battery.
+
+Default to a **375px viewport** and **PT-BR** unless the persona says otherwise.
+That is the platform's centre of gravity, and bugs that only appear there are
+exactly the ones a desktop-English audit never sees.
+
+## Walk the journey in order
+
+Note where you'd quit if you weren't being paid to continue. That moment is
+usually the most valuable finding in the run.
+
+**1 — Cold arrival (first 60 seconds).** Land on `/` as an anonymous visitor.
+Without scrolling: can you tell what this is, who it's for, what you'd get, and
+what it costs? Is the primary action obvious, and does it go somewhere sensible?
+A landing page that requires scrolling to answer "what is this" loses the
+booth persona entirely.
+
+**2 — Starting to learn.** Follow the main CTA. How many taps until you are
+learning something, rather than reading about learning? Are you asked to sign
+up, connect a wallet, or make choices before you've been given any value? Any
+demand made before the first moment of value is worth flagging with the number
+of taps that precede it.
+
+**3 — The first lesson.** Read it as a learner, not a reviewer. Does it teach or
+merely assert? Is the first code challenge doable by someone who just read the
+prose above it, or does it assume a leap? Try to fail: submit something wrong,
+submit empty, submit almost-right. Is the feedback specific enough to learn
+from, or is it a red X? Do hints help or spoil? Does the editor work on a phone
+— can you type, scroll, see the output?
+
+**4 — The signup moment.** When you're finally asked to sign in, does it feel
+earned? Try more than one path (email/embedded wallet, external wallet, Google)
+and check the thing that actually matters: **does the work you already did
+survive?** Progress silently lost at signup is a P0, because the learner
+experiences it as the platform taking something from them.
+
+**5 — Finishing something.** Complete a lesson and, if scope allows, a whole
+course. Does the reward land (XP, streak, achievement, credential) and is it
+legible — do you know what you just got and what it's worth? At the end of a
+course, do you know what to do next? A course that ends in a void wastes the
+motivation it just built.
+
+**6 — Coming back.** Look at what would pull you back tomorrow: streaks, daily
+quests, review, emails, the dashboard's "continue". Is the next step obvious
+after a week away, or does returning mean re-orienting from scratch?
+
+Along the way, keep an eye on the ambient stuff learners feel but rarely report:
+page speed on a phone, layout breaking at 375px, hit targets, error states that
+say something useful, back-button behaviour, and whether anything is only
+reachable by hover.
+
+## Judge the content, separately
+
+UX and content fail differently, and a beautiful shell around thin material is a
+specific, common, expensive failure. Read the actual lessons — from the bundle
+if you can't run the app — and ask:
+
+- **Is it correct?** Anything factually wrong about Solana is P0: it teaches a
+  falsehood and the credential then certifies it.
+- **Is it current?** Solana's tooling moves fast. Deprecated APIs, old Anchor
+  patterns, or a superseded web3.js style are worse than nothing — a learner who
+  brings them to an interview looks out of date because of you.
+- **Does it build understanding?** Explanation before jargon, concrete before
+  abstract, and a reason to care before the mechanism. Prose that lists facts a
+  learner could have read in the docs is a missed opportunity, not a lesson.
+- **Is the difficulty curve honest?** Find the step where the gradient spikes —
+  the point where a learner who understood everything so far would suddenly be
+  stuck. That step is where drop-off lives.
+- **Are the quizzes worth passing?** Check specifically for the classic
+  giveaways: the correct option is the longest, or the only grammatical one, or
+  the only one that isn't obviously silly. Could you pass by reading the
+  question alone, without the lesson? Quote the question when you flag it.
+- **Do the challenges teach or just check?** A challenge that can be solved by
+  pattern-matching the starter code without understanding it is decoration.
+- **Is the Portuguese and Spanish good?** Not merely present. Machine-translated
+  technical content reads as unserious to exactly the audience the platform is
+  for, and a bad translation of a good lesson is a bad lesson. Quote a sentence
+  when it's off. Also check that the three locale files agree — a missing key
+  throws at runtime.
+
+## Writing it up
+
+Group findings by journey stage, because that's how a fix gets scoped, and lead
+each with what the learner experiences. Include the quit-point explicitly.
+Where you can, say roughly how many learners a finding touches (everyone /
+mobile only / PT-BR only / wallet users only) — that's what turns a list into a
+priority order.

--- a/docs/qa-reports/2026-08-19.md
+++ b/docs/qa-reports/2026-08-19.md
@@ -1,0 +1,301 @@
+# Academy QA — 2026-08-19
+
+**Evidence mode:** C — code + content bundle. Production is unreachable from the
+audit sandbox (proxy 403) and a local run with placeholder credentials would
+gate every course out through the on-chain sync check, manufacturing false
+findings. Every runtime/UX claim below is therefore marked unverified, and the
+"Not checked" section is unusually large. Content, assessment design, and
+cheat-resistance are fully auditable in this mode and are where this run's
+weight sits.
+**Scope:** all 3 courses, all 20 lessons, all 47 quiz questions, all 4 code
+challenges, the completion/grading path, the credential surface, i18n.
+**Persona:** Ana — front-end dev in Recife, PT-BR, arrives on mobile.
+**Previous report:** none — this run sets the baseline.
+
+## Bottom line
+
+**Learner — would I recommend this to a friend starting Solana today?**
+**Yes, with caveats.** The writing is genuinely good: native Brazilian
+Portuguese, concrete analogies (PIX as the speed benchmark), real images,
+sensible pacing. The caveat that matters: a Portuguese speaker who finishes the
+funnel has spent about ten minutes and has nowhere to go next in their own
+language — the only substantial course is English-only.
+
+**Employer — would I accept this credential in a hiring process?**
+**Screening only**, for the credential most holders will have. The Speedrun and
+Pílula courses certify reading ~2,500 words of thesis content and answering
+open-book, three-option multiple choice. That is evidence of interest and
+follow-through, not of skill. The `btc-to-sol-evolution` credential is a
+different animal — 15 lessons, ~58,000 words, and four graded challenges
+including two Anchor programs that are actually compiled against test suites —
+and I would treat that one as a weak-to-moderate positive signal.
+
+To move up a tier, the platform would need to **require at least one
+server-graded code challenge for any credential-bearing course.** The machinery
+already exists and works; the entry courses simply don't use it.
+
+## Scorecard
+
+| Dimension                   | Score | Δ   | Why                                                                                                                                                                            |
+| --------------------------- | ----- | --- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Learner**                 |       |     |                                                                                                                                                                                |
+| Onboarding clarity          | 3     | —   | Funnel is coherent in code (hero → Speedrun lesson 1, anonymous-first). Provisional: not verified in a browser.                                                                |
+| Lesson quality              | 4     | —   | Strong writing, concrete analogies, images, stepper quizzes with per-option feedback. Docked because the entry course explains _why Solana matters_, not _how to build_.       |
+| Content accuracy & currency | 4     | —   | Nothing factually wrong spotted; Anchor idioms are current. Not exhaustively fact-checked, and several claims are dated (Dec 2025) so they will age.                           |
+| Localisation quality        | 3     | —   | UI parity is exemplary (1,420 keys × 3 locales, zero drift). Course _content_ is monolingual per course, so ES learners get Spanish chrome around Portuguese/English material. |
+| Mobile experience           | —     | —   | Not scored: no live run this cycle.                                                                                                                                            |
+| Reasons to come back        | 3     | —   | Streaks, quests, review, referrals all exist in code; unverified live. The PT-BR content dead end works against all of them.                                                   |
+| **Employer**                |       |     |                                                                                                                                                                                |
+| Verifiability               | 4     | —   | Public certificate page, on-chain explorer link, soulbound. Docked for the `is_public` dependency and an unconfirmed cluster.                                                  |
+| Cheat resistance            | 2     | —   | Completion grading is genuinely server-side and deterministic — but in the funnel courses it grades open-book multiple choice with unlimited retries.                          |
+| Job relevance               | 2     | —   | Split: 2 for the funnel courses (zero code), 4 for `btc-to-sol-evolution`. Scored on the credential most holders will hold.                                                    |
+| Depth & coverage            | 3     | —   | One genuinely deep course, two very short ones, three total.                                                                                                                   |
+| Currency of tooling         | 4     | —   | `anchor_lang::prelude::*`, current Anchor patterns, buildable Rust compiled server-side.                                                                                       |
+
+1 broken · 2 significant gaps · 3 works, unremarkable · 4 good, minor gaps ·
+5 genuinely strong
+
+## Since the last report
+
+No previous report — this run sets the baseline.
+
+## Priority list
+
+| #   | Severity | Lens     | Finding                                                                               | Who it hits                                  |
+| --- | -------- | -------- | ------------------------------------------------------------------------------------- | -------------------------------------------- |
+| 1   | P1       | Employer | Funnel-course credentials rest entirely on open-book multiple choice — no graded code | Every credential holder from Speedrun/Pílula |
+| 2   | P1       | Employer | Quizzes are structurally guessable: 68% longest-option, 100% carry a payload tell     | All quizzes, all courses                     |
+| 3   | P1       | Learner  | PT-BR dead end: nothing substantial to continue to after the 10-minute funnel         | The primary (Brazilian) audience             |
+| 4   | P2       | Employer | Credential verifiability silently breaks if the holder sets their profile private     | Candidates sharing links                     |
+| 5   | P2       | Employer | Cluster unconfirmed — devnet credentials would be materially weaker evidence          | All credentials (needs confirmation)         |
+| 6   | P3       | Learner  | All 47 questions are three-option single-select — format monotony                     | All learners                                 |
+
+## Learner findings
+
+### [Content] The Portuguese path ends after ten minutes — P1
+
+**What happens:** Ana lands on the homepage, follows "Start building" into the
+Solana Speedrun, and finishes four lessons totalling ~2,100 words. She's engaged
+and wants more. The catalogue's only substantial course,
+`btc-to-sol-evolution`, is written entirely in English — 15 lessons, ~58,000
+words, all of it. Her options are to read a book's worth of technical English or
+to stop.
+
+**Evidence:** `content/generated/lessons.json` — `lesson-ssr-*` (4 lessons,
+~2,100 words, PT-BR), `lesson-psp-*` (1 lesson, 440 words, PT-BR),
+`lesson-b2s-*` (15 lessons, ~58,000 words, EN). Lesson content carries a single
+plain-string `title` and one block set — there is no per-locale content
+mechanism in the bundle at all.
+
+**Why it matters:** The platform's audience is Brazilian, the UI localisation is
+excellent, and the funnel is deliberately Portuguese — so the drop-off lands
+exactly on the audience the platform is built for, at the moment of peak
+motivation. This also drives the "reasons to come back" score: streaks and
+quests can't retain someone who has run out of content.
+
+**Fix:** Either translate `btc-to-sol-evolution` (large, but it is the single
+highest-leverage content investment available), or add an intermediate PT-BR
+course so the funnel has a second step. Shorter term, set expectations at the
+end of the Speedrun — telling Ana the next course is in English is much better
+than letting her discover it.
+
+### [Content] The entry course teaches the thesis, not the craft — P2
+
+**What happens:** The Speedrun's four lessons are about _why_ Solana matters —
+tokenized equities, institutional adoption, parallel execution, Superteam
+bounties. Well-written and motivating, but a learner finishes knowing what
+Solana is for and having written nothing.
+
+**Evidence:** `lesson-ssr-por-que-solana`, `-como-funciona`,
+`-superteam-porta-de-entrada`, `-seu-momento-onchain`; block composition is
+`{prose:1, quiz:1}` for all four. Quoted opening: _"Você manda R$ 20 pelo PIX e
+o dinheiro chega antes de guardar o celular no bolso."_
+
+**Why it matters:** Fine as a funnel — this is a good ten-minute pitch. It
+becomes a problem only because the credential it issues is presented as
+equivalent to the deep course's, which is the employer finding below.
+
+**Fix:** No content change needed if the credential naming distinguishes the two
+(see the employer section). If the Speedrun is meant to be a _learning_ entry
+rather than a pitch, one hands-on step — a wallet interaction, a real
+transaction — would change its character entirely.
+
+**Quit point:** Not observable without a live run. On the evidence available,
+the likeliest quit is _after_ the Speedrun rather than during it — a content
+gap, not a friction gap, which is the better problem to have.
+
+### [i18n] UI localisation is a strength worth protecting — P3 (positive)
+
+1,420 keys with **zero** structural drift across `en`/`es`/`pt-BR`, and only 7
+of 859 long strings identical across all three (brand terms). No
+`MISSING_MESSAGE` risk and no machine-translation smell in the UI.
+
+## Employer findings
+
+**What this credential actually certifies:** for `solana-speedrun` and
+`pilula-solana-superteam` — that the holder opened every lesson page and
+submitted correct answers to three-option multiple-choice questions whose
+answers were present in the page payload, with unlimited attempts. For
+`btc-to-sol-evolution` — the same, plus four graded challenges, two of which are
+Rust/Anchor programs compiled server-side against test suites.
+
+### [Cheat resistance] The funnel credential grades only open-book multiple choice — P1
+
+**What happens:** A candidate can hold a Solana Speedrun credential having read
+nothing. The quiz `correct` flags ship to the browser by design (a documented
+"D4 open-book ruling" — the rationale is instant formative feedback with no API
+round-trip, which is good pedagogy), a question locks once answered correctly,
+and Next only unlocks on a correct answer. So the intended flow is _retry until
+right_, with the answers visible in the payload.
+
+**Evidence:** `blocks/quiz-block.tsx:31` — _"The `correct` flags ship to the
+client DELIBERATELY (D4 open-book ruling), so instant feedback needs no API —
+the server stays authoritative at completion."_ `lib/content/project.ts:122`
+passes `correct` through the projection; `lessons/[id]/page.tsx:29` hands the
+full lesson to a `"use client"` component, so it is serialised into the page
+payload. Block composition for all five funnel lessons is `{prose:1, quiz:1}` —
+no code blocks exist in either course.
+
+**Why it matters:** The server-side gate is real and well built — but a gate is
+only as strong as what it measures. Grading open-book answers verifies the
+learner submitted the right options; it cannot distinguish knowledge from
+persistence. In the deep course, code challenges carry the weight instead. In
+the funnel courses there is nothing else, so the credential carries no technical
+information.
+
+**Fix:** Require at least one server-graded code challenge in any course that
+issues a credential. Everything needed already works — deterministic graders,
+`buildable` Rust compiled against tests, proof fingerprinting. Alternatively,
+name the funnel credentials so they don't read as skill claims (a "completion"
+badge rather than a credential), which is a copy change rather than a content
+one. Do one or the other; the current state promises more than it verifies.
+
+### [Cheat resistance] Quiz items are structurally guessable — P1
+
+**What happens:** Across all 47 questions the correct answer is the longest
+option 68% of the time, against a 33% baseline for three options — so a
+test-taker heuristic alone roughly doubles the chance of a correct answer with
+zero domain knowledge. Separately, **100% of questions** carry a perfect
+structural tell: only the _incorrect_ options have a `feedback` field, so the
+option lacking one is always the answer.
+
+**Evidence:** Computed over `content/generated/lessons.json`: 47 questions, all
+three-option single-select, 32/47 longest-is-correct, 47/47 feedback-asymmetric.
+Example — `lesson-psp-solana-em-2-minutos`: _"A Solana é rápida como o quê?"_
+with options "Como um boleto, que compensa em dias" / "Como o PIX: confirma em
+menos de meio segundo e custa menos de 1 centavo" / "Como a fila do banco, que
+anda quando dá". The question asks what it is _fast_ like; exactly one option
+describes something fast. It is answerable from the stem alone.
+
+**Why it matters:** This compounds the finding above — the assessment is weak
+both by design (open-book) and by construction (guessable). It also affects
+learning, not just credentialing: a learner who guesses right gets the reward
+without the understanding.
+
+**Fix:** Write distractors as _plausible near-misses_ rather than obviously
+wrong or joke options, and balance option lengths. The current distractors are
+often self-defeating ("Porque quase ninguém usa a rede ainda", "Num sorteio
+entre os membros"). Authoring plausible wrong answers is the single highest-value
+content change for assessment quality. The feedback asymmetry is worth fixing
+too — authoring a confirming note on correct options removes the tell and
+improves the learning moment.
+
+### [Verifiability] The credential is independently checkable — and that is genuinely strong
+
+Credit where due: the certificate page is publicly readable when the holder's
+profile is public (`schema.sql:379` — _"Public certificates are viewable by
+everyone"_, `USING (public.is_public_profile(user_id))`, default `is_public =
+true`), it links out to Solana Explorer for the on-chain asset
+(`certificates/[id]/page.tsx:176`), and credentials are soulbound Metaplex Core
+NFTs — non-transferable, so they cannot be bought or handed over. There are no
+INSERT/UPDATE policies on `certificates` at all; all writes go through
+service-role API routes, with a comment stating the reason explicitly. That is a
+materially better artefact than a PDF certificate, and it should not be
+regressed.
+
+### [Verifiability] Going private silently breaks employer links — P2
+
+**What happens:** A candidate who sets their profile to private makes their own
+certificate page unreadable to anyone else. The link they put on their CV starts
+rendering "not found" with no indication to them that it has.
+
+**Evidence:** `certificates/[id]/page.tsx` reads the row through the browser
+Supabase client; the only non-owner SELECT policy is gated on
+`is_public_profile(user_id)` (`schema.sql:379`).
+
+**Why it matters:** From the employer's side this is indistinguishable from a
+fabricated link — the worst possible failure mode for a verification surface.
+
+**Fix:** Warn on the privacy toggle that it will break shared credential links,
+or keep certificate rows readable by id (they're UUIDs, so unguessable) while
+keeping the profile private.
+
+### [Verifiability] Which cluster do production credentials live on? — P2, needs confirmation
+
+The explorer link is built from `resolveSolanaNetwork()`, and every checked-in
+example sets `NEXT_PUBLIC_SOLANA_NETWORK=devnet` (`.env.example:18`,
+`apps/web/CLAUDE.md:55`). I could not read the production environment from the
+audit sandbox, so this is a question, not a finding. It matters because devnet
+assets are free to mint and the cluster is periodically reset — an employer who
+follows the explorer link to a devnet asset is looking at something anyone could
+have created. If production is on devnet, "verifiable on-chain" needs a caveat
+in the copy; if it is on mainnet, this is closed and worth noting in the next
+report.
+
+### [Job relevance] The deep course would survive a technical screen; the funnel wouldn't
+
+`btc-to-sol-evolution` asks the learner to write an Anchor vault with checked
+arithmetic and a program deployed to devnet, graded by compilation against test
+suites (`lesson-b2s-an-anchor-vault`: 3 tests, `buildable`;
+`lesson-b2s-your-first-solana-program`: 3 tests, `buildable`; plus two
+TypeScript challenges with 4 and 6 tests). That is real evidence — a candidate
+who did it unaided can read and write Anchor code. The funnel courses ask for
+nothing executable.
+
+**Fix:** This asymmetry is the strategic finding of this run. The course that
+would earn hiring trust is the one the homepage does _not_ funnel into and the
+one the primary audience cannot read. Aligning those three things — funnel,
+language, and assessment rigour — is worth more than any individual fix in this
+report.
+
+## What's strong
+
+- **Server-authoritative completion.** `/api/lessons/complete` requires a
+  deterministic grader to pass for every graded block, with proof fingerprinting,
+  rate limiting, and replay handling. Completion cannot be forged by calling the
+  API.
+- **No self-issued certificates.** No INSERT/UPDATE policies on `certificates`;
+  the schema comments explain why.
+- **Soulbound, explorer-linked credentials** — a genuinely better artefact than
+  the industry norm.
+- **UI localisation discipline** — 1,420 keys, three locales, zero drift.
+- **Content writing quality** in the PT-BR courses: native register, concrete
+  local analogies, properly illustrated.
+- **Compiled Rust challenges** — server-side compilation against test suites is
+  the strongest assessment primitive the platform has. It is under-used, not
+  missing.
+
+## Not checked
+
+Substantial, because of the evidence mode:
+
+- The running application — no browser session at all. Nothing about layout,
+  mobile rendering, page speed, or broken flows was verified this cycle.
+- Signup and enrolment flows across the four auth paths; whether anonymous
+  progress survives signup.
+- The code editor and challenge runner as a learner experiences them.
+- Credential minting end to end, and what the metadata actually contains.
+- Production environment configuration (cluster, feature flags).
+- Community forum, AI tutor, review/spaced-repetition, referrals UI.
+- Exhaustive fact-checking of content claims (spot-checked only).
+- Accessibility.
+
+## Next run
+
+1. Run in mode A or B and cover everything in "Not checked" above — especially
+   mobile, the signup-progress-preservation question, and the challenge runner.
+2. Confirm the production cluster and close the devnet question.
+3. Re-test the two P1 employer findings if the credential/assessment changes
+   land, and re-score cheat resistance.
+4. Rotate `btc-to-sol-evolution`'s later modules into content review — this run
+   sampled its structure and challenges but did not read all 58,000 words.

--- a/docs/qa-reports/README.md
+++ b/docs/qa-reports/README.md
@@ -1,0 +1,20 @@
+# QA reports
+
+Dated platform audits produced by the `academy-qa` skill
+(`.claude/skills/academy-qa/`). Run it with `/academy-qa`, or just ask for a
+platform QA / student feedback / credential-credibility review.
+
+Each report audits the platform through two lenses in one pass — a learner using
+the app, and a hiring company deciding whether an Academy credential is real
+evidence a candidate knows Solana — and ranks the findings together, because
+engineering time is one budget.
+
+**Filename:** `YYYY-MM-DD.md`, one per run.
+
+**Cadence:** roughly quarterly, plus after any change to onboarding, assessment,
+or credential issuance — those are the surfaces where a regression quietly
+changes what the credential means.
+
+Each run reads the previous report first and reports what was fixed, what is
+still open, and what regressed, so the scorecard trend is the point rather than
+the individual scores.


### PR DESCRIPTION
## Summary

Adds `/academy-qa` — a repeatable platform audit that evaluates the Academy through two lenses in a single pass and produces a dated, prioritised report in `docs/qa-reports/`.

The premise: the platform makes two promises to two different parties — **learners** get skills, **employers** get signal — and they fail independently. A course can be delightful to use and worthless as hiring evidence (everything guessable, nothing verifiable); it can be rigorous and lose every learner at signup. Auditing one lens is how a platform ends up excellent at the thing nobody was complaining about. Findings from both lenses are ranked together, because engineering time is one budget.

## What's in it

| File | Role |
| --- | --- |
| `SKILL.md` | Run order, evidence modes, severity model, scorecard, the two verdicts |
| `student-pass.md` | Journey protocol + content-quality review |
| `employer-pass.md` | Credential-validity audit (six questions → verdict tier) |
| `platform-map.md` | Where everything lives, so runs evaluate instead of rediscover |
| `report-template.md` | Fixed output shape + a worked finding for calibration |

**Student pass** adopts a *named* persona (vague personas produce vague feedback), defaults to **PT-BR at 375px** since that's the audience's centre of gravity, and walks arrival → first lesson → signup → completion → return, recording the point where a real learner would quit. Content is judged separately: factual accuracy, currency of tooling, difficulty curve, guessable quizzes, and translation quality — machine-translated technical PT-BR reads as unserious to exactly the audience this is for.

**Employer pass** audits the credential the way a hiring engineer would: what is actually claimed, can an outsider verify it without trusting us, could someone hold it *without knowing the material*, does it map to real work, does it discriminate, is it current. It ends in a plain verdict (Strong signal / Weak signal / Screening only / Not acceptable) plus the single change that would move it up a tier.

## Design choices worth flagging

- **Anti-slop rules are explicit.** Every finding needs evidence you can click, the user consequence, severity, and a concrete fix; the template includes a vague-vs-sharp worked example. The failure mode of an audit like this is forty observations that could apply to any website.
- **It compounds.** Each run reads the previous report and reports what was fixed / still open / regressed. The scorecard's value is the trend, not any single score.
- **Production is read-only.** Anything that mutates state — completing lessons through the API, probing bypasses, minting — runs local or on a preview. On-chain writes cost real SOL and are often irreversible.
- **A real lead is already recorded.** The content bundle carries a per-option `correct` flag on quizzes and full `solution`/`tests` on code blocks. Whether those are stripped before reaching the browser is a question of fact the employer pass checks first — if a learner with devtools can read the answers, the assessment measures curiosity, not knowledge.

## Notes

Docs and skill files only — no application code, no tests affected. Follows the existing `.claude/skills/` layout (`user-invocable: true`, flat reference files) used by `superteam-academy-dev`.

Suggested cadence, recorded in `docs/qa-reports/README.md`: roughly quarterly, plus after any change to onboarding, assessment, or credential issuance — the surfaces where a regression quietly changes what the credential means.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MJMV9QpjXQ42PVjgEeMQp4)_