### PR TITLE
perf: mount wallet/Dynamic/gamification providers only on platform routes (#1097)

### DIFF
--- a/apps/web/src/app/[locale]/(marketing)/layout.tsx
+++ b/apps/web/src/app/[locale]/(marketing)/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { DynamicReturnCatcher } from "@/components/auth/dynamic-return-catcher";
 
 export const metadata: Metadata = {
   title: "Superteam Academy — Solana Developer Education",
@@ -11,5 +12,12 @@ export default function MarketingLayout({
 }: {
   children: React.ReactNode;
 }) {
-  return children;
+  // The catcher completes a Dynamic social/device redirect that lands on a
+  // marketing page, where the (platform) provider stack is absent (#1097).
+  return (
+    <>
+      <DynamicReturnCatcher />
+      {children}
+    </>
+  );
 }

--- a/apps/web/src/app/[locale]/(platform)/layout.tsx
+++ b/apps/web/src/app/[locale]/(platform)/layout.tsx
@@ -1,11 +1,41 @@
+import { SolanaWalletProvider } from "@/lib/solana/wallet-provider";
+import { DynamicWalletProvider } from "@/components/auth/dynamic-wallet-provider";
+import { GamificationOverlays } from "@/components/gamification/gamification-overlays";
+import { LowSolBanner } from "@/components/layout/low-sol-banner";
+
+/**
+ * (platform) routes carry the wallet/Dynamic provider stack and the
+ * gamification overlays (#1097); marketing/admin routes do not, and reach
+ * wallet features through AuthModal's lazily-mounted scoped stack instead.
+ *
+ * Order matters and mirrors what [locale]/layout.tsx had before the
+ * demotion: SolanaWalletProvider outside DynamicWalletProvider, both inside
+ * the global Auth/Analytics providers. Crossing marketing↔platform unmounts
+ * the stack; wallet-adapter keeps `walletName` in localStorage and never
+ * disconnects the adapter on unmount, so re-entry silently reconnects via
+ * autoConnect, and WalletAuthHandler's existing-session check keeps the
+ * reconnect from re-prompting SIWS.
+ */
 export default function PlatformLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
   return (
-    <div className="container px-4 pb-20 pt-6 sm:px-6 md:pt-8 lg:px-8 lg:pb-8">
-      {children}
-    </div>
+    <SolanaWalletProvider>
+      {/* DynamicAuthHandler is mounted by the provider itself, not here:
+          its hook throws outside a DynamicContextProvider, so it must never
+          be a sibling. */}
+      <DynamicWalletProvider>
+        {/* Moved out of the Header (#1097): the banner needs useWallet /
+            useConnection, which only resolve under this stack. Devnet-only,
+            learner-facing — marketing routes never showed it anyway. */}
+        <LowSolBanner />
+        <div className="container px-4 pb-20 pt-6 sm:px-6 md:pt-8 lg:px-8 lg:pb-8">
+          {children}
+        </div>
+        <GamificationOverlays />
+      </DynamicWalletProvider>
+    </SolanaWalletProvider>
   );
 }

--- a/apps/web/src/app/[locale]/admin/layout.tsx
+++ b/apps/web/src/app/[locale]/admin/layout.tsx
@@ -1,6 +1,7 @@
 import { notFound } from "next/navigation";
 import { getTranslations } from "next-intl/server";
 import { requireAdmin } from "@/lib/admin/auth";
+import { DynamicReturnCatcher } from "@/components/auth/dynamic-return-catcher";
 import { AdminNav } from "./admin-nav";
 
 /**
@@ -34,6 +35,9 @@ export default async function AdminLayout({
 
   return (
     <div className="min-h-screen bg-bg text-text">
+      {/* Admin sits outside (platform), so a Dynamic redirect (e.g. a device
+          registration link) landing here needs the catcher (#1097). */}
+      <DynamicReturnCatcher />
       <div className="mx-auto max-w-6xl px-4 py-8">
         <div className="mb-8">
           <h1 className="font-display text-2xl font-bold text-text">

--- a/apps/web/src/app/[locale]/layout.tsx
+++ b/apps/web/src/app/[locale]/layout.tsx
@@ -4,14 +4,12 @@ import { getMessages } from "next-intl/server";
 import { notFound } from "next/navigation";
 import { locales, type Locale } from "@/lib/i18n/config";
 import { ThemeProvider } from "@/components/layout/theme-provider";
-import { SolanaWalletProvider } from "@/lib/solana/wallet-provider";
 import { AnalyticsProvider } from "@/components/analytics/analytics-provider";
 import { AuthProvider } from "@/lib/auth/auth-provider";
 import { ReferralCapture } from "@/components/referrals/referral-capture";
-import { DynamicWalletProvider } from "@/components/auth/dynamic-wallet-provider";
 import { Header } from "@/components/layout/header";
 import { MobileBottomNav } from "@/components/layout/mobile-bottom-nav";
-import { GamificationOverlays } from "@/components/gamification/gamification-overlays";
+import { ToastContainer } from "@/components/ui/toast-container";
 
 interface LocaleLayoutProps {
   children: React.ReactNode;
@@ -35,6 +33,12 @@ export default async function LocaleLayout(props: LocaleLayoutProps) {
   // inline theme-flash-prevention <script> so it satisfies the nonce policy.
   const nonce = (await headers()).get("x-nonce") ?? undefined;
 
+  // The wallet/Dynamic provider stack and the gamification overlays are NOT
+  // here (#1097): they mount in (platform)/layout.tsx, so marketing and admin
+  // first loads don't pay for wallet-adapter, the Dynamic SDK, or TanStack
+  // Query. Header children that touch the wallet degrade through
+  // useOptionalWallet, and the sign-in modal lazily mounts its own scoped
+  // stack when opened outside (platform).
   return (
     <ThemeProvider
       attribute="data-theme"
@@ -44,29 +48,25 @@ export default async function LocaleLayout(props: LocaleLayoutProps) {
       nonce={nonce}
     >
       <NextIntlClientProvider messages={messages}>
-        <SolanaWalletProvider>
-          {/* DynamicAuthHandler is mounted by the provider itself, not here:
-              its hook throws outside a DynamicContextProvider, so it must never
-              be a sibling. */}
-          <DynamicWalletProvider>
-            <AuthProvider>
-              {/* Captures ?ref= codes on any page and claims them once a
-                  session exists — attribution without touching any of the
-                  four auth flows. No UI. */}
-              <ReferralCapture />
-              <AnalyticsProvider>
-                <div className="grid-bg flex min-h-screen flex-col bg-[var(--bg)]">
-                  <Header />
-                  <main id="main-content" className="flex-1 pt-[60px]">
-                    {children}
-                  </main>
-                  <MobileBottomNav />
-                  <GamificationOverlays />
-                </div>
-              </AnalyticsProvider>
-            </AuthProvider>
-          </DynamicWalletProvider>
-        </SolanaWalletProvider>
+        <AuthProvider>
+          {/* Captures ?ref= codes on any page and claims them once a
+              session exists — attribution without touching any of the
+              four auth flows. No UI. */}
+          <ReferralCapture />
+          <AnalyticsProvider>
+            <div className="grid-bg flex min-h-screen flex-col bg-[var(--bg)]">
+              <Header />
+              <main id="main-content" className="flex-1 pt-[60px]">
+                {children}
+              </main>
+              <MobileBottomNav />
+              {/* Global on purpose: marketing pages dispatch toasts too
+                  (AuthErrorToast on refused logins), so the container cannot
+                  ride along with the (platform)-only overlays. */}
+              <ToastContainer />
+            </div>
+          </AnalyticsProvider>
+        </AuthProvider>
       </NextIntlClientProvider>
     </ThemeProvider>
   );

--- a/apps/web/src/components/auth/__tests__/auth-modal-no-dynamic-provider.test.tsx
+++ b/apps/web/src/components/auth/__tests__/auth-modal-no-dynamic-provider.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 /* eslint-disable import/order -- vi.mock factories are hoisted above imports. */
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { NextIntlClientProvider } from "next-intl";
 import messages from "@/messages/en.json";
@@ -44,10 +44,27 @@ vi.mock("@/lib/dynamic/config", () => ({
   getDynamicEnvironmentId: () => null,
 }));
 
+import { publishAmbientWallet } from "@/lib/solana/ambient-wallet-store";
 import { AuthModal } from "../auth-modal";
 
+// A live ambient registration models a (platform) route (#1097); it is the
+// plain module store, not a Dynamic provider, so this render still exercises
+// "no DynamicProvider mounted".
+let unregisterAmbient: (() => void) | null = null;
+beforeEach(() => {
+  unregisterAmbient = publishAmbientWallet({
+    connected: false,
+    publicKey: null,
+    disconnect: vi.fn(),
+    openWalletModal: vi.fn(),
+  });
+});
+afterEach(() => {
+  unregisterAmbient?.();
+});
+
 describe("AuthModal with Dynamic disabled and no provider mounted", () => {
-  it("opens without throwing, and offers the other sign-in methods", () => {
+  it("opens without throwing, and offers the other sign-in methods", { timeout: 15_000 }, async () => {
     expect(() =>
       render(
         <NextIntlClientProvider locale="en" messages={messages}>
@@ -56,10 +73,24 @@ describe("AuthModal with Dynamic disabled and no provider mounted", () => {
       )
     ).not.toThrow();
 
-    expect(screen.getByText(messages.auth.signInTitle)).toBeInTheDocument();
-    // The wallet route stays available — it is the guaranteed way in.
+    // findBy with a generous timeout: the dialog body is a lazy chunk since
+    // #1097, and its first import in a suite loads the Dynamic SDK.
     expect(
-      screen.getByRole("button", { name: messages.auth.connectSolanaWallet })
+      await screen.findByText(
+        messages.auth.signInTitle,
+        {},
+        { timeout: 10_000 }
+      )
+    ).toBeInTheDocument();
+    // The wallet route stays available — it is the guaranteed way in.
+    // findBy with a generous timeout: the body chunk's first import in this
+    // suite loads the (unmocked) Dynamic SDK.
+    expect(
+      await screen.findByRole(
+        "button",
+        { name: messages.auth.connectSolanaWallet },
+        { timeout: 10_000 }
+      )
     ).toBeInTheDocument();
     // ...and the email button is absent rather than broken.
     expect(
@@ -81,7 +112,7 @@ describe("AuthModal with Dynamic disabled and no provider mounted", () => {
   // A separate render: a click leaves every button disabled while the
   // full-page OAuth navigation is presumed imminent, so the two kill-switch
   // clicks cannot share one modal instance.
-  it("GitHub falls back to Supabase OAuth the same way", () => {
+  it("GitHub falls back to Supabase OAuth the same way", { timeout: 15_000 }, async () => {
     render(
       <NextIntlClientProvider locale="en" messages={messages}>
         <AuthModal open onOpenChange={() => {}} />
@@ -89,7 +120,11 @@ describe("AuthModal with Dynamic disabled and no provider mounted", () => {
     );
 
     fireEvent.click(
-      screen.getByRole("button", { name: messages.auth.signInWithGitHub })
+      await screen.findByRole(
+        "button",
+        { name: messages.auth.signInWithGitHub },
+        { timeout: 10_000 }
+      )
     );
     expect(signInWithOAuth).toHaveBeenCalledWith(
       expect.objectContaining({ provider: "github" })

--- a/apps/web/src/components/auth/__tests__/auth-modal-scoped-providers.test.tsx
+++ b/apps/web/src/components/auth/__tests__/auth-modal-scoped-providers.test.tsx
@@ -1,0 +1,166 @@
+// @vitest-environment jsdom
+import type { ReactElement } from "react";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { NextIntlClientProvider } from "next-intl";
+import messages from "@/messages/en.json";
+import {
+  publishAmbientWallet,
+  setWalletReturnCaptureActive,
+} from "@/lib/solana/ambient-wallet-store";
+import { AuthModal } from "../auth-modal";
+
+/**
+ * #1097 — where the wallet/Dynamic providers come from when the sign-in
+ * modal opens:
+ *
+ * - No live stack (marketing/admin): AuthModal lazily mounts
+ *   ScopedAuthProviders as a sibling of the Dialog, and keeps it mounted
+ *   after close (the Solana path hands off to the wallet-select modal, which
+ *   lives in that stack).
+ * - Live ambient stack ((platform) routes register in the store): the scoped
+ *   stack must NOT mount — a second WalletProvider duplicates autoConnect,
+ *   listeners, and SIWS.
+ * - Catcher capture window (a Dynamic redirect return is standing up its own
+ *   stack): the modal must not arm either (review F4).
+ */
+
+vi.mock("@/lib/supabase/client", () => ({
+  createClient: vi.fn(() => ({
+    auth: { signInWithOAuth: vi.fn().mockResolvedValue({ error: null }) },
+  })),
+}));
+vi.mock("@/lib/analytics", () => ({ trackEvent: vi.fn() }));
+
+// The real module mounts wallet-adapter + the Dynamic SDK; this suite is
+// about WHEN the stack mounts, not what is inside it. Like the real stack's
+// registrar, the fake registers itself in the ambient store on mount so the
+// modal's body gate opens.
+vi.mock("@/components/auth/scoped-auth-providers", async () => {
+  const { publishAmbientWallet: publish } = await import(
+    "@/lib/solana/ambient-wallet-store"
+  );
+  const { useEffect } = await import("react");
+  return {
+    default: function FakeScopedStack() {
+      useEffect(
+        () =>
+          publish({
+            connected: false,
+            publicKey: null,
+            disconnect: async () => {},
+            openWalletModal: () => {},
+          }),
+        []
+      );
+      return <div data-testid="scoped-providers" />;
+    },
+  };
+});
+
+function renderWithIntl(ui: ReactElement) {
+  return render(
+    <NextIntlClientProvider locale="en" messages={messages}>
+      {ui}
+    </NextIntlClientProvider>
+  );
+}
+
+const fakeAmbient = () =>
+  publishAmbientWallet({
+    connected: false,
+    publicKey: null,
+    disconnect: async () => {},
+    openWalletModal: () => {},
+  });
+
+const CONNECT_WALLET = messages.auth.connectSolanaWallet;
+
+afterEach(() => {
+  // Reset module-store state between tests: a publish clears the capture
+  // flag, and unregistering leaves the store empty.
+  fakeAmbient()();
+  vi.clearAllMocks();
+});
+
+describe("AuthModal scoped provider mounting (#1097)", () => {
+  it("lazily mounts the scoped stack when opened with no live stack, and the body renders once it registers", { timeout: 15_000 }, async () => {
+    renderWithIntl(<AuthModal open onOpenChange={() => {}} />);
+
+    expect(await screen.findByTestId("scoped-providers")).toBeInTheDocument();
+    // Generous timeout: the body chunk's first import loads the Dynamic SDK.
+    expect(
+      await screen.findByRole(
+        "button",
+        { name: CONNECT_WALLET },
+        { timeout: 10_000 }
+      )
+    ).toBeInTheDocument();
+  });
+
+  it("mounts nothing scoped while closed", () => {
+    renderWithIntl(<AuthModal open={false} onOpenChange={() => {}} />);
+    expect(screen.queryByTestId("scoped-providers")).not.toBeInTheDocument();
+  });
+
+  it("keeps the scoped stack mounted after the dialog closes (wallet-modal handoff)", { timeout: 15_000 }, async () => {
+    const { rerender } = renderWithIntl(
+      <AuthModal open onOpenChange={() => {}} />
+    );
+    await screen.findByTestId("scoped-providers");
+
+    rerender(
+      <NextIntlClientProvider locale="en" messages={messages}>
+        <AuthModal open={false} onOpenChange={() => {}} />
+      </NextIntlClientProvider>
+    );
+
+    expect(
+      screen.queryByText(messages.auth.signInTitle)
+    ).not.toBeInTheDocument();
+    expect(screen.getByTestId("scoped-providers")).toBeInTheDocument();
+  });
+
+  it("never mounts the scoped stack when a live stack is registered (double-mount guard)", { timeout: 15_000 }, async () => {
+    const unregister = fakeAmbient();
+    try {
+      renderWithIntl(<AuthModal open onOpenChange={() => {}} />);
+
+      expect(
+        await screen.findByRole(
+          "button",
+          { name: CONNECT_WALLET },
+          { timeout: 10_000 }
+        )
+      ).toBeInTheDocument();
+      expect(screen.queryByTestId("scoped-providers")).not.toBeInTheDocument();
+    } finally {
+      unregister();
+    }
+  });
+
+  it("does not arm while the catcher's capture window is open (F4), then renders the body once that stack registers", { timeout: 15_000 }, async () => {
+    setWalletReturnCaptureActive();
+    renderWithIntl(<AuthModal open onOpenChange={() => {}} />);
+
+    // The modal shows the standing-up spinner and must not start its own
+    // stack while the catcher's is on the way.
+    expect(screen.queryByTestId("scoped-providers")).not.toBeInTheDocument();
+
+    // The catcher's stack registers (this also clears the capture flag)…
+    const unregister = fakeAmbient();
+    try {
+      // …and the body proceeds against it, still with no modal-owned stack.
+      expect(
+        await screen.findByRole(
+          "button",
+          { name: CONNECT_WALLET },
+          { timeout: 10_000 }
+        )
+      ).toBeInTheDocument();
+      expect(screen.queryByTestId("scoped-providers")).not.toBeInTheDocument();
+    } finally {
+      unregister();
+    }
+  });
+});

--- a/apps/web/src/components/auth/__tests__/auth-modal-scoped-providers.test.tsx
+++ b/apps/web/src/components/auth/__tests__/auth-modal-scoped-providers.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import type { ReactElement } from "react";
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import { NextIntlClientProvider } from "next-intl";
 import messages from "@/messages/en.json";
 import {
@@ -37,9 +37,8 @@ vi.mock("@/lib/analytics", () => ({ trackEvent: vi.fn() }));
 // registrar, the fake registers itself in the ambient store on mount so the
 // modal's body gate opens.
 vi.mock("@/components/auth/scoped-auth-providers", async () => {
-  const { publishAmbientWallet: publish } = await import(
-    "@/lib/solana/ambient-wallet-store"
-  );
+  const { publishAmbientWallet: publish } =
+    await import("@/lib/solana/ambient-wallet-store");
   const { useEffect } = await import("react");
   return {
     default: function FakeScopedStack() {
@@ -84,83 +83,134 @@ afterEach(() => {
 });
 
 describe("AuthModal scoped provider mounting (#1097)", () => {
-  it("lazily mounts the scoped stack when opened with no live stack, and the body renders once it registers", { timeout: 15_000 }, async () => {
-    renderWithIntl(<AuthModal open onOpenChange={() => {}} />);
+  it(
+    "lazily mounts the scoped stack when opened with no live stack, and the body renders once it registers",
+    { timeout: 15_000 },
+    async () => {
+      renderWithIntl(<AuthModal open onOpenChange={() => {}} />);
 
-    expect(await screen.findByTestId("scoped-providers")).toBeInTheDocument();
-    // Generous timeout: the body chunk's first import loads the Dynamic SDK.
-    expect(
-      await screen.findByRole(
-        "button",
-        { name: CONNECT_WALLET },
-        { timeout: 10_000 }
-      )
-    ).toBeInTheDocument();
-  });
+      expect(await screen.findByTestId("scoped-providers")).toBeInTheDocument();
+      // Generous timeout: the body chunk's first import loads the Dynamic SDK.
+      expect(
+        await screen.findByRole(
+          "button",
+          { name: CONNECT_WALLET },
+          { timeout: 10_000 }
+        )
+      ).toBeInTheDocument();
+    }
+  );
 
   it("mounts nothing scoped while closed", () => {
     renderWithIntl(<AuthModal open={false} onOpenChange={() => {}} />);
     expect(screen.queryByTestId("scoped-providers")).not.toBeInTheDocument();
   });
 
-  it("keeps the scoped stack mounted after the dialog closes (wallet-modal handoff)", { timeout: 15_000 }, async () => {
-    const { rerender } = renderWithIntl(
-      <AuthModal open onOpenChange={() => {}} />
-    );
-    await screen.findByTestId("scoped-providers");
+  it(
+    "keeps the scoped stack mounted after the dialog closes (wallet-modal handoff)",
+    { timeout: 15_000 },
+    async () => {
+      const { rerender } = renderWithIntl(
+        <AuthModal open onOpenChange={() => {}} />
+      );
+      await screen.findByTestId("scoped-providers");
 
-    rerender(
-      <NextIntlClientProvider locale="en" messages={messages}>
-        <AuthModal open={false} onOpenChange={() => {}} />
-      </NextIntlClientProvider>
-    );
+      rerender(
+        <NextIntlClientProvider locale="en" messages={messages}>
+          <AuthModal open={false} onOpenChange={() => {}} />
+        </NextIntlClientProvider>
+      );
 
-    expect(
-      screen.queryByText(messages.auth.signInTitle)
-    ).not.toBeInTheDocument();
-    expect(screen.getByTestId("scoped-providers")).toBeInTheDocument();
-  });
+      expect(
+        screen.queryByText(messages.auth.signInTitle)
+      ).not.toBeInTheDocument();
+      expect(screen.getByTestId("scoped-providers")).toBeInTheDocument();
+    }
+  );
 
-  it("never mounts the scoped stack when a live stack is registered (double-mount guard)", { timeout: 15_000 }, async () => {
-    const unregister = fakeAmbient();
-    try {
+  it(
+    "never mounts the scoped stack when a live stack is registered (double-mount guard)",
+    { timeout: 15_000 },
+    async () => {
+      const unregister = fakeAmbient();
+      try {
+        renderWithIntl(<AuthModal open onOpenChange={() => {}} />);
+
+        expect(
+          await screen.findByRole(
+            "button",
+            { name: CONNECT_WALLET },
+            { timeout: 10_000 }
+          )
+        ).toBeInTheDocument();
+        expect(
+          screen.queryByTestId("scoped-providers")
+        ).not.toBeInTheDocument();
+      } finally {
+        unregister();
+      }
+    }
+  );
+
+  it(
+    "disarms its own stack when another one registers while mounted (NEW-2: navigation with the modal open)",
+    { timeout: 15_000 },
+    async () => {
+      renderWithIntl(<AuthModal open onOpenChange={() => {}} />);
+      await screen.findByTestId("scoped-providers");
+
+      // The learner navigates to a (platform) route with the dialog up: the
+      // layout's stack registers as a second live stack…
+      const unregister = fakeAmbient();
+      try {
+        // …and the modal drops its own, converging back to one stack while the
+        // body keeps rendering against the newcomer.
+        await waitFor(() =>
+          expect(
+            screen.queryByTestId("scoped-providers")
+          ).not.toBeInTheDocument()
+        );
+        expect(
+          await screen.findByRole(
+            "button",
+            { name: CONNECT_WALLET },
+            { timeout: 10_000 }
+          )
+        ).toBeInTheDocument();
+      } finally {
+        unregister();
+      }
+    }
+  );
+
+  it(
+    "does not arm while the catcher's capture window is open (F4), then renders the body once that stack registers",
+    { timeout: 15_000 },
+    async () => {
+      setWalletReturnCaptureActive();
       renderWithIntl(<AuthModal open onOpenChange={() => {}} />);
 
-      expect(
-        await screen.findByRole(
-          "button",
-          { name: CONNECT_WALLET },
-          { timeout: 10_000 }
-        )
-      ).toBeInTheDocument();
+      // The modal shows the standing-up spinner and must not start its own
+      // stack while the catcher's is on the way.
       expect(screen.queryByTestId("scoped-providers")).not.toBeInTheDocument();
-    } finally {
-      unregister();
+
+      // The catcher's stack registers (this also clears the capture flag)…
+      const unregister = fakeAmbient();
+      try {
+        // …and the body proceeds against it, still with no modal-owned stack.
+        expect(
+          await screen.findByRole(
+            "button",
+            { name: CONNECT_WALLET },
+            { timeout: 10_000 }
+          )
+        ).toBeInTheDocument();
+        expect(
+          screen.queryByTestId("scoped-providers")
+        ).not.toBeInTheDocument();
+      } finally {
+        unregister();
+      }
     }
-  });
-
-  it("does not arm while the catcher's capture window is open (F4), then renders the body once that stack registers", { timeout: 15_000 }, async () => {
-    setWalletReturnCaptureActive();
-    renderWithIntl(<AuthModal open onOpenChange={() => {}} />);
-
-    // The modal shows the standing-up spinner and must not start its own
-    // stack while the catcher's is on the way.
-    expect(screen.queryByTestId("scoped-providers")).not.toBeInTheDocument();
-
-    // The catcher's stack registers (this also clears the capture flag)…
-    const unregister = fakeAmbient();
-    try {
-      // …and the body proceeds against it, still with no modal-owned stack.
-      expect(
-        await screen.findByRole(
-          "button",
-          { name: CONNECT_WALLET },
-          { timeout: 10_000 }
-        )
-      ).toBeInTheDocument();
-      expect(screen.queryByTestId("scoped-providers")).not.toBeInTheDocument();
-    } finally {
-      unregister();
-    }
-  });
+  );
 });

--- a/apps/web/src/components/auth/__tests__/auth-modal.test.tsx
+++ b/apps/web/src/components/auth/__tests__/auth-modal.test.tsx
@@ -1,9 +1,10 @@
 // @vitest-environment jsdom
 import type { ReactElement } from "react";
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { NextIntlClientProvider } from "next-intl";
 import messages from "@/messages/en.json";
+import { publishAmbientWallet } from "@/lib/solana/ambient-wallet-store";
 import { AuthModal } from "../auth-modal";
 
 const dynamicState = vi.hoisted(() => ({
@@ -13,6 +14,9 @@ const dynamicState = vi.hoisted(() => ({
 
 vi.mock("@/lib/dynamic/config", () => ({
   isDynamicEnabled: () => dynamicState.enabled,
+  // Read through lib/dynamic/client by DynamicSocialSignIn's imperative
+  // stale-session check (#1097); null = "no client", which is fine here.
+  getDynamicEnvironmentId: () => null,
 }));
 
 vi.mock("@solana/wallet-adapter-react-ui", () => ({
@@ -54,6 +58,11 @@ function renderWithIntl(ui: ReactElement) {
   );
 }
 
+// This suite models a (platform) route: the layout's provider stack is live
+// in the ambient store (#1097). The scoped (marketing) path has its own
+// suite, auth-modal-scoped-providers.test.tsx.
+let unregisterAmbient: (() => void) | null = null;
+
 const TITLE = messages.auth.signInTitle;
 const DEFAULT_TRIGGER = messages.common.signIn;
 
@@ -61,17 +70,33 @@ beforeEach(() => {
   vi.clearAllMocks();
   dynamicState.enabled = false;
   dynamicState.redirectMock.mockResolvedValue(undefined);
+  unregisterAmbient = publishAmbientWallet({
+    connected: false,
+    publicKey: null,
+    disconnect: vi.fn(async () => {}),
+    openWalletModal: vi.fn(),
+  });
+});
+
+afterEach(() => {
+  unregisterAmbient?.();
 });
 
 describe("AuthModal — one error placement (#1077)", () => {
-  it("renders a Dynamic button failure at modal level, not inline under the button", async () => {
+  it("renders a Dynamic button failure at modal level, not inline under the button", { timeout: 15_000 }, async () => {
     dynamicState.enabled = true;
     dynamicState.redirectMock.mockRejectedValueOnce(new Error("no settings"));
     vi.spyOn(console, "error").mockImplementation(() => {});
 
     renderWithIntl(<AuthModal open onOpenChange={() => {}} />);
+    // findBy with a generous timeout: the dialog body is a lazy chunk since
+    // #1097, and its first import in a suite is slow.
     fireEvent.click(
-      screen.getByRole("button", { name: messages.auth.signInWithGoogle })
+      await screen.findByRole(
+        "button",
+        { name: messages.auth.signInWithGoogle },
+        { timeout: 10_000 }
+      )
     );
 
     const alert = await screen.findByRole("alert");
@@ -81,15 +106,17 @@ describe("AuthModal — one error placement (#1077)", () => {
     expect(screen.getAllByRole("alert")).toHaveLength(1);
   });
 
-  it("clears the modal-level error when a new Dynamic attempt starts", async () => {
+  it("clears the modal-level error when a new Dynamic attempt starts", { timeout: 15_000 }, async () => {
     dynamicState.enabled = true;
     dynamicState.redirectMock.mockRejectedValueOnce(new Error("no settings"));
     vi.spyOn(console, "error").mockImplementation(() => {});
 
     renderWithIntl(<AuthModal open onOpenChange={() => {}} />);
-    const googleButton = screen.getByRole("button", {
-      name: messages.auth.signInWithGoogle,
-    });
+    const googleButton = await screen.findByRole(
+      "button",
+      { name: messages.auth.signInWithGoogle },
+      { timeout: 10_000 }
+    );
     fireEvent.click(googleButton);
     await screen.findByRole("alert");
 
@@ -102,10 +129,14 @@ describe("AuthModal — one error placement (#1077)", () => {
 });
 
 describe("AuthModal — controlled mode (#556)", () => {
-  it("opens programmatically via the open prop, without rendering a trigger button", () => {
+  it("opens programmatically via the open prop, without rendering a trigger button", { timeout: 15_000 }, async () => {
     renderWithIntl(<AuthModal open onOpenChange={() => {}} />);
 
-    expect(screen.getByText(TITLE)).toBeInTheDocument();
+    // findBy with a generous timeout: the dialog body is a lazy chunk since
+    // #1097, and its first import in a suite loads the Dynamic SDK.
+    expect(
+      await screen.findByText(TITLE, {}, { timeout: 10_000 })
+    ).toBeInTheDocument();
     expect(
       screen.queryByRole("button", { name: DEFAULT_TRIGGER })
     ).not.toBeInTheDocument();
@@ -120,11 +151,11 @@ describe("AuthModal — controlled mode (#556)", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("reports close through onOpenChange", () => {
+  it("reports close through onOpenChange", { timeout: 15_000 }, async () => {
     const onOpenChange = vi.fn();
     renderWithIntl(<AuthModal open onOpenChange={onOpenChange} />);
 
-    fireEvent.keyDown(screen.getByText(TITLE), { key: "Escape" });
+    fireEvent.keyDown(await screen.findByText(TITLE), { key: "Escape" });
     expect(onOpenChange).toHaveBeenCalledWith(false);
   });
 
@@ -144,23 +175,23 @@ describe("AuthModal — controlled mode (#556)", () => {
 });
 
 describe("AuthModal — uncontrolled mode (unchanged)", () => {
-  it("renders the default trigger and opens on click", () => {
+  it("renders the default trigger and opens on click", { timeout: 15_000 }, async () => {
     renderWithIntl(<AuthModal />);
 
     const trigger = screen.getByRole("button", { name: DEFAULT_TRIGGER });
     expect(screen.queryByText(TITLE)).not.toBeInTheDocument();
 
     fireEvent.click(trigger);
-    expect(screen.getByText(TITLE)).toBeInTheDocument();
+    expect(await screen.findByText(TITLE)).toBeInTheDocument();
   });
 });
 
 describe("AuthModal — Later affordance (LX-A4b)", () => {
-  it("shows the keep-progress framing, a Later button, and reassurance copy", () => {
+  it("shows the keep-progress framing, a Later button, and reassurance copy", { timeout: 15_000 }, async () => {
     renderWithIntl(<AuthModal open onOpenChange={() => {}} showLater />);
 
     expect(
-      screen.getByText(messages.auth.keepProgressTitle)
+      await screen.findByText(messages.auth.keepProgressTitle)
     ).toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: messages.auth.later })
@@ -186,21 +217,25 @@ describe("AuthModal — Later affordance (LX-A4b)", () => {
     expect(claimCopy).toContain("saved");
   });
 
-  it("closes and calls onLater when Later is tapped", () => {
+  it("closes and calls onLater when Later is tapped", { timeout: 15_000 }, async () => {
     const onOpenChange = vi.fn();
     const onLater = vi.fn();
     renderWithIntl(
       <AuthModal open onOpenChange={onOpenChange} showLater onLater={onLater} />
     );
 
-    fireEvent.click(screen.getByRole("button", { name: messages.auth.later }));
+    fireEvent.click(
+      await screen.findByRole("button", { name: messages.auth.later })
+    );
     expect(onOpenChange).toHaveBeenCalledWith(false);
     expect(onLater).toHaveBeenCalledTimes(1);
   });
 
-  it("omits the Later affordance by default", () => {
+  it("omits the Later affordance by default", { timeout: 15_000 }, async () => {
     renderWithIntl(<AuthModal open onOpenChange={() => {}} />);
 
+    // Wait for the lazy body before asserting the button's absence.
+    await screen.findByText(TITLE);
     expect(
       screen.queryByRole("button", { name: messages.auth.later })
     ).not.toBeInTheDocument();

--- a/apps/web/src/components/auth/__tests__/auth-modal.test.tsx
+++ b/apps/web/src/components/auth/__tests__/auth-modal.test.tsx
@@ -83,64 +83,76 @@ afterEach(() => {
 });
 
 describe("AuthModal — one error placement (#1077)", () => {
-  it("renders a Dynamic button failure at modal level, not inline under the button", { timeout: 15_000 }, async () => {
-    dynamicState.enabled = true;
-    dynamicState.redirectMock.mockRejectedValueOnce(new Error("no settings"));
-    vi.spyOn(console, "error").mockImplementation(() => {});
+  it(
+    "renders a Dynamic button failure at modal level, not inline under the button",
+    { timeout: 15_000 },
+    async () => {
+      dynamicState.enabled = true;
+      dynamicState.redirectMock.mockRejectedValueOnce(new Error("no settings"));
+      vi.spyOn(console, "error").mockImplementation(() => {});
 
-    renderWithIntl(<AuthModal open onOpenChange={() => {}} />);
-    // findBy with a generous timeout: the dialog body is a lazy chunk since
-    // #1097, and its first import in a suite is slow.
-    fireEvent.click(
-      await screen.findByRole(
+      renderWithIntl(<AuthModal open onOpenChange={() => {}} />);
+      // findBy with a generous timeout: the dialog body is a lazy chunk since
+      // #1097, and its first import in a suite is slow.
+      fireEvent.click(
+        await screen.findByRole(
+          "button",
+          { name: messages.auth.signInWithGoogle },
+          { timeout: 10_000 }
+        )
+      );
+
+      const alert = await screen.findByRole("alert");
+      expect(alert).toHaveTextContent(messages.auth.googleSignInFailed);
+      // Modal-level style (text-sm), the same channel Supabase fallbacks use.
+      expect(alert.className).toContain("text-sm");
+      expect(screen.getAllByRole("alert")).toHaveLength(1);
+    }
+  );
+
+  it(
+    "clears the modal-level error when a new Dynamic attempt starts",
+    { timeout: 15_000 },
+    async () => {
+      dynamicState.enabled = true;
+      dynamicState.redirectMock.mockRejectedValueOnce(new Error("no settings"));
+      vi.spyOn(console, "error").mockImplementation(() => {});
+
+      renderWithIntl(<AuthModal open onOpenChange={() => {}} />);
+      const googleButton = await screen.findByRole(
         "button",
         { name: messages.auth.signInWithGoogle },
         { timeout: 10_000 }
-      )
-    );
+      );
+      fireEvent.click(googleButton);
+      await screen.findByRole("alert");
 
-    const alert = await screen.findByRole("alert");
-    expect(alert).toHaveTextContent(messages.auth.googleSignInFailed);
-    // Modal-level style (text-sm), the same channel Supabase fallbacks use.
-    expect(alert.className).toContain("text-sm");
-    expect(screen.getAllByRole("alert")).toHaveLength(1);
-  });
-
-  it("clears the modal-level error when a new Dynamic attempt starts", { timeout: 15_000 }, async () => {
-    dynamicState.enabled = true;
-    dynamicState.redirectMock.mockRejectedValueOnce(new Error("no settings"));
-    vi.spyOn(console, "error").mockImplementation(() => {});
-
-    renderWithIntl(<AuthModal open onOpenChange={() => {}} />);
-    const googleButton = await screen.findByRole(
-      "button",
-      { name: messages.auth.signInWithGoogle },
-      { timeout: 10_000 }
-    );
-    fireEvent.click(googleButton);
-    await screen.findByRole("alert");
-
-    // Next attempt resolves (never navigates in jsdom) — the stale error goes.
-    fireEvent.click(googleButton);
-    await waitFor(() =>
-      expect(screen.queryByRole("alert")).not.toBeInTheDocument()
-    );
-  });
+      // Next attempt resolves (never navigates in jsdom) — the stale error goes.
+      fireEvent.click(googleButton);
+      await waitFor(() =>
+        expect(screen.queryByRole("alert")).not.toBeInTheDocument()
+      );
+    }
+  );
 });
 
 describe("AuthModal — controlled mode (#556)", () => {
-  it("opens programmatically via the open prop, without rendering a trigger button", { timeout: 15_000 }, async () => {
-    renderWithIntl(<AuthModal open onOpenChange={() => {}} />);
+  it(
+    "opens programmatically via the open prop, without rendering a trigger button",
+    { timeout: 15_000 },
+    async () => {
+      renderWithIntl(<AuthModal open onOpenChange={() => {}} />);
 
-    // findBy with a generous timeout: the dialog body is a lazy chunk since
-    // #1097, and its first import in a suite loads the Dynamic SDK.
-    expect(
-      await screen.findByText(TITLE, {}, { timeout: 10_000 })
-    ).toBeInTheDocument();
-    expect(
-      screen.queryByRole("button", { name: DEFAULT_TRIGGER })
-    ).not.toBeInTheDocument();
-  });
+      // findBy with a generous timeout: the dialog body is a lazy chunk since
+      // #1097, and its first import in a suite loads the Dynamic SDK.
+      expect(
+        await screen.findByText(TITLE, {}, { timeout: 10_000 })
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: DEFAULT_TRIGGER })
+      ).not.toBeInTheDocument();
+    }
+  );
 
   it("renders nothing while closed in controlled mode (no stray sign-in button)", () => {
     renderWithIntl(<AuthModal open={false} onOpenChange={() => {}} />);
@@ -175,31 +187,45 @@ describe("AuthModal — controlled mode (#556)", () => {
 });
 
 describe("AuthModal — uncontrolled mode (unchanged)", () => {
-  it("renders the default trigger and opens on click", { timeout: 15_000 }, async () => {
-    renderWithIntl(<AuthModal />);
+  it(
+    "renders the default trigger and opens on click",
+    { timeout: 15_000 },
+    async () => {
+      renderWithIntl(<AuthModal />);
 
-    const trigger = screen.getByRole("button", { name: DEFAULT_TRIGGER });
-    expect(screen.queryByText(TITLE)).not.toBeInTheDocument();
+      const trigger = screen.getByRole("button", { name: DEFAULT_TRIGGER });
+      expect(screen.queryByText(TITLE)).not.toBeInTheDocument();
 
-    fireEvent.click(trigger);
-    expect(await screen.findByText(TITLE)).toBeInTheDocument();
-  });
+      fireEvent.click(trigger);
+      expect(await screen.findByText(TITLE)).toBeInTheDocument();
+    }
+  );
 });
 
 describe("AuthModal — Later affordance (LX-A4b)", () => {
-  it("shows the keep-progress framing, a Later button, and reassurance copy", { timeout: 15_000 }, async () => {
-    renderWithIntl(<AuthModal open onOpenChange={() => {}} showLater />);
+  it(
+    "shows the keep-progress framing, a Later button, and reassurance copy",
+    { timeout: 15_000 },
+    async () => {
+      renderWithIntl(<AuthModal open onOpenChange={() => {}} showLater />);
 
-    expect(
-      await screen.findByText(messages.auth.keepProgressTitle)
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole("button", { name: messages.auth.later })
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText(messages.auth.progressSavedLocally)
-    ).toBeInTheDocument();
-  });
+      expect(
+        await screen.findByText(messages.auth.keepProgressTitle)
+      ).toBeInTheDocument();
+      // The Later button and reassurance copy live in the LAZY body (the title is
+      // Dialog-header chrome, outside it) — findBy, or CI load flakes this.
+      expect(
+        await screen.findByRole(
+          "button",
+          { name: messages.auth.later },
+          { timeout: 10_000 }
+        )
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(messages.auth.progressSavedLocally)
+      ).toBeInTheDocument();
+    }
+  );
 
   it("never uses discard/lose/delete language (F4) — progress is framed as kept", () => {
     const claimCopy = [
@@ -217,19 +243,28 @@ describe("AuthModal — Later affordance (LX-A4b)", () => {
     expect(claimCopy).toContain("saved");
   });
 
-  it("closes and calls onLater when Later is tapped", { timeout: 15_000 }, async () => {
-    const onOpenChange = vi.fn();
-    const onLater = vi.fn();
-    renderWithIntl(
-      <AuthModal open onOpenChange={onOpenChange} showLater onLater={onLater} />
-    );
+  it(
+    "closes and calls onLater when Later is tapped",
+    { timeout: 15_000 },
+    async () => {
+      const onOpenChange = vi.fn();
+      const onLater = vi.fn();
+      renderWithIntl(
+        <AuthModal
+          open
+          onOpenChange={onOpenChange}
+          showLater
+          onLater={onLater}
+        />
+      );
 
-    fireEvent.click(
-      await screen.findByRole("button", { name: messages.auth.later })
-    );
-    expect(onOpenChange).toHaveBeenCalledWith(false);
-    expect(onLater).toHaveBeenCalledTimes(1);
-  });
+      fireEvent.click(
+        await screen.findByRole("button", { name: messages.auth.later })
+      );
+      expect(onOpenChange).toHaveBeenCalledWith(false);
+      expect(onLater).toHaveBeenCalledTimes(1);
+    }
+  );
 
   it("omits the Later affordance by default", { timeout: 15_000 }, async () => {
     renderWithIntl(<AuthModal open onOpenChange={() => {}} />);

--- a/apps/web/src/components/auth/__tests__/dynamic-auth-handler-social-return.test.tsx
+++ b/apps/web/src/components/auth/__tests__/dynamic-auth-handler-social-return.test.tsx
@@ -65,6 +65,8 @@ vi.mock("@/lib/dynamic/client", () => ({ logoutDynamic }));
 vi.mock("@/lib/dynamic/siws", () => ({ toMessageSigner: vi.fn() }));
 vi.mock("@/lib/dynamic/social", () => ({
   bridgeDynamicSession,
+}));
+vi.mock("@/lib/dynamic/social-return-pending", () => ({
   setSocialReturnPending: vi.fn(),
 }));
 vi.mock("@/components/ui/toast-container", () => ({ dispatchToast: vi.fn() }));

--- a/apps/web/src/components/auth/__tests__/dynamic-return-catcher.test.tsx
+++ b/apps/web/src/components/auth/__tests__/dynamic-return-catcher.test.tsx
@@ -1,0 +1,79 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, waitFor } from "@testing-library/react";
+import {
+  getWalletReturnCaptureActive,
+  publishAmbientWallet,
+} from "@/lib/solana/ambient-wallet-store";
+import { DynamicReturnCatcher } from "../dynamic-return-catcher";
+
+/**
+ * NEW-1 (#1097 review): the catcher sets the capture flag synchronously when
+ * it decides to mount the scoped stack. If that lazy chunk then FAILS to
+ * load (stale chunk after a deploy), nothing would ever register to clear
+ * the flag — every sign-in trigger would stay disabled at "Signing in…" and
+ * an uncaught layout-level throw would take out the route. The boundary must
+ * swallow the failure, clear the flag, and log.
+ */
+
+const { logErrorMock } = vi.hoisted(() => ({ logErrorMock: vi.fn() }));
+
+vi.mock("@/lib/dynamic/config", () => ({
+  isDynamicEnabled: () => true,
+}));
+vi.mock("@/lib/logging", () => ({ logError: logErrorMock }));
+// The chunk load itself fails: the factory throwing makes the dynamic import
+// (and therefore React.lazy) reject.
+vi.mock("@/components/auth/scoped-auth-providers", () => {
+  throw new Error("chunk load failed");
+});
+
+function setUrl(search: string) {
+  window.history.replaceState({}, "", `/${search}`);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // React logs caught boundary errors; keep the output readable.
+  vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  setUrl("");
+  // Reset the capture flag (a registration clears it) and leave the store empty.
+  publishAmbientWallet({
+    connected: false,
+    publicKey: null,
+    disconnect: async () => {},
+    openWalletModal: () => {},
+  })();
+  vi.restoreAllMocks();
+});
+
+describe("DynamicReturnCatcher chunk failure (NEW-1)", () => {
+  it("clears the capture flag, logs, and never escalates to the route", async () => {
+    setUrl("?dynamicOauthState=s&dynamicOauthCode=c");
+
+    const { container } = render(<DynamicReturnCatcher />);
+
+    // The decision sets the flag before any chunk resolves…
+    expect(getWalletReturnCaptureActive()).toBe(true);
+
+    // …and the failed load clears it via the boundary instead of throwing.
+    await waitFor(() => expect(getWalletReturnCaptureActive()).toBe(false));
+    expect(logErrorMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        errorId: "dynamic-return-catcher.chunk-failed",
+      })
+    );
+    // Headless recovery: nothing rendered, route intact.
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("stays inert (no flag, no import) on an ordinary page load", () => {
+    setUrl("");
+    const { container } = render(<DynamicReturnCatcher />);
+    expect(getWalletReturnCaptureActive()).toBe(false);
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/apps/web/src/components/auth/__tests__/dynamic-social-sign-in.test.tsx
+++ b/apps/web/src/components/auth/__tests__/dynamic-social-sign-in.test.tsx
@@ -24,8 +24,13 @@ vi.mock("@dynamic-labs-sdk/client", () => ({
   logout: logoutMock,
   signInWithSocialRedirect: redirectMock,
 }));
-vi.mock("@dynamic-labs-sdk/react-hooks", () => ({
-  useUser: () => ({ data: userState.current }),
+// Since #1097 the component reads the session imperatively (getCore over the
+// client singleton) instead of through the provider-bound useUser hook.
+vi.mock("@dynamic-labs-sdk/client/core", () => ({
+  getCore: () => ({ state: { get: () => ({ user: userState.current }) } }),
+}));
+vi.mock("@/lib/dynamic/client", () => ({
+  getDynamicClient: () => ({}),
 }));
 vi.mock("@/lib/analytics", () => ({ trackEvent: vi.fn() }));
 

--- a/apps/web/src/components/auth/auth-modal-body.tsx
+++ b/apps/web/src/components/auth/auth-modal-body.tsx
@@ -1,0 +1,228 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { GithubLogo } from "@phosphor-icons/react";
+import { Button } from "@/components/ui/button";
+import { GoogleLogo } from "@/components/icons/google-logo";
+import { SolanaLogo } from "@/components/icons/solana-logo";
+import { createClient } from "@/lib/supabase/client";
+import { buildOAuthRedirect } from "@/lib/auth/oauth-redirect";
+import { trackEvent } from "@/lib/analytics";
+import { isDynamicEnabled } from "@/lib/dynamic/config";
+import { getAmbientWallet } from "@/lib/solana/ambient-wallet-store";
+import { DynamicSocialSignIn } from "@/components/auth/dynamic-social-sign-in";
+
+export type AuthLoadingMethod = "solana" | "google" | "github" | null;
+
+export interface AuthModalBodyProps {
+  loading: AuthLoadingMethod;
+  setLoading: (v: AuthLoadingMethod) => void;
+  errorMessage: string | null;
+  setErrorMessage: (v: string | null) => void;
+  setOpen: (v: boolean) => void;
+  showLater: boolean;
+  onLater?: () => void;
+}
+
+/**
+ * The sign-in buttons inside the dialog. A separate, lazily-loaded module
+ * (#1097): its import graph (DynamicSocialSignIn → the Dynamic SDK) is
+ * exactly what must stay out of the global header chunk, and AuthModal
+ * renders in the Header on every route. Never import this statically from
+ * anything layout-reachable.
+ *
+ * Needs no provider above it in the React tree: the wallet-select modal is
+ * reached through the ambient store (the live stack registers
+ * `openWalletModal`), and the Dynamic buttons call the SDK imperatively.
+ * AuthModal only renders this once a stack is registered.
+ */
+export default function AuthModalBody({
+  loading,
+  setLoading,
+  errorMessage,
+  setErrorMessage,
+  setOpen,
+  showLater,
+  onLater,
+}: AuthModalBodyProps) {
+  const t = useTranslations("auth");
+  const dynamicEnabled = isDynamicEnabled();
+
+  // Return the learner to the page they signed in from (#619 review): the OAuth
+  // callback otherwise always lands on /dashboard, stranding someone mid-lesson
+  // — and, post-LX-A4, away from the replay that finishes their banked work. The
+  // path-shape guard lives in buildOAuthRedirect (unit-tested); the callback
+  // re-sanitizes server-side too.
+  const oauthRedirectTo = () =>
+    buildOAuthRedirect(window.location.origin, window.location.pathname);
+
+  const handleConnectSolana = () => {
+    setLoading("solana");
+    trackEvent("auth_method_selected", { method: "solana" });
+    // Brief loading state, then hand off to the wallet-select modal of
+    // whichever provider stack is live — read at call time from the store,
+    // since this body renders outside the stack's React tree.
+    setTimeout(() => {
+      setOpen(false);
+      setLoading(null);
+      setTimeout(() => getAmbientWallet()?.openWalletModal(), 200);
+    }, 400);
+  };
+
+  const handleConnectGitHub = async () => {
+    setLoading("github");
+    setErrorMessage(null);
+    trackEvent("auth_method_selected", { method: "github" });
+    try {
+      const supabase = createClient();
+      const { error } = await supabase.auth.signInWithOAuth({
+        provider: "github",
+        options: {
+          redirectTo: oauthRedirectTo(),
+        },
+      });
+      if (error) {
+        console.error("[AuthModal] GitHub sign-in error:", error.message);
+        setErrorMessage(t("githubSignInFailed"));
+        setLoading(null);
+      }
+    } catch (err: unknown) {
+      const message =
+        err instanceof Error ? err.message : t("githubSignInFailed");
+      console.error("[AuthModal] GitHub sign-in error:", message);
+      setErrorMessage(t("githubSignInFailed"));
+      setLoading(null);
+    }
+  };
+
+  const handleConnectGoogle = async () => {
+    setLoading("google");
+    setErrorMessage(null);
+    trackEvent("auth_method_selected", { method: "google" });
+    try {
+      const supabase = createClient();
+      const { error } = await supabase.auth.signInWithOAuth({
+        provider: "google",
+        options: {
+          redirectTo: oauthRedirectTo(),
+        },
+      });
+      if (error) {
+        console.error("[AuthModal] Google sign-in error:", error.message);
+        setErrorMessage(t("googleSignInFailed"));
+        setLoading(null);
+      }
+    } catch (err: unknown) {
+      const message =
+        err instanceof Error ? err.message : t("googleSignInFailed");
+      console.error("[AuthModal] Google sign-in error:", message);
+      setErrorMessage(t("googleSignInFailed"));
+      setLoading(null);
+    }
+  };
+
+  return (
+    <div className="mt-6 space-y-3">
+      <Button
+        variant="outline"
+        className="h-12 w-full gap-3 text-sm font-medium"
+        onClick={handleConnectSolana}
+        disabled={loading !== null}
+      >
+        {loading === "solana" ? (
+          <div className="h-5 w-5 animate-spin rounded-full border-2 border-current border-t-transparent" />
+        ) : (
+          <SolanaLogo className="h-5 w-5 shrink-0" />
+        )}
+        {loading === "solana" ? t("connecting") : t("connectSolanaWallet")}
+      </Button>
+
+      <div className="relative my-4">
+        <div className="absolute inset-0 flex items-center">
+          <span className="w-full border-t" />
+        </div>
+        <div className="relative flex justify-center text-xs uppercase">
+          <span className="bg-bg px-2 text-text-3">{t("or")}</span>
+        </div>
+      </div>
+
+      {/* Google goes through Dynamic when it is configured, so the learner
+          also walks away with an embedded wallet; the Supabase OAuth
+          button below is the fallback AND the kill switch — unsetting the
+          environment id restores it untouched. */}
+      {dynamicEnabled ? (
+        <DynamicSocialSignIn
+          provider="google"
+          disabled={loading !== null}
+          onError={setErrorMessage}
+        />
+      ) : (
+        <Button
+          variant="outline"
+          className="h-12 w-full gap-3 text-sm font-medium"
+          onClick={handleConnectGoogle}
+          disabled={loading !== null}
+        >
+          {loading === "google" ? (
+            <div className="h-5 w-5 animate-spin rounded-full border-2 border-current border-t-transparent" />
+          ) : (
+            <GoogleLogo className="h-5 w-5 shrink-0" />
+          )}
+          {loading === "google" ? t("connecting") : t("signInWithGoogle")}
+        </Button>
+      )}
+
+      {/* GitHub goes through Dynamic when it is configured, so the learner
+          also walks away with an embedded wallet; the Supabase OAuth
+          button below is the fallback AND the kill switch — unsetting the
+          environment id restores it untouched. */}
+      {dynamicEnabled ? (
+        <DynamicSocialSignIn
+          provider="github"
+          disabled={loading !== null}
+          onError={setErrorMessage}
+        />
+      ) : (
+        <Button
+          variant="outline"
+          className="h-12 w-full gap-3 text-sm font-medium"
+          onClick={handleConnectGitHub}
+          disabled={loading !== null}
+        >
+          {loading === "github" ? (
+            <div className="h-5 w-5 animate-spin rounded-full border-2 border-current border-t-transparent" />
+          ) : (
+            <GithubLogo className="h-5 w-5 shrink-0" weight="fill" />
+          )}
+          {loading === "github" ? t("connecting") : t("signInWithGitHub")}
+        </Button>
+      )}
+
+      {errorMessage && (
+        <p className="text-center text-sm text-danger" role="alert">
+          {errorMessage}
+        </p>
+      )}
+
+      {showLater && (
+        <div className="space-y-3 pt-1">
+          <Button
+            variant="ghost"
+            className="h-10 w-full text-sm font-medium text-text-3"
+            onClick={() => {
+              setOpen(false);
+              onLater?.();
+            }}
+            disabled={loading !== null}
+          >
+            {t("later")}
+          </Button>
+          {/* Reassurance — the work is KEPT, never discarded (F4). */}
+          <p className="text-center text-xs text-text-3">
+            {t("progressSavedLocally")}
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/auth/auth-modal.tsx
+++ b/apps/web/src/components/auth/auth-modal.tsx
@@ -1,9 +1,20 @@
 "use client";
 
-import { forwardRef, useState, type ComponentProps } from "react";
+import {
+  Component,
+  forwardRef,
+  lazy,
+  Suspense,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ComponentProps,
+  type ComponentType,
+  type ReactNode,
+} from "react";
+import { usePathname } from "next/navigation";
 import { useTranslations } from "next-intl";
-import { useWalletModal } from "@solana/wallet-adapter-react-ui";
-import { GithubLogo } from "@phosphor-icons/react";
 import {
   Dialog,
   DialogContent,
@@ -13,14 +24,15 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
-import { GoogleLogo } from "@/components/icons/google-logo";
-import { SolanaLogo } from "@/components/icons/solana-logo";
-import { createClient } from "@/lib/supabase/client";
-import { buildOAuthRedirect } from "@/lib/auth/oauth-redirect";
-import { trackEvent } from "@/lib/analytics";
-import { isDynamicEnabled } from "@/lib/dynamic/config";
+import {
+  useAmbientWalletLive,
+  useWalletReturnCaptureActive,
+} from "@/lib/solana/ambient-wallet-store";
 import { useSocialReturnPending } from "@/hooks/use-social-return-pending";
-import { DynamicSocialSignIn } from "@/components/auth/dynamic-social-sign-in";
+import type {
+  AuthLoadingMethod,
+  AuthModalBodyProps,
+} from "@/components/auth/auth-modal-body";
 
 interface AuthModalProps {
   trigger?: React.ReactNode;
@@ -43,9 +55,10 @@ interface AuthModalProps {
 
 /**
  * The button that opens the auth modal, with the social-return spinner built
- * in: while the Google/GitHub return handshake runs, the button shows
- * "Signing in…" and disables itself. AuthModal's default trigger; also for
- * custom triggers (the landing hero) that hand-copied this markup before
+ * in: while the Google/GitHub return handshake runs — or while the catcher is
+ * standing up the provider stack for a redirect return (#1097) — the button
+ * shows "Signing in…" and disables itself. AuthModal's default trigger; also
+ * for custom triggers (the landing hero) that hand-copied this markup before
  * #1077. Forwards ref and props so it works under `DialogTrigger asChild`.
  */
 export const AuthTriggerButton = forwardRef<
@@ -54,10 +67,12 @@ export const AuthTriggerButton = forwardRef<
 >(function AuthTriggerButton({ label, disabled, ...props }, ref) {
   const t = useTranslations("auth");
   const socialReturnPending = useSocialReturnPending();
+  const captureActive = useWalletReturnCaptureActive();
+  const returning = socialReturnPending || captureActive;
 
   return (
-    <Button ref={ref} disabled={disabled || socialReturnPending} {...props}>
-      {socialReturnPending ? (
+    <Button ref={ref} disabled={disabled || returning} {...props}>
+      {returning ? (
         <span className="inline-flex items-center gap-2">
           <span
             className="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent"
@@ -72,6 +87,31 @@ export const AuthTriggerButton = forwardRef<
   );
 });
 
+/**
+ * Catches a failed lazy chunk load (e.g. a stale chunk 404 right after a
+ * deploy) so it surfaces as an in-modal retry instead of the root error page
+ * (#1097 review F3). Remounted via `key` on retry, because a rejected
+ * `React.lazy` stays rejected — the parent recreates the lazy components too.
+ */
+class ChunkErrorBoundary extends Component<
+  { onError: () => void; children: ReactNode },
+  { failed: boolean }
+> {
+  state = { failed: false };
+
+  static getDerivedStateFromError() {
+    return { failed: true };
+  }
+
+  componentDidCatch() {
+    this.props.onError();
+  }
+
+  render() {
+    return this.state.failed ? null : this.props.children;
+  }
+}
+
 export function AuthModal({
   trigger,
   open: controlledOpen,
@@ -81,6 +121,7 @@ export function AuthModal({
 }: AuthModalProps) {
   const t = useTranslations("auth");
   const tCommon = useTranslations("common");
+  const pathname = usePathname();
   const [internalOpen, setInternalOpen] = useState(false);
   const isControlled = controlledOpen !== undefined;
   const open = isControlled ? controlledOpen : internalOpen;
@@ -88,221 +129,148 @@ export function AuthModal({
     if (!isControlled) setInternalOpen(v);
     onOpenChange?.(v);
   };
-  const [loading, setLoading] = useState<"solana" | "google" | "github" | null>(
-    null
-  );
+  const [loading, setLoading] = useState<AuthLoadingMethod>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
-  // NOT a Dynamic hook call. Every hook in `@dynamic-labs-sdk/react-hooks`
-  // throws `MissingProviderError` when no provider is mounted, so calling one
-  // here would crash sign-in in any build without an environment id. Hooks
-  // cannot be conditional, so the gate is a component boundary instead:
-  // DynamicSocialSignIn owns the hooks and mounts only when Dynamic is enabled.
-  const dynamicEnabled = isDynamicEnabled();
-  const { setVisible } = useWalletModal();
 
-  // Return the learner to the page they signed in from (#619 review): the OAuth
-  // callback otherwise always lands on /dashboard, stranding someone mid-lesson
-  // — and, post-LX-A4, away from the replay that finishes their banked work. The
-  // path-shape guard lives in buildOAuthRedirect (unit-tested); the callback
-  // re-sanitizes server-side too.
-  const oauthRedirectTo = () =>
-    buildOAuthRedirect(window.location.origin, window.location.pathname);
+  // Where the wallet/Dynamic providers come from (#1097): on (platform)
+  // routes the layout's stack is registered in the ambient store; elsewhere
+  // the first open arms a lazily-loaded scoped stack, mounted as a SIBLING of
+  // the Dialog (never around it — the Dialog's tree position stays stable)
+  // and sticky after close, because the Solana path closes this modal and
+  // hands off to the wallet-select modal, which lives in that stack.
+  //
+  // The two live-stack guards:
+  //  - ambientLive: never arm while any stack is registered — nesting or
+  //    duplicating WalletProvider doubles autoConnect, listeners, and SIWS.
+  //  - captureActive: DynamicReturnCatcher has decided to mount its own stack
+  //    for a redirect return but its chunk has not registered yet; arming in
+  //    that window would race it (review F4).
+  const ambientLive = useAmbientWalletLive();
+  const captureActive = useWalletReturnCaptureActive();
+  const [scopedMounted, setScopedMounted] = useState(false);
+  useEffect(() => {
+    // An effect rather than a setOpen side effect so controlled openers
+    // (open prop flipped by a parent) take the scoped path too.
+    if (open && !ambientLive && !captureActive) setScopedMounted(true);
+  }, [open, ambientLive, captureActive]);
 
-  const handleConnectSolana = () => {
-    setLoading("solana");
-    trackEvent("auth_method_selected", { method: "solana" });
-    // Brief loading state, then hand off to wallet adapter modal
-    setTimeout(() => {
-      setOpen(false);
-      setLoading(null);
-      setTimeout(() => setVisible(true), 200);
-    }, 400);
-  };
+  // Disarm on client-side navigation while closed: without this, a scoped
+  // stack armed on a marketing page would keep living beside the (platform)
+  // stack after the learner navigates there.
+  const openRef = useRef(open);
+  openRef.current = open;
+  useEffect(() => {
+    if (!openRef.current) setScopedMounted(false);
+  }, [pathname]);
 
-  const handleConnectGitHub = async () => {
-    setLoading("github");
-    setErrorMessage(null);
-    trackEvent("auth_method_selected", { method: "github" });
-    try {
-      const supabase = createClient();
-      const { error } = await supabase.auth.signInWithOAuth({
-        provider: "github",
-        options: {
-          redirectTo: oauthRedirectTo(),
-        },
-      });
-      if (error) {
-        console.error("[AuthModal] GitHub sign-in error:", error.message);
-        setErrorMessage(t("githubSignInFailed"));
-        setLoading(null);
-      }
-    } catch (err: unknown) {
-      const message =
-        err instanceof Error ? err.message : t("githubSignInFailed");
-      console.error("[AuthModal] GitHub sign-in error:", message);
-      setErrorMessage(t("githubSignInFailed"));
-      setLoading(null);
-    }
-  };
+  // Chunk-load failure handling (review F3): both lazies are recreated per
+  // attempt because a rejected React.lazy caches its rejection.
+  const [chunkFailed, setChunkFailed] = useState(false);
+  const [attempt, setAttempt] = useState(0);
+  const { LazyBody, LazyStack } = useMemo(() => {
+    void attempt; // cache-buster: a new attempt makes fresh lazy components
+    return {
+      LazyBody: lazy(
+        () => import("@/components/auth/auth-modal-body")
+      ) as ComponentType<AuthModalBodyProps>,
+      LazyStack: lazy(() => import("@/components/auth/scoped-auth-providers")),
+    };
+  }, [attempt]);
 
-  const handleConnectGoogle = async () => {
-    setLoading("google");
-    setErrorMessage(null);
-    trackEvent("auth_method_selected", { method: "google" });
-    try {
-      const supabase = createClient();
-      const { error } = await supabase.auth.signInWithOAuth({
-        provider: "google",
-        options: {
-          redirectTo: oauthRedirectTo(),
-        },
-      });
-      if (error) {
-        console.error("[AuthModal] Google sign-in error:", error.message);
-        setErrorMessage(t("googleSignInFailed"));
-        setLoading(null);
-      }
-    } catch (err: unknown) {
-      const message =
-        err instanceof Error ? err.message : t("googleSignInFailed");
-      console.error("[AuthModal] Google sign-in error:", message);
-      setErrorMessage(t("googleSignInFailed"));
-      setLoading(null);
-    }
-  };
+  const spinner = (
+    <div
+      className="flex h-40 items-center justify-center"
+      role="status"
+      aria-label={t("signingIn")}
+    >
+      <div className="h-6 w-6 animate-spin rounded-full border-2 border-current border-t-transparent" />
+    </div>
+  );
 
   return (
-    <Dialog
-      open={open}
-      onOpenChange={(v) => {
-        if (!loading) {
-          setOpen(v);
-          if (!v) setErrorMessage(null);
-        }
-      }}
-    >
-      {(trigger !== undefined || !isControlled) && (
-        <DialogTrigger asChild>
-          {/* While the Google-return handshake runs, the trigger button
-              carries the loading state — the alternative was a full-screen
-              overlay, and the owner preferred the button. */}
-          {trigger ?? (
-            <AuthTriggerButton variant="push" label={tCommon("signIn")} />
-          )}
-        </DialogTrigger>
-      )}
-      <DialogContent className="sm:max-w-sm">
-        <DialogHeader>
-          <DialogTitle className="text-center">
-            {t(showLater ? "keepProgressTitle" : "signInTitle")}
-          </DialogTitle>
-          <DialogDescription className="text-center">
-            {t(showLater ? "keepProgressSubtitle" : "signInSubtitle")}
-          </DialogDescription>
-        </DialogHeader>
-        <div className="mt-6 space-y-3">
-          <Button
-            variant="outline"
-            className="h-12 w-full gap-3 text-sm font-medium"
-            onClick={handleConnectSolana}
-            disabled={loading !== null}
-          >
-            {loading === "solana" ? (
-              <div className="h-5 w-5 animate-spin rounded-full border-2 border-current border-t-transparent" />
-            ) : (
-              <SolanaLogo className="h-5 w-5 shrink-0" />
+    <>
+      {scopedMounted ? (
+        <ChunkErrorBoundary
+          key={`stack-${attempt}`}
+          onError={() => setChunkFailed(true)}
+        >
+          <Suspense fallback={null}>
+            <LazyStack />
+          </Suspense>
+        </ChunkErrorBoundary>
+      ) : null}
+      <Dialog
+        open={open}
+        onOpenChange={(v) => {
+          if (!loading) {
+            setOpen(v);
+            if (!v) setErrorMessage(null);
+          }
+        }}
+      >
+        {(trigger !== undefined || !isControlled) && (
+          <DialogTrigger asChild>
+            {/* While the Google-return handshake runs, the trigger button
+                carries the loading state — the alternative was a full-screen
+                overlay, and the owner preferred the button. */}
+            {trigger ?? (
+              <AuthTriggerButton variant="push" label={tCommon("signIn")} />
             )}
-            {loading === "solana" ? t("connecting") : t("connectSolanaWallet")}
-          </Button>
-
-          <div className="relative my-4">
-            <div className="absolute inset-0 flex items-center">
-              <span className="w-full border-t" />
-            </div>
-            <div className="relative flex justify-center text-xs uppercase">
-              <span className="bg-bg px-2 text-text-3">{t("or")}</span>
-            </div>
-          </div>
-
-          {/* Google goes through Dynamic when it is configured, so the learner
-              also walks away with an embedded wallet; the Supabase OAuth
-              button below is the fallback AND the kill switch — unsetting the
-              environment id restores it untouched. */}
-          {dynamicEnabled ? (
-            <DynamicSocialSignIn
-              provider="google"
-              disabled={loading !== null}
-              onError={setErrorMessage}
-            />
-          ) : (
-            <Button
-              variant="outline"
-              className="h-12 w-full gap-3 text-sm font-medium"
-              onClick={handleConnectGoogle}
-              disabled={loading !== null}
-            >
-              {loading === "google" ? (
-                <div className="h-5 w-5 animate-spin rounded-full border-2 border-current border-t-transparent" />
-              ) : (
-                <GoogleLogo className="h-5 w-5 shrink-0" />
-              )}
-              {loading === "google" ? t("connecting") : t("signInWithGoogle")}
-            </Button>
-          )}
-
-          {/* GitHub goes through Dynamic when it is configured, so the learner
-              also walks away with an embedded wallet; the Supabase OAuth
-              button below is the fallback AND the kill switch — unsetting the
-              environment id restores it untouched. */}
-          {dynamicEnabled ? (
-            <DynamicSocialSignIn
-              provider="github"
-              disabled={loading !== null}
-              onError={setErrorMessage}
-            />
-          ) : (
-            <Button
-              variant="outline"
-              className="h-12 w-full gap-3 text-sm font-medium"
-              onClick={handleConnectGitHub}
-              disabled={loading !== null}
-            >
-              {loading === "github" ? (
-                <div className="h-5 w-5 animate-spin rounded-full border-2 border-current border-t-transparent" />
-              ) : (
-                <GithubLogo className="h-5 w-5 shrink-0" weight="fill" />
-              )}
-              {loading === "github" ? t("connecting") : t("signInWithGitHub")}
-            </Button>
-          )}
-
-          {errorMessage && (
-            <p className="text-center text-sm text-danger" role="alert">
-              {errorMessage}
-            </p>
-          )}
-
-          {showLater && (
-            <div className="space-y-3 pt-1">
-              <Button
-                variant="ghost"
-                className="h-10 w-full text-sm font-medium text-text-3"
-                onClick={() => {
-                  setOpen(false);
-                  onLater?.();
-                }}
-                disabled={loading !== null}
+          </DialogTrigger>
+        )}
+        <DialogContent className="sm:max-w-sm">
+          <DialogHeader>
+            <DialogTitle className="text-center">
+              {t(showLater ? "keepProgressTitle" : "signInTitle")}
+            </DialogTitle>
+            <DialogDescription className="text-center">
+              {t(showLater ? "keepProgressSubtitle" : "signInSubtitle")}
+            </DialogDescription>
+          </DialogHeader>
+          {chunkFailed ? (
+            <div className="mt-6 flex flex-col items-center gap-4">
+              <p
+                className="max-w-xs text-center text-sm font-medium text-danger"
+                role="alert"
               >
-                {t("later")}
-              </Button>
-              {/* Reassurance — the work is KEPT, never discarded (F4). */}
-              <p className="text-center text-xs text-text-3">
-                {t("progressSavedLocally")}
+                {t("authFailed")}
               </p>
+              <Button
+                variant="push"
+                size="sm"
+                onClick={() => {
+                  setChunkFailed(false);
+                  setAttempt((a) => a + 1);
+                }}
+              >
+                {t("retry")}
+              </Button>
             </div>
+          ) : !ambientLive ? (
+            // The provider stack is still standing up (scoped chunk loading,
+            // or the catcher's) — the body needs it registered before the
+            // wallet buttons can do anything.
+            spinner
+          ) : (
+            <ChunkErrorBoundary
+              key={`body-${attempt}`}
+              onError={() => setChunkFailed(true)}
+            >
+              <Suspense fallback={spinner}>
+                <LazyBody
+                  loading={loading}
+                  setLoading={setLoading}
+                  errorMessage={errorMessage}
+                  setErrorMessage={setErrorMessage}
+                  setOpen={setOpen}
+                  showLater={showLater}
+                  onLater={onLater}
+                />
+              </Suspense>
+            </ChunkErrorBoundary>
           )}
-        </div>
-      </DialogContent>
-    </Dialog>
+        </DialogContent>
+      </Dialog>
+    </>
   );
 }

--- a/apps/web/src/components/auth/auth-modal.tsx
+++ b/apps/web/src/components/auth/auth-modal.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import {
-  Component,
   forwardRef,
   lazy,
   Suspense,
@@ -11,7 +10,6 @@ import {
   useState,
   type ComponentProps,
   type ComponentType,
-  type ReactNode,
 } from "react";
 import { usePathname } from "next/navigation";
 import { useTranslations } from "next-intl";
@@ -25,9 +23,11 @@ import {
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import {
+  useAmbientStackCount,
   useAmbientWalletLive,
   useWalletReturnCaptureActive,
 } from "@/lib/solana/ambient-wallet-store";
+import { ChunkErrorBoundary } from "@/components/auth/chunk-error-boundary";
 import { useSocialReturnPending } from "@/hooks/use-social-return-pending";
 import type {
   AuthLoadingMethod,
@@ -87,31 +87,6 @@ export const AuthTriggerButton = forwardRef<
   );
 });
 
-/**
- * Catches a failed lazy chunk load (e.g. a stale chunk 404 right after a
- * deploy) so it surfaces as an in-modal retry instead of the root error page
- * (#1097 review F3). Remounted via `key` on retry, because a rejected
- * `React.lazy` stays rejected — the parent recreates the lazy components too.
- */
-class ChunkErrorBoundary extends Component<
-  { onError: () => void; children: ReactNode },
-  { failed: boolean }
-> {
-  state = { failed: false };
-
-  static getDerivedStateFromError() {
-    return { failed: true };
-  }
-
-  componentDidCatch() {
-    this.props.onError();
-  }
-
-  render() {
-    return this.state.failed ? null : this.props.children;
-  }
-}
-
 export function AuthModal({
   trigger,
   open: controlledOpen,
@@ -157,11 +132,29 @@ export function AuthModal({
   // Disarm on client-side navigation while closed: without this, a scoped
   // stack armed on a marketing page would keep living beside the (platform)
   // stack after the learner navigates there.
+  //
+  // TIMING (review): the disarm effect runs in the same React commit that
+  // renders the new route's layout, so the two WalletProviders overlap for at
+  // most a single frame — while autoConnect's connect() is an async
+  // round-trip into the wallet extension that has not resolved yet, and
+  // WalletAuthHandler only fires SIWS on `connected` flipping true. A
+  // double-SIWS would need the overlap to outlive that round-trip; one frame
+  // cannot. This effect must NOT be merged into the same commit as the route
+  // swap by moving it into render — keep it an effect.
   const openRef = useRef(open);
   openRef.current = open;
   useEffect(() => {
     if (!openRef.current) setScopedMounted(false);
   }, [pathname]);
+
+  // …and while OPEN: navigation with the dialog up (or any second stack
+  // registering) shows as a registration count of 2 — this stack's own
+  // registration plus the newcomer's. Dropping ours converges back to one;
+  // the body keeps working against the newcomer via the store (review NEW-2).
+  const stackCount = useAmbientStackCount();
+  useEffect(() => {
+    if (scopedMounted && stackCount >= 2) setScopedMounted(false);
+  }, [scopedMounted, stackCount]);
 
   // Chunk-load failure handling (review F3): both lazies are recreated per
   // attempt because a rejected React.lazy caches its rejection.

--- a/apps/web/src/components/auth/chunk-error-boundary.tsx
+++ b/apps/web/src/components/auth/chunk-error-boundary.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { Component, type ErrorInfo, type ReactNode } from "react";
+
+/**
+ * Catches a failed lazy chunk load (e.g. a stale chunk 404 right after a
+ * deploy) so it never bubbles to the root error page (#1097 review F3/NEW-1).
+ * Renders nothing when failed — the owner decides what recovery looks like
+ * via `onError` (AuthModal shows an in-modal retry; DynamicReturnCatcher
+ * clears its capture flag and stays silent). A rejected `React.lazy` caches
+ * its rejection, so retrying means remounting via `key` AND recreating the
+ * lazy components.
+ */
+export class ChunkErrorBoundary extends Component<
+  { onError: (error: Error) => void; children: ReactNode },
+  { failed: boolean }
+> {
+  state = { failed: false };
+
+  static getDerivedStateFromError() {
+    return { failed: true };
+  }
+
+  componentDidCatch(error: Error, _info: ErrorInfo) {
+    this.props.onError(error);
+  }
+
+  render() {
+    return this.state.failed ? null : this.props.children;
+  }
+}

--- a/apps/web/src/components/auth/dynamic-auth-handler.tsx
+++ b/apps/web/src/components/auth/dynamic-auth-handler.tsx
@@ -21,10 +21,8 @@ import { createClient } from "@/lib/supabase/client";
 import { runWalletSiws } from "@/lib/wallet/siws";
 import { logoutDynamic } from "@/lib/dynamic/client";
 import { toMessageSigner } from "@/lib/dynamic/siws";
-import {
-  bridgeDynamicSession,
-  setSocialReturnPending,
-} from "@/lib/dynamic/social";
+import { bridgeDynamicSession } from "@/lib/dynamic/social";
+import { setSocialReturnPending } from "@/lib/dynamic/social-return-pending";
 import { dispatchToast } from "@/components/ui/toast-container";
 
 /**

--- a/apps/web/src/components/auth/dynamic-return-catcher.tsx
+++ b/apps/web/src/components/auth/dynamic-return-catcher.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { lazy, Suspense, useEffect, useState } from "react";
+import { isDynamicEnabled } from "@/lib/dynamic/config";
+import { setWalletReturnCaptureActive } from "@/lib/solana/ambient-wallet-store";
+
+const ScopedAuthProviders = lazy(
+  () => import("@/components/auth/scoped-auth-providers")
+);
+
+/**
+ * Completes a Dynamic redirect that lands on a provider-less route.
+ *
+ * Dynamic social sign-in is a full-page navigation back to the page the
+ * learner left (`DynamicSocialSignIn` passes `redirectUrl: location.href`),
+ * and `DynamicAuthHandler` — which finishes the handshake — used to be
+ * mounted globally. Since #1097 the provider stack lives on (platform) routes
+ * only, so a return landing on a marketing or admin page would strand the
+ * sign-in. This component is mounted on exactly those route groups: it sniffs
+ * the SDK's callback params from the URL (no SDK import — the param names are
+ * the stable contract of `detectSocialRedirectUrl` /
+ * `detectDeviceRegistrationRedirect`) and lazily mounts the scoped provider
+ * stack, whose handlers then run the real, SDK-verified detection.
+ *
+ * On every ordinary page load this renders null and loads nothing.
+ */
+export function DynamicReturnCatcher() {
+  const [mount, setMount] = useState(false);
+
+  useEffect(() => {
+    if (!isDynamicEnabled()) return;
+    const params = new URLSearchParams(window.location.search);
+    if (
+      (params.has("dynamicOauthState") && params.has("dynamicOauthCode")) ||
+      params.has("deviceRegistrationToken")
+    ) {
+      // Synchronously, BEFORE the lazy chunk resolves: AuthModal must not arm
+      // its own scoped stack in the window between this decision and the
+      // stack registering in the ambient store (two stacks would race
+      // autoConnect and SIWS). Registration clears the flag.
+      setWalletReturnCaptureActive();
+      setMount(true);
+    }
+  }, []);
+
+  if (!mount) return null;
+  return (
+    <Suspense fallback={null}>
+      <ScopedAuthProviders />
+    </Suspense>
+  );
+}

--- a/apps/web/src/components/auth/dynamic-return-catcher.tsx
+++ b/apps/web/src/components/auth/dynamic-return-catcher.tsx
@@ -2,7 +2,12 @@
 
 import { lazy, Suspense, useEffect, useState } from "react";
 import { isDynamicEnabled } from "@/lib/dynamic/config";
-import { setWalletReturnCaptureActive } from "@/lib/solana/ambient-wallet-store";
+import { logError } from "@/lib/logging";
+import {
+  clearWalletReturnCapture,
+  setWalletReturnCaptureActive,
+} from "@/lib/solana/ambient-wallet-store";
+import { ChunkErrorBoundary } from "@/components/auth/chunk-error-boundary";
 
 const ScopedAuthProviders = lazy(
   () => import("@/components/auth/scoped-auth-providers")
@@ -44,9 +49,25 @@ export function DynamicReturnCatcher() {
   }, []);
 
   if (!mount) return null;
+  // A failed chunk load must clear the capture flag it set (review NEW-1):
+  // no registration will ever arrive to clear it, and a stuck flag keeps
+  // every sign-in trigger disabled at "Signing in…" for the page's life —
+  // while an uncaught layout-level throw would take out the whole route.
+  // Silent recovery is right for a headless catcher: the learner clicks
+  // sign-in again and the modal path (flag now clear) takes over.
   return (
-    <Suspense fallback={null}>
-      <ScopedAuthProviders />
-    </Suspense>
+    <ChunkErrorBoundary
+      onError={(error) => {
+        clearWalletReturnCapture();
+        logError({
+          errorId: "dynamic-return-catcher.chunk-failed",
+          error,
+        });
+      }}
+    >
+      <Suspense fallback={null}>
+        <ScopedAuthProviders />
+      </Suspense>
+    </ChunkErrorBoundary>
   );
 }

--- a/apps/web/src/components/auth/dynamic-social-sign-in.tsx
+++ b/apps/web/src/components/auth/dynamic-social-sign-in.tsx
@@ -3,11 +3,12 @@
 import { useState, type ComponentType } from "react";
 import { useTranslations } from "next-intl";
 import { logout, signInWithSocialRedirect } from "@dynamic-labs-sdk/client";
-import { useUser } from "@dynamic-labs-sdk/react-hooks";
+import { getCore } from "@dynamic-labs-sdk/client/core";
 import { GithubLogo } from "@phosphor-icons/react";
 import { Button } from "@/components/ui/button";
-import { GoogleLogo } from "@/components/icons/google-logo";
+import { getDynamicClient } from "@/lib/dynamic/client";
 import { trackEvent } from "@/lib/analytics";
+import { GoogleLogo } from "@/components/icons/google-logo";
 
 /**
  * A social sign-in button routed through Dynamic instead of Supabase OAuth.
@@ -21,10 +22,12 @@ import { trackEvent } from "@/lib/analytics";
  * by `DynamicAuthHandler`; there is no popup variant on web (see
  * `lib/dynamic/social.ts`).
  *
- * Split out because `useUser` throws `MissingProviderError` outside a
- * `DynamicProvider`, and hooks cannot be conditional, so the feature gate has
- * to be a component boundary. One component serves every provider — adding a
- * third is a PROVIDERS entry, not a copy-paste.
+ * Reads the Dynamic session imperatively (the SDK's own `getCore` escape
+ * hatch, same one `lib/dynamic/social.ts` uses) rather than through
+ * `useUser`, because since #1097 this renders in the lazily-loaded modal
+ * body OUTSIDE any `DynamicProvider` — every `@dynamic-labs-sdk/react-hooks`
+ * hook throws `MissingProviderError` there. One component serves every
+ * provider — adding a third is a PROVIDERS entry, not a copy-paste.
  */
 type DynamicSocialProvider = "google" | "github";
 
@@ -66,7 +69,6 @@ export function DynamicSocialSignIn({
 }) {
   const t = useTranslations("auth");
   const [starting, setStarting] = useState(false);
-  const { data: dynamicUser } = useUser();
   const { Icon, labelKey, errorKey } = PROVIDERS[provider];
 
   const handleClick = async () => {
@@ -78,7 +80,17 @@ export function DynamicSocialSignIn({
       // different symptom: `processSocialCallback` branches on `client.user`
       // and calls `oauthVerify` (LINK this account to the existing Dynamic
       // user) instead of `oauthSignIn` when one is present. This button is
-      // strictly sign-in, so a session that predates it is cleared.
+      // strictly sign-in, so a session that predates it is cleared. Read at
+      // click time from core state — no provider, no hook (see docblock).
+      const client = getDynamicClient();
+      let dynamicUser: unknown = null;
+      if (client) {
+        try {
+          dynamicUser = getCore(client).state.get().user;
+        } catch {
+          // Core unavailable — treat as "no session".
+        }
+      }
       if (dynamicUser) await logout();
       await signInWithSocialRedirect({
         provider,

--- a/apps/web/src/components/auth/scoped-auth-providers.tsx
+++ b/apps/web/src/components/auth/scoped-auth-providers.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { SolanaWalletProvider } from "@/lib/solana/wallet-provider";
+import { DynamicWalletProvider } from "@/components/auth/dynamic-wallet-provider";
+
+/**
+ * The full wallet/Dynamic provider stack, for the places OUTSIDE (platform)
+ * routes that still need it on demand (#1097): around the AuthModal body when
+ * it opens on a marketing/admin page, and under `DynamicReturnCatcher` when a
+ * social-redirect return lands on one.
+ *
+ * Loaded exclusively through `React.lazy` — this module is the chunk boundary
+ * that keeps wallet-adapter, Dynamic, and TanStack Query out of marketing
+ * first loads. Never import it statically from anything marketing-reachable.
+ *
+ * `lib/dynamic/client.ts`'s SSR tree-shape constraint (never mount the
+ * providers browser-only at layout level) does not apply here: everything
+ * under this component mounts post-hydration on user action or URL detection,
+ * so there is no server tree to mismatch. The Dynamic client itself is a
+ * module singleton with an `initialised` flag, so a second stack in the same
+ * page never re-initialises it.
+ *
+ * Mounting this beside a live (platform) stack would duplicate autoConnect
+ * and wallet listeners — callers must gate on the ambient store
+ * (`useAmbientWalletLive` / the capture flag) first.
+ */
+export default function ScopedAuthProviders({
+  children,
+}: {
+  children?: ReactNode;
+}) {
+  return (
+    <SolanaWalletProvider>
+      <DynamicWalletProvider>{children}</DynamicWalletProvider>
+    </SolanaWalletProvider>
+  );
+}

--- a/apps/web/src/components/auth/user-menu.tsx
+++ b/apps/web/src/components/auth/user-menu.tsx
@@ -13,7 +13,7 @@ import {
   Trophy,
   UserCircle,
 } from "@phosphor-icons/react";
-import { useWallet } from "@solana/wallet-adapter-react";
+import { useAmbientWallet } from "@/lib/solana/ambient-wallet-store";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -25,7 +25,7 @@ import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { fetchIsAdmin } from "@/lib/admin/client";
 import { resetUser } from "@/lib/analytics";
 import { createClient } from "@/lib/supabase/client";
-import { logoutDynamic } from "@/lib/dynamic/client";
+import { isDynamicEnabled } from "@/lib/dynamic/config";
 
 interface UserMenuProps {
   username: string;
@@ -42,7 +42,11 @@ export function UserMenu({
 }: UserMenuProps) {
   const tCommon = useTranslations("common");
   const tNav = useTranslations("nav");
-  const { disconnect, connected } = useWallet();
+  // The wallet surface published by whichever provider stack is live
+  // ((platform) layout or the modal's scoped stack, #1097) — UserMenu renders
+  // in the global Header ABOVE both, so context can't reach it and the module
+  // store can. Null when no stack is mounted.
+  const wallet = useAmbientWallet();
   const [copied, setCopied] = useState(false);
 
   // Cosmetic Admin entry: shown only when the server says the session is on
@@ -64,24 +68,39 @@ export function UserMenu({
   }, []);
 
   const handleSignOut = useCallback(async () => {
-    if (connected) {
+    if (wallet?.connected) {
       try {
-        await disconnect();
+        await wallet.disconnect();
       } catch {
         // Wallet may already be disconnected — proceed with sign-out
       }
     }
+    // Belt and braces for the no-stack case (signing out on a marketing
+    // page): wallet-adapter persists the selected wallet under `walletName`
+    // (WalletProvider's localStorageKey default) and silently reconnects it
+    // via autoConnect on the next provider mount — WalletAuthHandler would
+    // then SIWS the learner straight back into the account they just left.
+    // Clearing the key makes the next provider mount start signed out.
+    try {
+      window.localStorage.removeItem("walletName");
+    } catch {
+      // Storage unavailable (privacy mode) — nothing persisted to clear.
+    }
     // End the Dynamic session too — without this, promptless MPC signing lets
     // the layout-level auth handler silently sign the learner back in on the
-    // next page load (see logoutDynamic).
-    await logoutDynamic();
+    // next page load (see logoutDynamic). Imported on demand: the static
+    // import would put the Dynamic SDK back into the global header chunk.
+    if (isDynamicEnabled()) {
+      const { logoutDynamic } = await import("@/lib/dynamic/client");
+      await logoutDynamic();
+    }
     const supabase = createClient();
     await supabase.auth.signOut();
     // Sever the analytics identity so the next visitor on this browser is not
     // attributed to the signed-out account.
     resetUser();
     window.location.href = `/${locale}`;
-  }, [locale, connected, disconnect]);
+  }, [locale, wallet]);
 
   const handleCopyAddress = useCallback(
     (e: React.MouseEvent) => {

--- a/apps/web/src/components/gamification/gamification-overlays.tsx
+++ b/apps/web/src/components/gamification/gamification-overlays.tsx
@@ -5,7 +5,6 @@ import { AchievementPopup } from "@/components/gamification/achievement-popup";
 import { CertificatePopup } from "@/components/gamification/certificate-popup";
 import { RewardPopupQueue } from "@/components/gamification/reward-popup";
 import { useGamificationEvents } from "@/hooks/use-gamification-events";
-import { ToastContainer } from "@/components/ui/toast-container";
 import { BankedProgressReplay } from "@/components/lessons/banked-progress-replay";
 import { SegmentSync } from "@/components/onboarding/segment-sync";
 
@@ -17,8 +16,10 @@ export function GamificationOverlays() {
 
   return (
     <>
-      {/* Toast container always renders — works for auth and non-auth contexts */}
-      <ToastContainer />
+      {/* ToastContainer is NOT here (#1097): these overlays mount only on
+          (platform) routes, while marketing pages dispatch toasts too (e.g.
+          AuthErrorToast on the landing page), so the container renders
+          globally in [locale]/layout.tsx instead. */}
       {/* Replays anonymously-banked completions once signed in (LX-A4c). */}
       <BankedProgressReplay />
       {/* Copies the anonymous /start intake into the profile on sign-in (LX-A3). */}

--- a/apps/web/src/components/layout/__tests__/low-sol-banner.test.tsx
+++ b/apps/web/src/components/layout/__tests__/low-sol-banner.test.tsx
@@ -13,6 +13,8 @@ const state = vi.hoisted(() => {
   };
 });
 
+// The banner mounts inside the (platform) provider stack (#1097), so its
+// hooks always resolve against a live provider — which these mocks model.
 vi.mock("@solana/wallet-adapter-react", () => ({
   useWallet: () => ({ publicKey: state.publicKey }),
   useConnection: () => ({ connection: state.connection }),

--- a/apps/web/src/components/layout/header.tsx
+++ b/apps/web/src/components/layout/header.tsx
@@ -16,7 +16,6 @@ import { UserMenu } from "@/components/auth/user-menu";
 import { LevelBadge } from "@/components/gamification/level-badge";
 import { xpToNextLevel, calculateLevel } from "@/lib/gamification/xp";
 import { createClient } from "@/lib/supabase/client";
-import { LowSolBanner } from "@/components/layout/low-sol-banner";
 
 // LX-B13 (#583): the leaderboard is intentionally NOT a primary nav CTA at
 // launch — it stays reachable via the user menu and the footer. Restore it
@@ -189,7 +188,8 @@ export function Header() {
   return (
     <header className="fixed left-0 right-0 top-0 z-[200]">
       <div className="relative bg-transparent backdrop-blur-md">
-        <LowSolBanner />
+        {/* LowSolBanner moved to (platform)/layout.tsx (#1097): it needs the
+            wallet providers, which no longer mount above the Header. */}
         <div className="relative mx-auto flex h-[56px] max-w-[1600px] items-center px-[16px]">
           {/* Left: Logo (desktop lg+) */}
           <Link

--- a/apps/web/src/components/layout/low-sol-banner.tsx
+++ b/apps/web/src/components/layout/low-sol-banner.tsx
@@ -16,6 +16,9 @@ const IS_DEVNET =
 
 export function LowSolBanner() {
   const t = useTranslations("nav");
+  // Mounted inside the (platform) provider stack since #1097 (it moved out of
+  // the global Header, which no longer has wallet providers above it), so
+  // these hooks always resolve against the live stack.
   const { publicKey } = useWallet();
   const { connection } = useConnection();
   const [balance, setBalance] = useState<number | null>(null);

--- a/apps/web/src/hooks/use-social-return-pending.ts
+++ b/apps/web/src/hooks/use-social-return-pending.ts
@@ -4,7 +4,7 @@ import { useSyncExternalStore } from "react";
 import {
   getSocialReturnPending,
   subscribeSocialReturnPending,
-} from "@/lib/dynamic/social";
+} from "@/lib/dynamic/social-return-pending";
 
 /**
  * Whether the Google-return handshake is running right now. Sign-in buttons

--- a/apps/web/src/lib/dynamic/social-return-pending.ts
+++ b/apps/web/src/lib/dynamic/social-return-pending.ts
@@ -1,0 +1,31 @@
+/**
+ * Social-return pending state, published by `DynamicAuthHandler` while the
+ * redirect-return handshake runs and consumed by the sign-in buttons (via
+ * `useSocialReturnPending`) so THEY carry the loading state — the owner's
+ * call over a full-screen overlay. A module-level store because the handler
+ * and the header render in unrelated trees; threading a context through the
+ * layout for one boolean would be all ceremony.
+ *
+ * Its own module, free of any Dynamic SDK import: the header's sign-in
+ * trigger reads this on EVERY route, and pulling `lib/dynamic/social` (which
+ * imports the SDK) into that chunk is exactly what #1097 removed.
+ */
+
+let socialReturnPending = false;
+const pendingListeners = new Set<() => void>();
+
+export function setSocialReturnPending(pending: boolean): void {
+  socialReturnPending = pending;
+  pendingListeners.forEach((listener) => listener());
+}
+
+export function subscribeSocialReturnPending(listener: () => void): () => void {
+  pendingListeners.add(listener);
+  return () => {
+    pendingListeners.delete(listener);
+  };
+}
+
+export function getSocialReturnPending(): boolean {
+  return socialReturnPending;
+}

--- a/apps/web/src/lib/dynamic/social.ts
+++ b/apps/web/src/lib/dynamic/social.ts
@@ -118,29 +118,6 @@ export async function bridgeDynamicSession(): Promise<DynamicBridgeOutcome> {
   }
 }
 
-/**
- * Social-return pending state, published by `DynamicAuthHandler` while the
- * redirect-return handshake runs and consumed by the sign-in buttons (via
- * `useSocialReturnPending`) so THEY carry the loading state — the owner's
- * call over a full-screen overlay. A module-level store because the handler
- * and the header render in unrelated trees; threading a context through the
- * layout for one boolean would be all ceremony.
- */
-let socialReturnPending = false;
-const pendingListeners = new Set<() => void>();
-
-export function setSocialReturnPending(pending: boolean): void {
-  socialReturnPending = pending;
-  pendingListeners.forEach((listener) => listener());
-}
-
-export function subscribeSocialReturnPending(listener: () => void): () => void {
-  pendingListeners.add(listener);
-  return () => {
-    pendingListeners.delete(listener);
-  };
-}
-
-export function getSocialReturnPending(): boolean {
-  return socialReturnPending;
-}
+// The social-return pending store moved to `lib/dynamic/social-return-pending`
+// (#1097): the header's sign-in trigger subscribes to it on every route, and
+// this module's SDK imports must not ride along into that chunk.

--- a/apps/web/src/lib/solana/__tests__/ambient-wallet-store.test.ts
+++ b/apps/web/src/lib/solana/__tests__/ambient-wallet-store.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import {
+  publishAmbientWallet,
+  getAmbientWallet,
+  setWalletReturnCaptureActive,
+  getWalletReturnCaptureActive,
+  type AmbientWalletState,
+} from "../ambient-wallet-store";
+
+const fake = (): AmbientWalletState => ({
+  connected: false,
+  publicKey: null,
+  disconnect: vi.fn(async () => {}),
+  openWalletModal: vi.fn(),
+});
+
+afterEach(() => {
+  // Leave the store empty (a publish also clears the capture flag).
+  publishAmbientWallet(fake())();
+});
+
+describe("ambient wallet store (#1097)", () => {
+  it("publishes and unregisters", () => {
+    const state = fake();
+    const unregister = publishAmbientWallet(state);
+    expect(getAmbientWallet()).toBe(state);
+    unregister();
+    expect(getAmbientWallet()).toBeNull();
+  });
+
+  it("a stale unregister never wipes a newer registration", () => {
+    const first = fake();
+    const second = fake();
+    const unregisterFirst = publishAmbientWallet(first);
+    const unregisterSecond = publishAmbientWallet(second);
+
+    // The first stack unmounts AFTER the second took over (route-group
+    // crossing): the live registration must survive.
+    unregisterFirst();
+    expect(getAmbientWallet()).toBe(second);
+
+    unregisterSecond();
+    expect(getAmbientWallet()).toBeNull();
+  });
+
+  it("the capture flag opens the window and any registration closes it", () => {
+    expect(getWalletReturnCaptureActive()).toBe(false);
+    setWalletReturnCaptureActive();
+    expect(getWalletReturnCaptureActive()).toBe(true);
+
+    const unregister = publishAmbientWallet(fake());
+    expect(getWalletReturnCaptureActive()).toBe(false);
+    unregister();
+    // Unregistering does not re-open the window.
+    expect(getWalletReturnCaptureActive()).toBe(false);
+  });
+});

--- a/apps/web/src/lib/solana/__tests__/ambient-wallet-store.test.ts
+++ b/apps/web/src/lib/solana/__tests__/ambient-wallet-store.test.ts
@@ -2,8 +2,11 @@ import { describe, it, expect, vi, afterEach } from "vitest";
 import {
   publishAmbientWallet,
   getAmbientWallet,
+  getAmbientStackCount,
   setWalletReturnCaptureActive,
   getWalletReturnCaptureActive,
+  clearWalletReturnCapture,
+  subscribeAmbientWallet,
   type AmbientWalletState,
 } from "../ambient-wallet-store";
 
@@ -41,6 +44,49 @@ describe("ambient wallet store (#1097)", () => {
 
     unregisterSecond();
     expect(getAmbientWallet()).toBeNull();
+  });
+
+  it("a same-owner re-publish never transits through null (NEW-3)", () => {
+    const owner = {};
+    const first = fake();
+    const second = fake();
+    const observed: (AmbientWalletState | null)[] = [];
+    const unsubscribe = subscribeAmbientWallet(() =>
+      observed.push(getAmbientWallet())
+    );
+
+    const unregister1 = publishAmbientWallet(first, owner);
+    const unregister2 = publishAmbientWallet(second, owner);
+
+    expect(observed).toEqual([first, second]);
+    expect(getAmbientStackCount()).toBe(1);
+
+    // The superseded publish's unregister is inert…
+    unregister1();
+    expect(getAmbientWallet()).toBe(second);
+    // …while the current one really unregisters.
+    unregister2();
+    expect(getAmbientWallet()).toBeNull();
+    expect(getAmbientStackCount()).toBe(0);
+    unsubscribe();
+  });
+
+  it("tracks the live stack count", () => {
+    expect(getAmbientStackCount()).toBe(0);
+    const unregisterA = publishAmbientWallet(fake());
+    const unregisterB = publishAmbientWallet(fake());
+    expect(getAmbientStackCount()).toBe(2);
+    unregisterA();
+    expect(getAmbientStackCount()).toBe(1);
+    unregisterB();
+    expect(getAmbientStackCount()).toBe(0);
+  });
+
+  it("clearWalletReturnCapture re-opens sign-in after a failed capture (NEW-1)", () => {
+    setWalletReturnCaptureActive();
+    expect(getWalletReturnCaptureActive()).toBe(true);
+    clearWalletReturnCapture();
+    expect(getWalletReturnCaptureActive()).toBe(false);
   });
 
   it("the capture flag opens the window and any registration closes it", () => {

--- a/apps/web/src/lib/solana/ambient-wallet-store.ts
+++ b/apps/web/src/lib/solana/ambient-wallet-store.ts
@@ -28,6 +28,13 @@ export interface AmbientWalletState {
 let state: AmbientWalletState | null = null;
 
 /**
+ * All live registrations, keyed by owner. Normally one entry; briefly two
+ * while crossing route groups (scoped stack + platform stack), which
+ * AuthModal watches via the count to disarm its own stack (review NEW-2).
+ */
+const registrations = new Map<object, AmbientWalletState>();
+
+/**
  * True from the moment `DynamicReturnCatcher` decides to mount the scoped
  * provider stack (synchronously, before the lazy chunk resolves) until any
  * stack registers. AuthModal must not arm its own scoped stack inside this
@@ -41,30 +48,63 @@ function emit(): void {
   listeners.forEach((listener) => listener());
 }
 
-function subscribe(listener: () => void): () => void {
+/** Notifies on any store change (registrations, state, capture flag). */
+export function subscribeAmbientWallet(listener: () => void): () => void {
   listeners.add(listener);
   return () => {
     listeners.delete(listener);
   };
 }
 
+const subscribe = subscribeAmbientWallet;
+
 /**
  * Called by the registrar inside `SolanaWalletProvider` on mount and on every
  * wallet-state change. Returns an unregister that only clears its OWN
  * registration — a stale unmount (e.g. the modal's scoped stack unmounting
  * after a platform stack took over) never wipes the live stack.
+ *
+ * `owner` identifies the registrar across re-publishes: passing the same
+ * owner replaces the registration IN PLACE, so subscribers never observe a
+ * transient null between two states of one stack (review NEW-3). It defaults
+ * to the state object itself, which keeps one-shot callers (tests) simple.
  */
-export function publishAmbientWallet(next: AmbientWalletState): () => void {
+export function publishAmbientWallet(
+  next: AmbientWalletState,
+  owner: object = next
+): () => void {
+  registrations.set(owner, next);
   state = next;
   // A live stack closes the catcher's capture window by definition.
   returnCaptureActive = false;
   emit();
   return () => {
+    const owned = registrations.get(owner);
+    if (owned !== next) return; // superseded by a newer publish for this owner
+    registrations.delete(owner);
     if (state === next) {
-      state = null;
-      emit();
+      // Fall back to any remaining stack (brief route-group overlaps).
+      state = [...registrations.values()][registrations.size - 1] ?? null;
     }
+    emit();
   };
+}
+
+/** How many provider stacks are currently registered. */
+export function getAmbientStackCount(): number {
+  return registrations.size;
+}
+
+/**
+ * Re-opens sign-in after a failed capture (review NEW-1): if the catcher's
+ * scoped-stack chunk fails to load, no registration will ever arrive to
+ * clear the flag — without this, every AuthTriggerButton stays disabled at
+ * "Signing in…" for the rest of the page's life.
+ */
+export function clearWalletReturnCapture(): void {
+  if (!returnCaptureActive) return;
+  returnCaptureActive = false;
+  emit();
 }
 
 export function getAmbientWallet(): AmbientWalletState | null {
@@ -82,6 +122,7 @@ export function getWalletReturnCaptureActive(): boolean {
 
 const serverNull = () => null;
 const serverFalse = () => false;
+const serverZero = () => 0;
 
 /** The live wallet surface, or null when no provider stack is mounted. */
 export function useAmbientWallet(): AmbientWalletState | null {
@@ -91,6 +132,11 @@ export function useAmbientWallet(): AmbientWalletState | null {
 /** Whether a wallet provider stack is currently mounted anywhere. */
 export function useAmbientWalletLive(): boolean {
   return useAmbientWallet() !== null;
+}
+
+/** Live registration count — see {@link getAmbientStackCount}. */
+export function useAmbientStackCount(): number {
+  return useSyncExternalStore(subscribe, getAmbientStackCount, serverZero);
 }
 
 /** See {@link setWalletReturnCaptureActive}. */

--- a/apps/web/src/lib/solana/ambient-wallet-store.ts
+++ b/apps/web/src/lib/solana/ambient-wallet-store.ts
@@ -1,0 +1,103 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+
+/**
+ * Bridge between the wallet provider stack and the components that render
+ * OUTSIDE it (#1097 rework): since the stack mounts in (platform)/layout.tsx
+ * — or scoped around the sign-in flow — while Header/UserMenu/AuthModal live
+ * in [locale]/layout.tsx ABOVE it, React context can never reach them. A
+ * module-level store can: `SolanaWalletProvider` publishes the live wallet
+ * surface from an inner registrar, and outside components subscribe via
+ * `useSyncExternalStore`.
+ *
+ * Deliberately SDK-free (same reasoning as `lib/dynamic/social-return-pending`):
+ * Header imports this on every route, so no wallet-adapter or Dynamic bytes
+ * may ride along.
+ */
+
+export interface AmbientWalletState {
+  connected: boolean;
+  /** Base58, or null while disconnected. */
+  publicKey: string | null;
+  disconnect: () => Promise<void>;
+  /** Opens wallet-adapter's wallet-select modal (WalletModalProvider). */
+  openWalletModal: () => void;
+}
+
+let state: AmbientWalletState | null = null;
+
+/**
+ * True from the moment `DynamicReturnCatcher` decides to mount the scoped
+ * provider stack (synchronously, before the lazy chunk resolves) until any
+ * stack registers. AuthModal must not arm its own scoped stack inside this
+ * window — two stacks would race autoConnect and SIWS.
+ */
+let returnCaptureActive = false;
+
+const listeners = new Set<() => void>();
+
+function emit(): void {
+  listeners.forEach((listener) => listener());
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+/**
+ * Called by the registrar inside `SolanaWalletProvider` on mount and on every
+ * wallet-state change. Returns an unregister that only clears its OWN
+ * registration — a stale unmount (e.g. the modal's scoped stack unmounting
+ * after a platform stack took over) never wipes the live stack.
+ */
+export function publishAmbientWallet(next: AmbientWalletState): () => void {
+  state = next;
+  // A live stack closes the catcher's capture window by definition.
+  returnCaptureActive = false;
+  emit();
+  return () => {
+    if (state === next) {
+      state = null;
+      emit();
+    }
+  };
+}
+
+export function getAmbientWallet(): AmbientWalletState | null {
+  return state;
+}
+
+export function setWalletReturnCaptureActive(): void {
+  returnCaptureActive = true;
+  emit();
+}
+
+export function getWalletReturnCaptureActive(): boolean {
+  return returnCaptureActive;
+}
+
+const serverNull = () => null;
+const serverFalse = () => false;
+
+/** The live wallet surface, or null when no provider stack is mounted. */
+export function useAmbientWallet(): AmbientWalletState | null {
+  return useSyncExternalStore(subscribe, getAmbientWallet, serverNull);
+}
+
+/** Whether a wallet provider stack is currently mounted anywhere. */
+export function useAmbientWalletLive(): boolean {
+  return useAmbientWallet() !== null;
+}
+
+/** See {@link setWalletReturnCaptureActive}. */
+export function useWalletReturnCaptureActive(): boolean {
+  return useSyncExternalStore(
+    subscribe,
+    getWalletReturnCaptureActive,
+    serverFalse
+  );
+}

--- a/apps/web/src/lib/solana/wallet-provider.tsx
+++ b/apps/web/src/lib/solana/wallet-provider.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, type ReactNode } from "react";
+import { useCallback, useEffect, useMemo, useRef, type ReactNode } from "react";
 import type { WalletError } from "@solana/wallet-adapter-base";
 import {
   ConnectionProvider,
@@ -30,18 +30,27 @@ interface SolanaWalletProviderProps {
 function AmbientWalletRegistrar() {
   const { connected, publicKey, disconnect } = useWallet();
   const { setVisible } = useWalletModal();
+  // Stable owner across re-publishes: same-owner publishes replace the
+  // registration IN PLACE, so subscribers never see a transient null while
+  // this stack updates its own state (review NEW-3).
+  const ownerRef = useRef<object>({});
+  const unregisterRef = useRef<(() => void) | null>(null);
 
   useEffect(() => {
-    // publishAmbientWallet returns an ownership-guarded unregister: if
-    // another stack registered since (brief overlaps exist while crossing
-    // route groups), this stack's unmount leaves it untouched.
-    return publishAmbientWallet({
-      connected,
-      publicKey: publicKey?.toBase58() ?? null,
-      disconnect,
-      openWalletModal: () => setVisible(true),
-    });
+    unregisterRef.current = publishAmbientWallet(
+      {
+        connected,
+        publicKey: publicKey?.toBase58() ?? null,
+        disconnect,
+        openWalletModal: () => setVisible(true),
+      },
+      ownerRef.current
+    );
   }, [connected, publicKey, disconnect, setVisible]);
+
+  useEffect(() => {
+    return () => unregisterRef.current?.();
+  }, []);
 
   return null;
 }

--- a/apps/web/src/lib/solana/wallet-provider.tsx
+++ b/apps/web/src/lib/solana/wallet-provider.tsx
@@ -1,19 +1,49 @@
 "use client";
 
-import { useCallback, useMemo, type ReactNode } from "react";
+import { useCallback, useEffect, useMemo, type ReactNode } from "react";
 import type { WalletError } from "@solana/wallet-adapter-base";
 import {
   ConnectionProvider,
   WalletProvider,
+  useWallet,
 } from "@solana/wallet-adapter-react";
-import { WalletModalProvider } from "@solana/wallet-adapter-react-ui";
+import {
+  WalletModalProvider,
+  useWalletModal,
+} from "@solana/wallet-adapter-react-ui";
 import { env } from "@/lib/env";
+import { publishAmbientWallet } from "@/lib/solana/ambient-wallet-store";
 import { WalletAuthHandler } from "@/components/auth/wallet-auth-handler";
 
 import "@solana/wallet-adapter-react-ui/styles.css";
 
 interface SolanaWalletProviderProps {
   children: ReactNode;
+}
+
+/**
+ * Publishes the live wallet surface into the ambient store (#1097): the
+ * provider stack mounts on (platform) routes — or scoped around the sign-in
+ * flow — BELOW the global Header, so Header children (UserMenu, AuthModal)
+ * can never reach these hooks through context and read the store instead.
+ */
+function AmbientWalletRegistrar() {
+  const { connected, publicKey, disconnect } = useWallet();
+  const { setVisible } = useWalletModal();
+
+  useEffect(() => {
+    // publishAmbientWallet returns an ownership-guarded unregister: if
+    // another stack registered since (brief overlaps exist while crossing
+    // route groups), this stack's unmount leaves it untouched.
+    return publishAmbientWallet({
+      connected,
+      publicKey: publicKey?.toBase58() ?? null,
+      disconnect,
+      openWalletModal: () => setVisible(true),
+    });
+  }, [connected, publicKey, disconnect, setVisible]);
+
+  return null;
 }
 
 export function SolanaWalletProvider({ children }: SolanaWalletProviderProps) {
@@ -46,6 +76,7 @@ export function SolanaWalletProvider({ children }: SolanaWalletProviderProps) {
         onError={onError}
       >
         <WalletModalProvider>
+          <AmbientWalletRegistrar />
           <WalletAuthHandler />
           {children}
         </WalletModalProvider>


### PR DESCRIPTION
Closes #1097.

Moves SolanaWalletProvider, DynamicWalletProvider (+its QueryClient), and GamificationOverlays from `[locale]/layout.tsx` into `(platform)/layout.tsx`, same order and constraint comments. ToastContainer is split out of the overlays and stays global — marketing dispatches toasts too (AuthErrorToast on the landing page).

**Landing First Load JS: 647 kB → 315 kB** (baseline main at eb9a4725; platform routes unchanged — dashboard 483 kB, courses 283 kB on the rebased branch). Chunk-group verification: across all 17 marketing first-load chunks, zero hits for wallet-adapter, the Dynamic SDK, TanStack Query, ConnectionProvider, WalletModalProvider — including the `useWallet` default-context module that v1 still carried.

Header renders in `[locale]/layout.tsx` ABOVE the demoted stack, so React context can never reach its wallet consumers (adversarial review of v1). The bridge is a module-level **ambient store** (`lib/solana/ambient-wallet-store.ts`, SDK-free): a registrar inside SolanaWalletProvider publishes `{connected, publicKey, disconnect, openWalletModal}` on mount and on change, with an ownership-guarded unregister so a stale unmount never wipes a newer stack.

- **Sign-out (F1)**: UserMenu disconnects via the store when a stack is live, and always clears wallet-adapter's `walletName` localStorage key (verified default in `WalletProvider.js`) — so autoConnect + WalletAuthHandler cannot silently re-SIWS the account that just signed out, even from a marketing page. Dynamic logout is a dynamic import (static would drag the SDK back into the header chunk).
- **LowSolBanner (F1b)**: moved out of Header into `(platform)/layout.tsx` inside the stack, plain `useWallet` again; its test mocks reverted accordingly.
- **Double-mount guard (F2)**: the modal arms its scoped stack only when the store has no live registration; the scoped stack mounts as a **sibling** of the Dialog (F5 — no reparenting; the Dialog's tree position never changes), sticky after close for the wallet-select handoff, and disarmed on client-side navigation while closed. Test-covered: ambient-live ⇒ never arms; no stack ⇒ arms; sticky after close.
- **Capture window (F4)**: DynamicReturnCatcher sets a synchronous module flag the moment it decides to mount (before its chunk resolves); the modal won't arm and the trigger shows the signing-in state inside that window; any stack registration closes it.
- **Chunk failure (F3)**: both lazies sit under an error boundary that renders a translated in-modal error + retry; retry recreates the lazy components (a rejected `React.lazy` caches its rejection).
- The modal body needs no provider above it now: the Solana button opens the wallet-select modal through the store, and DynamicSocialSignIn reads the stale-session check imperatively via the SDK's `getCore` (same escape hatch `lib/dynamic/social.ts` uses) instead of `useUser`.

**Tradeoff:** the sign-in click on marketing/admin lazy-loads the modal body + provider stack — a brief spinner in the modal on first open.

**No repeat SIWS on platform re-entry:** crossing marketing→platform remounts SolanaWalletProvider and autoConnect silently reconnects, re-firing WalletAuthHandler's connect effect (`hasTriedAuth` is per-mount and does NOT guard this). What does: `authenticate()` calls `supabase.auth.getUser()` and returns before any prompt when a session exists (`wallet-auth-handler.tsx:39`). The ref only prevents double-trigger within a mount.

Tests: 3027 pass, including the ambient store (ownership, capture flag), scoped-vs-ambient/capture modal mounting, and the reworked DynamicSocialSignIn session check.
