### PR TITLE
fix(email): claim RPCs re-check consent and exclude placeholder emails

### DIFF
--- a/apps/web/src/lib/auth/wallet-placeholder.ts
+++ b/apps/web/src/lib/auth/wallet-placeholder.ts
@@ -11,6 +11,12 @@
  * to know that).
  *
  * Importable from both server and client code — keep it dependency-free.
+ *
+ * SQL mirror (#1075): the email claim RPCs (`claim_due_session_reminders`,
+ * `claim_due_reengagement`) apply the same predicate as
+ * `lower(u.email) NOT LIKE '%@wallet.superteam-lms.local'` — see
+ * supabase/migrations/20260819190000_email_claim_consent_recheck.sql. A domain
+ * change must land in both languages.
  */
 
 /** Domain suffix of the synthetic wallet-auth placeholder email. */

--- a/apps/web/src/lib/supabase/__tests__/email-claim-consent-recheck-execution.test.ts
+++ b/apps/web/src/lib/supabase/__tests__/email-claim-consent-recheck-execution.test.ts
@@ -1,0 +1,443 @@
+// #1075: REAL SQL-execution tests for the claim RPCs' consent re-check and the
+// case-insensitive wallet-placeholder exclusion, replayed against the PROD
+// migration lineage.
+//
+// Lineage replayed here (repo filename → applied prod ledger version):
+//   20260728120000_email_subscriptions.sql        → 20260727200924
+//   20260731120000_reminder_consent.sql           → 20260731120914
+//   20260731150000_kind_scoped_unsubscribe.sql    → 20260731142948
+//   20260731170000_reengagement_pipeline.sql      → 20260731154032
+//   20260804120000_recurring_lesson_plan.sql      → 20260804190632   ← last applied
+//   20260819190000_email_claim_consent_recheck.sql → THIS CHANGE (not yet applied)
+//
+// RED-PROOF: the "pre-fix" block replays the identical fixtures WITHOUT this
+// migration and shows a MIXED-CASE placeholder being claimed by BOTH RPCs —
+// the byte-wise `NOT LIKE` only catches the lowercase spelling (#921 F5).
+// Reverting the migration turns the GREEN placeholder assertions into exactly
+// that failure.
+//
+// TIMEZONE (#956): date anchors are computed from
+// `(now() AT TIME ZONE 'America/Sao_Paulo')::date`, never from
+// `(now() - interval)::date`.
+//
+// @vitest-environment node
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { PGlite } from "@electric-sql/pglite";
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from "vitest";
+
+function findRepoRoot(): string {
+  let dir = dirname(fileURLToPath(import.meta.url));
+  while (!existsSync(resolve(dir, "supabase/schema.sql"))) {
+    const parent = dirname(dir);
+    if (parent === dir)
+      throw new Error("repo root (supabase/schema.sql) not found");
+    dir = parent;
+  }
+  return dir;
+}
+
+const repoRoot = findRepoRoot();
+const readMigration = (name: string) =>
+  readFileSync(resolve(repoRoot, "supabase/migrations", name), "utf8");
+
+const LINEAGE = [
+  "20260728120000_email_subscriptions.sql",
+  "20260731120000_reminder_consent.sql",
+  "20260731150000_kind_scoped_unsubscribe.sql",
+  "20260731170000_reengagement_pipeline.sql",
+  "20260804120000_recurring_lesson_plan.sql",
+].map(readMigration);
+const recheckMigration = readMigration(
+  "20260819190000_email_claim_consent_recheck.sql"
+);
+const schema = readFileSync(resolve(repoRoot, "supabase/schema.sql"), "utf8");
+
+// Objects created outside these migrations (Supabase roles, auth schema, and
+// the baseline tables both claim RPCs read). Same stub the #899 suite uses.
+const STUB_SETUP = `
+  CREATE ROLE anon;
+  CREATE ROLE authenticated;
+  CREATE ROLE service_role;
+  CREATE SCHEMA IF NOT EXISTS auth;
+  CREATE TABLE auth.users (id uuid PRIMARY KEY, email text);
+  CREATE FUNCTION auth.uid() RETURNS uuid LANGUAGE sql STABLE AS 'SELECT NULL::uuid';
+  CREATE TABLE public.profiles (
+    id uuid PRIMARY KEY,
+    prefs jsonb NOT NULL DEFAULT '{}',
+    created_at timestamptz NOT NULL DEFAULT now()
+  );
+  CREATE TABLE public.enrollments (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+    course_id text NOT NULL,
+    enrolled_at timestamptz DEFAULT now(),
+    completed_at timestamptz,
+    UNIQUE(user_id, course_id)
+  );
+  CREATE TABLE public.user_progress (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+    course_id text NOT NULL,
+    lesson_id text NOT NULL,
+    completed boolean DEFAULT false,
+    completed_at timestamptz,
+    UNIQUE(user_id, lesson_id)
+  );
+  CREATE TABLE public.user_xp (
+    user_id uuid PRIMARY KEY REFERENCES public.profiles(id) ON DELETE CASCADE,
+    longest_streak int DEFAULT 0,
+    last_activity_date date
+  );
+  CREATE TABLE public.certificates (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id uuid NOT NULL REFERENCES public.profiles(id) ON DELETE CASCADE,
+    course_id text NOT NULL,
+    UNIQUE(user_id, course_id)
+  );
+`;
+
+const uid = (n: number): string => {
+  const c = String(n % 10);
+  return `${c.repeat(8)}-${c.repeat(4)}-${c.repeat(4)}-${c.repeat(4)}-${c.repeat(12)}`;
+};
+
+/** Ordinary consenting learner — must keep being claimed by both RPCs. */
+const OK = uid(1);
+/** Wallet placeholder in MIXED case — the #921 F5 gap. */
+const MIXEDCASE = uid(2);
+/** Consenting at seed; each test flips consent OFF before claiming. */
+const FLIPPED = uid(3);
+/** Wallet placeholder in lower case — already excluded pre-fix (control). */
+const LOWERCASE = uid(4);
+
+const ALL = [OK, MIXEDCASE, FLIPPED, LOWERCASE];
+
+const WEEK = ["sun", "mon", "tue", "wed", "thu", "fri", "sat"] as const;
+
+/** The weekday token the session claim computes for "today" in São Paulo. */
+const TODAY = WEEK[
+  new Date(
+    new Intl.DateTimeFormat("en-CA", {
+      timeZone: "America/Sao_Paulo",
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+    }).format(new Date()) + "T12:00:00Z"
+  ).getUTCDay()
+] as string;
+
+const EMAILS: Record<string, string> = {
+  [OK]: "ok@example.com",
+  [MIXEDCASE]: "AbC123@Wallet.Superteam-LMS.LOCAL",
+  [FLIPPED]: "flipped@example.com",
+  [LOWERCASE]: "def456@wallet.superteam-lms.local",
+};
+
+// Every learner has a plan for today (session-reminder due) AND is lapsed 30
+// days (re-engagement due) — so ONLY the consent/placeholder gates decide.
+const SEED = `
+  INSERT INTO public.profiles(id, prefs, created_at)
+  SELECT id::uuid,
+         '{"nextLesson":{"days":["${TODAY}"],"time":"19:00"}}'::jsonb,
+         now() - interval '200 days'
+  FROM unnest(ARRAY[${ALL.map((id) => `'${id}'`).join(", ")}]) AS t(id);
+
+  INSERT INTO auth.users(id, email) VALUES
+    ${ALL.map((id) => `('${id}', '${EMAILS[id]}')`).join(",\n    ")};
+
+  INSERT INTO public.email_subscriptions(user_id, reminder_opt_in, reminder_consent_at, reminder_locale)
+  SELECT id::uuid, true, now(), 'pt-BR'
+  FROM unnest(ARRAY[${ALL.map((id) => `'${id}'`).join(", ")}]) AS t(id);
+
+  INSERT INTO public.user_xp(user_id, longest_streak, last_activity_date)
+  SELECT id::uuid, 5, ((now() AT TIME ZONE 'America/Sao_Paulo')::date - 30)
+  FROM unnest(ARRAY[${ALL.map((id) => `'${id}'`).join(", ")}]) AS t(id);
+`;
+
+/** Frees every claim slot and restores every seeded consent. */
+const RESET = `
+  DELETE FROM public.email_reminder_log;
+  UPDATE public.email_subscriptions
+  SET reminder_opt_in = true, reminder_unsubscribed_at = NULL;
+`;
+
+async function build(withRecheck: boolean): Promise<PGlite> {
+  const pg = await PGlite.create();
+  await pg.exec(STUB_SETUP);
+  for (const sql of LINEAGE) await pg.exec(sql);
+  if (withRecheck) await pg.exec(recheckMigration);
+  await pg.exec(SEED);
+  return pg;
+}
+
+async function claimSession(pg: PGlite): Promise<string[]> {
+  const { rows } = await pg.query<{ user_id: string }>(
+    "SELECT user_id FROM public.claim_due_session_reminders($1)",
+    [TODAY]
+  );
+  return rows.map((r) => r.user_id).sort();
+}
+
+async function claimReengagement(pg: PGlite): Promise<string[]> {
+  const { rows } = await pg.query<{ user_id: string }>(
+    "SELECT user_id FROM public.claim_due_reengagement('reengagement_7d', 7, 14)"
+  );
+  return rows.map((r) => r.user_id).sort();
+}
+
+let db: PGlite;
+
+// ── RED: pre-fix, the byte-wise gate lets a MIXED-CASE placeholder through ───
+describe("#1075 RED — pre-fix lineage claims a mixed-case placeholder", () => {
+  beforeAll(async () => {
+    db = await build(false);
+  }, 60_000);
+  beforeEach(async () => {
+    await db.exec(RESET);
+  });
+  afterAll(async () => {
+    await db.close();
+  });
+
+  it("session claim returns the mixed-case placeholder (the F5 defect)", async () => {
+    const claimed = await claimSession(db);
+    expect(claimed).toContain(MIXEDCASE);
+    // …while the lowercase spelling was always excluded.
+    expect(claimed).not.toContain(LOWERCASE);
+  });
+
+  it("re-engagement claim returns the mixed-case placeholder too", async () => {
+    const claimed = await claimReengagement(db);
+    expect(claimed).toContain(MIXEDCASE);
+    expect(claimed).not.toContain(LOWERCASE);
+  });
+});
+
+// ── GREEN: placeholder exclusion is case-insensitive ────────────────────────
+describe("#1075 GREEN — no placeholder spelling is ever claimed", () => {
+  beforeAll(async () => {
+    db = await build(true);
+  }, 60_000);
+  beforeEach(async () => {
+    await db.exec(RESET);
+  });
+  afterAll(async () => {
+    await db.close();
+  });
+
+  it("session claim excludes mixed-case AND lowercase placeholders", async () => {
+    const claimed = await claimSession(db);
+    expect(claimed).not.toContain(MIXEDCASE);
+    expect(claimed).not.toContain(LOWERCASE);
+    // …and writes them no ledger row (they were never claimed, not released).
+    const { rows } = await db.query<{ n: number }>(
+      "SELECT count(*)::int AS n FROM public.email_reminder_log WHERE user_id = ANY($1)",
+      [[MIXEDCASE, LOWERCASE]]
+    );
+    expect(rows[0]!.n).toBe(0);
+  });
+
+  it("re-engagement claim excludes both placeholder spellings", async () => {
+    const claimed = await claimReengagement(db);
+    expect(claimed).not.toContain(MIXEDCASE);
+    expect(claimed).not.toContain(LOWERCASE);
+  });
+
+  it("an ordinary consenting learner is still claimed by both RPCs", async () => {
+    expect(await claimSession(db)).toContain(OK);
+    await db.exec(RESET);
+    expect(await claimReengagement(db)).toContain(OK);
+  });
+
+  it("still hands the session claim the REMINDER-scoped token (#896)", async () => {
+    const { rows } = await db.query<{
+      user_id: string;
+      unsubscribe_token: string;
+    }>(
+      "SELECT user_id, unsubscribe_token FROM public.claim_due_session_reminders($1)",
+      [TODAY]
+    );
+    const ok = rows.find((r) => r.user_id === OK)!;
+    const { rows: tokens } = await db.query<{
+      marketing: string;
+      reminder: string;
+    }>(
+      `SELECT unsubscribe_token AS marketing, reminder_unsubscribe_token AS reminder
+       FROM public.email_subscriptions WHERE user_id = '${OK}'`
+    );
+    expect(ok.unsubscribe_token).toBe(tokens[0]!.reminder);
+    expect(ok.unsubscribe_token).not.toBe(tokens[0]!.marketing);
+  });
+});
+
+// ── GREEN: consent flipped off after scheduling excludes the row ────────────
+describe("#1075 GREEN — consent is re-checked at claim time", () => {
+  beforeAll(async () => {
+    db = await build(true);
+  }, 60_000);
+  beforeEach(async () => {
+    await db.exec(RESET);
+  });
+  afterAll(async () => {
+    await db.close();
+  });
+
+  it("a learner who unsubscribed after scheduling is not session-claimed", async () => {
+    // FLIPPED scheduled a plan for today while consenting; the flip lands
+    // BEFORE the cron claims — the claim must exclude them.
+    await db.exec(
+      `UPDATE public.email_subscriptions
+       SET reminder_opt_in = false, reminder_unsubscribed_at = now()
+       WHERE user_id = '${FLIPPED}'`
+    );
+    const claimed = await claimSession(db);
+    expect(claimed).not.toContain(FLIPPED);
+    expect(claimed).toContain(OK);
+    // No ledger row either — an excluded learner consumes no idempotency slot.
+    const { rows } = await db.query<{ n: number }>(
+      "SELECT count(*)::int AS n FROM public.email_reminder_log WHERE user_id = $1",
+      [FLIPPED]
+    );
+    expect(rows[0]!.n).toBe(0);
+  });
+
+  it("the same flip excludes the learner from the re-engagement claim", async () => {
+    await db.exec(
+      `UPDATE public.email_subscriptions
+       SET reminder_opt_in = false, reminder_unsubscribed_at = now()
+       WHERE user_id = '${FLIPPED}'`
+    );
+    const claimed = await claimReengagement(db);
+    expect(claimed).not.toContain(FLIPPED);
+    expect(claimed).toContain(OK);
+  });
+
+  it("the marketing opt-in cannot stand in for reminder consent", async () => {
+    await db.exec(
+      `UPDATE public.email_subscriptions
+       SET reminder_opt_in = false, opt_in = true
+       WHERE user_id = '${FLIPPED}'`
+    );
+    expect(await claimSession(db)).not.toContain(FLIPPED);
+    await db.exec(RESET);
+    await db.exec(
+      `UPDATE public.email_subscriptions
+       SET reminder_opt_in = false, opt_in = true
+       WHERE user_id = '${FLIPPED}'`
+    );
+    expect(await claimReengagement(db)).not.toContain(FLIPPED);
+  });
+
+  it("re-consenting makes the learner claimable again", async () => {
+    await db.exec(
+      `UPDATE public.email_subscriptions SET reminder_opt_in = false
+       WHERE user_id = '${FLIPPED}'`
+    );
+    expect(await claimSession(db)).not.toContain(FLIPPED);
+    await db.exec(RESET); // restores consent; frees the day's slots
+    expect(await claimSession(db)).toContain(FLIPPED);
+  });
+
+  it("re-applying the migration is a no-op (idempotent replay)", async () => {
+    await db.exec(recheckMigration);
+    await db.exec(recheckMigration);
+    const claimed = await claimSession(db);
+    expect(claimed).toContain(OK);
+    expect(claimed).not.toContain(MIXEDCASE);
+  });
+});
+
+// ── The migration's own shape + the schema.sql mirror ───────────────────────
+describe("#1075 migration shape + schema.sql mirror", () => {
+  it("lowers the placeholder gate in BOTH bodies and leaves no byte-wise gate", () => {
+    const lowered =
+      recheckMigration.match(
+        /AND lower\(u\.email\) NOT LIKE '%@wallet\.superteam-lms\.local'/g
+      ) ?? [];
+    expect(lowered.length).toBe(2);
+    expect(recheckMigration).not.toContain(
+      "AND u.email NOT LIKE '%@wallet.superteam-lms.local'"
+    );
+  });
+
+  it("asserts consent inside both claim WHEREs", () => {
+    const consent =
+      recheckMigration.match(/^    WHERE es\.reminder_opt_in = true$/gm) ?? [];
+    expect(consent.length).toBe(2);
+  });
+
+  it("keeps both signatures, so the app reads and the #731 probe are untouched", () => {
+    expect(recheckMigration).toContain(
+      "CREATE OR REPLACE FUNCTION claim_due_session_reminders(p_weekday TEXT DEFAULT NULL)\n" +
+        "RETURNS TABLE (user_id UUID, email TEXT, unsubscribe_token UUID, locale TEXT, plan_time TEXT)"
+    );
+    expect(recheckMigration).toContain(
+      "CREATE OR REPLACE FUNCTION claim_due_reengagement(\n" +
+        "  p_kind          TEXT,\n" +
+        "  p_inactive_days INTEGER DEFAULT 7,\n" +
+        "  p_cap_days      INTEGER DEFAULT 14,\n" +
+        "  p_max_remaining INTEGER DEFAULT 1,\n" +
+        "  p_course_totals JSONB   DEFAULT '{}'::jsonb\n" +
+        ")"
+    );
+  });
+
+  it("keeps the #899 cap set and the #896 reminder token", () => {
+    expect(recheckMigration).toContain(
+      "v_capped_kinds TEXT[] := ARRAY['reengagement_7d', 'course_nudge']"
+    );
+    expect(
+      (
+        recheckMigration.match(
+          /^ +es\.reminder_unsubscribe_token +AS tok,$/gm
+        ) ?? []
+      ).length
+    ).toBe(2);
+    expect(
+      (recheckMigration.match(/^  ORDER BY d\.uid;$/gm) ?? []).length
+    ).toBe(2);
+  });
+
+  it("keeps SECURITY DEFINER, a pinned search_path and service_role-ONLY grants", () => {
+    expect((recheckMigration.match(/^SECURITY DEFINER$/gm) ?? []).length).toBe(
+      2
+    );
+    expect(
+      (recheckMigration.match(/^SET search_path = ''$/gm) ?? []).length
+    ).toBe(2);
+    expect(recheckMigration).toContain(
+      "REVOKE ALL ON FUNCTION claim_due_session_reminders(TEXT) FROM PUBLIC, anon, authenticated;"
+    );
+    expect(recheckMigration).toContain(
+      "GRANT EXECUTE ON FUNCTION claim_due_session_reminders(TEXT) TO service_role;"
+    );
+    expect(recheckMigration).toContain(
+      "REVOKE ALL ON FUNCTION claim_due_reengagement(TEXT, INTEGER, INTEGER, INTEGER, JSONB)\n  FROM PUBLIC, anon, authenticated;"
+    );
+    expect(recheckMigration).toContain(
+      "GRANT EXECUTE ON FUNCTION claim_due_reengagement(TEXT, INTEGER, INTEGER, INTEGER, JSONB)\n  TO service_role;"
+    );
+    expect(recheckMigration).not.toMatch(
+      /GRANT EXECUTE[^\n]*TO (anon|authenticated)/
+    );
+  });
+
+  it("schema.sql mirrors the lowered gate in both claim bodies", () => {
+    const lowered =
+      schema.match(
+        /AND lower\(u\.email\) NOT LIKE '%@wallet\.superteam-lms\.local'/g
+      ) ?? [];
+    expect(lowered.length).toBe(2);
+  });
+
+  it("the TS predicate and the SQL gate share the one domain literal", () => {
+    const ts = readFileSync(
+      resolve(repoRoot, "apps/web/src/lib/auth/wallet-placeholder.ts"),
+      "utf8"
+    );
+    expect(ts).toContain('"@wallet.superteam-lms.local"');
+    expect(recheckMigration).toContain("'%@wallet.superteam-lms.local'");
+  });
+});

--- a/supabase/migrations/20260819190000_email_claim_consent_recheck.sql
+++ b/supabase/migrations/20260819190000_email_claim_consent_recheck.sql
@@ -1,0 +1,379 @@
+-- ============================================================================
+-- Migration: email_claim_consent_recheck — case-insensitive placeholder
+--            exclusion + pinned claim-time consent gate in the claim RPCs
+--            (#1075, part 2 of #921; part 1 = #1074's shared TS predicate)
+--
+-- The email claim RPCs — `claim_due_session_reminders` (#869/#896/#980 lineage)
+-- and `claim_due_reengagement` (#899) — are the ONLY consent gate the send
+-- pipelines trust (`lib/email/reminders.ts`, `lib/email/reengagement-send.ts`
+-- take recipients exclusively from them). Two problems, one fix each:
+--
+--   (a) The wallet-placeholder exclusion was a byte-wise
+--       `u.email NOT LIKE '%@wallet.superteam-lms.local'` — CASE-SENSITIVE
+--       (#921's F5). GoTrue lowercases stored emails today, but that is a
+--       GoTrue implementation detail, not an invariant this gate may lean on:
+--       a differently-cased placeholder would sail through and be "mailed".
+--       #1074 made the TS predicate case-insensitive
+--       (`isWalletPlaceholderEmail`, apps/web/src/lib/auth/wallet-placeholder.ts);
+--       this migration is its SQL mirror:
+--         lower(u.email) NOT LIKE '%@wallet.superteam-lms.local'
+--       The domain literal lives in the claim-RPC bodies here (and their
+--       supabase/schema.sql mirror) and in WALLET_PLACEHOLDER_EMAIL_DOMAIN on
+--       the TS side — one canonical predicate per language, cross-referenced
+--       both ways. Change one, change the other.
+--
+--   (b) Consent must hold AT CLAIM TIME, not merely when the learner scheduled
+--       a plan or became due. Both bodies already assert
+--       `es.reminder_opt_in = true` inside the claim's WHERE — the claim CTE
+--       and the ledger INSERT are ONE statement, so a learner who flipped
+--       consent off between scheduling and the cron's claim is excluded and no
+--       ledger row is written for them. This migration does not need to add
+--       that predicate; it RE-ASSERTS it: the line is now marked as the #1075
+--       claim-time consent gate so a future body rewrite cannot silently drop
+--       it, and the PGlite suite pins it behaviourally
+--       (email-claim-consent-recheck-execution.test.ts). The residual window
+--       is claim→Resend inside ONE pipeline invocation (seconds) — the shape
+--       #1075 accepts by choosing claim-time enforcement over a send-time
+--       re-read.
+--
+-- SCOPE. Exactly the two CLAIM RPCs. `list_marketing_recipients` (#769,
+-- marketing campaigns) is not a claim RPC and stays as-is.
+--
+-- NOT CHANGED (re-stated because CREATE OR REPLACE silently carries a body
+-- forward while a reviewer assumes otherwise): both SIGNATURES and OUT-column
+-- lists (app reads + the #731 schema-expectation probe), the idempotency
+-- claims (one `email_reminder_log` row per user/kind/São Paulo day, INSERT …
+-- ON CONFLICT DO NOTHING in the same statement), the #899 N = 14 frequency cap
+-- and its advisory-lock serialisation, the #980 `days[]` eligibility read, the
+-- #896 REMINDER-scoped token, `ORDER BY d.uid`, and the SECURITY MODEL —
+-- SECURITY DEFINER, `SET search_path = ''`, REVOKEd from
+-- PUBLIC/anon/authenticated, GRANTed to service_role ALONE (grants re-stated
+-- below per house pattern; nothing widens). Each body below is byte-identical
+-- to its current definition (§2 of 20260804120000_recurring_lesson_plan.sql,
+-- §3 of 20260731170000_reengagement_pipeline.sql) except the lines marked
+-- "#1074"/"#1075".
+--
+-- Idempotent: CREATE OR REPLACE only, no data change. Explicit BEGIN/COMMIT.
+-- Post-apply checks and a tested ROLLBACK in the trailer. Mirrored into
+-- supabase/schema.sql.
+--
+-- Replays cleanly on the PROD lineage: replaces the bodies applied as
+-- 20260804190632 (recurring_lesson_plan) and 20260731154032
+-- (reengagement_pipeline); depends on nothing newer.
+-- ============================================================================
+
+BEGIN;
+
+-- ── 1. claim_due_session_reminders — lower() the placeholder gate ────────────
+-- Byte-for-byte the #980 body except the lines marked #1074/#1075.
+CREATE OR REPLACE FUNCTION claim_due_session_reminders(p_weekday TEXT DEFAULT NULL)
+RETURNS TABLE (user_id UUID, email TEXT, unsubscribe_token UUID, locale TEXT, plan_time TEXT)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+#variable_conflict use_column
+DECLARE
+  v_today   DATE := (now() AT TIME ZONE 'America/Sao_Paulo')::date;
+  -- Lowercase English abbreviation (mon…sun) — the token the plan picker stores
+  -- in every element of `days`. No TM prefix ⇒ lc_time-independent.
+  v_weekday TEXT := COALESCE(
+    p_weekday,
+    trim(to_char((now() AT TIME ZONE 'America/Sao_Paulo'), 'dy'))
+  );
+BEGIN
+  RETURN QUERY
+  WITH due AS (
+    SELECT
+      es.user_id                                     AS uid,
+      u.email::text                                  AS mail,
+      -- #896: the reminder-scoped secret. A reminder email must never carry the
+      -- marketing token (the OUT column keeps its name — signature unchanged).
+      es.reminder_unsubscribe_token                  AS tok,
+      es.reminder_locale                             AS loc,
+      COALESCE(p.prefs -> 'nextLesson' ->> 'time', '') AS ptime
+    FROM public.email_subscriptions es
+    JOIN auth.users u ON u.id = es.user_id
+    JOIN public.profiles p ON p.id = es.user_id
+    -- #1075: consent is asserted HERE, at claim time — the claim and the ledger
+    -- INSERT are one statement, so a flip between the learner scheduling and
+    -- the cron claiming excludes the row.
+    WHERE es.reminder_opt_in = true
+      AND u.email IS NOT NULL
+      AND u.email <> ''
+      -- Synthetic wallet-auth addresses are not inboxes (see #779). lower():
+      -- SQL mirror of isWalletPlaceholderEmail (#1074,
+      -- apps/web/src/lib/auth/wallet-placeholder.ts) — a differently-cased
+      -- placeholder must not slip past a byte-wise LIKE. Keep the two in step.
+      AND lower(u.email) NOT LIKE '%@wallet.superteam-lms.local'
+      -- THE multi-day change: membership of the committed list. Deliberately no
+      -- OR on a legacy `->> 'day'` — §1 converted every stored one, and a `day`
+      -- that reappears afterwards means a stale writer is live, which must be
+      -- visible rather than papered over.
+      AND (p.prefs -> 'nextLesson' -> 'days') ? v_weekday
+  ),
+  claimed AS (
+    INSERT INTO public.email_reminder_log (user_id, kind, sent_on)
+    SELECT due.uid, 'session_plan', v_today FROM due
+    ON CONFLICT (user_id, kind, sent_on) DO NOTHING
+    RETURNING email_reminder_log.user_id AS uid
+  )
+  SELECT d.uid, d.mail, d.tok, d.loc, d.ptime
+  FROM due d
+  JOIN claimed c ON c.uid = d.uid
+  -- Deterministic order so the pipeline's chunk boundaries (and therefore its
+  -- Resend idempotency keys) are reproducible across a retry.
+  ORDER BY d.uid;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION claim_due_session_reminders(TEXT) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION claim_due_session_reminders(TEXT) TO service_role;
+
+-- ── 2. claim_due_reengagement — lower() the placeholder gate ─────────────────
+-- Byte-for-byte the #899 body except the lines marked #1074/#1075.
+CREATE OR REPLACE FUNCTION claim_due_reengagement(
+  p_kind          TEXT,
+  p_inactive_days INTEGER DEFAULT 7,
+  p_cap_days      INTEGER DEFAULT 14,
+  p_max_remaining INTEGER DEFAULT 1,
+  p_course_totals JSONB   DEFAULT '{}'::jsonb
+)
+RETURNS TABLE (
+  user_id              UUID,
+  email                TEXT,
+  unsubscribe_token    UUID,
+  locale               TEXT,
+  streak_days          INTEGER,
+  days_inactive        INTEGER,
+  course_id            TEXT,
+  completed_lesson_ids TEXT[]
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+#variable_conflict use_column
+DECLARE
+  v_today DATE := (now() AT TIME ZONE 'America/Sao_Paulo')::date;
+  -- Kinds that CONSUME and are BLOCKED BY the cap. 'session_plan' is absent on
+  -- purpose — see the header. One place to widen if the policy ever changes.
+  v_capped_kinds TEXT[] := ARRAY['reengagement_7d', 'course_nudge'];
+BEGIN
+  -- Reject anything outside the re-engagement family, so this RPC can never be
+  -- used to mint (or, via the release twin, delete) a session_plan ledger row.
+  IF p_kind IS NULL OR NOT (p_kind = ANY(v_capped_kinds)) THEN
+    RAISE EXCEPTION 'unsupported re-engagement kind: %', p_kind;
+  END IF;
+  -- A zero/negative window would make the gate vacuous — fail loudly rather
+  -- than quietly nudge everyone daily.
+  IF p_inactive_days IS NULL OR p_inactive_days < 1 THEN
+    RAISE EXCEPTION 'p_inactive_days must be >= 1';
+  END IF;
+  IF p_cap_days IS NULL OR p_cap_days < 1 THEN
+    RAISE EXCEPTION 'p_cap_days must be >= 1';
+  END IF;
+  IF p_max_remaining IS NULL OR p_max_remaining < 1 THEN
+    RAISE EXCEPTION 'p_max_remaining must be >= 1';
+  END IF;
+
+  -- Serialise re-engagement claims so the CROSS-KIND cap holds under
+  -- concurrency (see the header). Transaction-scoped: released on commit.
+  --
+  -- ISOLATION-LEVEL CAVEAT (gate F2, informational). This is correct under READ
+  -- COMMITTED — the default, and what PostgREST/Supabase uses: the RETURN QUERY
+  -- below takes a FRESH snapshot after the lock is granted, so it sees the rows
+  -- the previous holder committed. Under REPEATABLE READ (or SERIALIZABLE) the
+  -- snapshot is fixed at the transaction's first statement, i.e. BEFORE the lock
+  -- is acquired, so a waiter would read a pre-lock view of email_reminder_log and
+  -- the cap could be evaluated against stale rows. Re-evaluate this lock (and
+  -- prefer a serialization-failure retry) if this function is ever called on a
+  -- connection that raises the isolation level.
+
+  PERFORM pg_catalog.pg_advisory_xact_lock(
+    pg_catalog.hashtext('claim_due_reengagement')
+  );
+
+  RETURN QUERY
+  WITH consenting AS (
+    SELECT
+      es.user_id                        AS uid,
+      u.email::text                     AS mail,
+      -- #896: the REMINDER-scoped secret. Re-engagement rides on reminder
+      -- consent, so it must never carry the marketing token.
+      es.reminder_unsubscribe_token     AS tok,
+      es.reminder_locale                AS loc,
+      COALESCE(ux.longest_streak, 0)::int AS streak,
+      GREATEST(
+        ux.last_activity_date,
+        (SELECT max(up.completed_at)
+           FROM public.user_progress up
+          WHERE up.user_id = es.user_id AND up.completed)::date,
+        (SELECT max(e.enrolled_at)
+           FROM public.enrollments e
+          WHERE e.user_id = es.user_id)::date,
+        p.created_at::date
+      ) AS last_seen
+    FROM public.email_subscriptions es
+    JOIN auth.users u      ON u.id = es.user_id
+    JOIN public.profiles p ON p.id = es.user_id
+    LEFT JOIN public.user_xp ux ON ux.user_id = es.user_id
+    -- #1075: consent is asserted HERE, at claim time — the claim and the ledger
+    -- INSERT are one statement, so a flip between the learner becoming due and
+    -- the cron claiming excludes the row.
+    WHERE es.reminder_opt_in = true
+      AND u.email IS NOT NULL
+      AND u.email <> ''
+      -- Synthetic wallet-auth addresses are not inboxes (see #779). lower():
+      -- SQL mirror of isWalletPlaceholderEmail (#1074,
+      -- apps/web/src/lib/auth/wallet-placeholder.ts) — a differently-cased
+      -- placeholder must not slip past a byte-wise LIKE. Keep the two in step.
+      AND lower(u.email) NOT LIKE '%@wallet.superteam-lms.local'
+  ),
+  lapsed AS (
+    SELECT c.*, (v_today - c.last_seen)::int AS inactive_days
+    FROM consenting c
+    WHERE c.last_seen IS NOT NULL
+      AND c.last_seen <= v_today - p_inactive_days
+      -- THE FREQUENCY CAP. `sent_on > v_today - p_cap_days` is a half-open
+      -- window that INCLUDES today, so the row a sibling pass wrote minutes ago
+      -- blocks this one, and tomorrow's run is blocked by today's row.
+      AND NOT EXISTS (
+        SELECT 1 FROM public.email_reminder_log l
+        WHERE l.user_id = c.uid
+          AND l.kind = ANY(v_capped_kinds)
+          AND l.sent_on > v_today - p_cap_days
+      )
+  ),
+  -- Nearest-to-done enrolled course per lapsed learner. DISTINCT ON keeps one
+  -- course per learner, deterministically (fewest remaining, then course id).
+  nearly AS (
+    SELECT DISTINCT ON (e.user_id)
+      e.user_id   AS uid,
+      e.course_id AS cid
+    FROM public.enrollments e
+    JOIN lapsed l ON l.uid = e.user_id
+    CROSS JOIN LATERAL (
+      SELECT (p_course_totals ->> e.course_id)::int AS total
+    ) t
+    LEFT JOIN LATERAL (
+      SELECT count(*)::int AS done
+      FROM public.user_progress up
+      WHERE up.user_id = e.user_id
+        AND up.course_id = e.course_id
+        AND up.completed
+    ) pr ON true
+    WHERE p_kind = 'course_nudge'
+      -- A course the bundle does not list (unsynced/retired) is never nudged.
+      AND t.total IS NOT NULL
+      AND e.completed_at IS NULL
+      -- Already credentialed ⇒ nothing to finish.
+      AND NOT EXISTS (
+        SELECT 1 FROM public.certificates ct
+        WHERE ct.user_id = e.user_id AND ct.course_id = e.course_id
+      )
+      AND (t.total - COALESCE(pr.done, 0)) BETWEEN 1 AND p_max_remaining
+    ORDER BY e.user_id, (t.total - COALESCE(pr.done, 0)), e.course_id
+  ),
+  due AS (
+    -- course_nudge: only learners with a nearly-done course, carrying it.
+    SELECT
+      l.uid, l.mail, l.tok, l.loc, l.streak, l.inactive_days,
+      n.cid AS cid,
+      COALESCE(
+        (SELECT array_agg(up.lesson_id ORDER BY up.lesson_id)
+           FROM public.user_progress up
+          WHERE up.user_id = l.uid
+            AND up.course_id = n.cid
+            AND up.completed),
+        ARRAY[]::text[]
+      ) AS done_ids
+    FROM lapsed l
+    JOIN nearly n ON n.uid = l.uid
+    WHERE p_kind = 'course_nudge'
+    UNION ALL
+    -- reengagement_7d: no course context AT ALL. Not merely unused — returning
+    -- one would let the caller render a course nudge under the generic ledger
+    -- kind, breaking the template→return instrumentation.
+    SELECT
+      l.uid, l.mail, l.tok, l.loc, l.streak, l.inactive_days,
+      NULL::text, ARRAY[]::text[]
+    FROM lapsed l
+    WHERE p_kind = 'reengagement_7d'
+  ),
+  claimed AS (
+    INSERT INTO public.email_reminder_log (user_id, kind, sent_on)
+    SELECT due.uid, p_kind, v_today FROM due
+    ON CONFLICT (user_id, kind, sent_on) DO NOTHING
+    RETURNING email_reminder_log.user_id AS uid
+  )
+  SELECT d.uid, d.mail, d.tok, d.loc, d.streak, d.inactive_days, d.cid, d.done_ids
+  FROM due d
+  JOIN claimed c ON c.uid = d.uid
+  -- Deterministic order so the pipeline's chunk boundaries — and therefore its
+  -- Resend idempotency keys — are reproducible across a retry.
+  ORDER BY d.uid;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION claim_due_reengagement(TEXT, INTEGER, INTEGER, INTEGER, JSONB)
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION claim_due_reengagement(TEXT, INTEGER, INTEGER, INTEGER, JSONB)
+  TO service_role;
+
+COMMIT;
+
+-- ============================================================================
+-- POST-APPLY INVARIANT CHECKS (run as the gate after applying; all must hold)
+-- ----------------------------------------------------------------------------
+-- 1. Both bodies gate on the LOWERED address, and no byte-wise gate remains:
+--    SELECT proname,
+--           prosrc LIKE '%lower(u.email) NOT LIKE ''%@wallet.superteam-lms.local''%' AS lowered,
+--           prosrc NOT LIKE '%AND u.email NOT LIKE%'                                 AS bytewise_gone
+--    FROM pg_proc
+--    WHERE proname IN ('claim_due_session_reminders', 'claim_due_reengagement');
+--    ⇒ lowered = true, bytewise_gone = true for both rows.
+--
+-- 2. Consent is still asserted at claim time in both bodies:
+--    SELECT proname, prosrc LIKE '%WHERE es.reminder_opt_in = true%' AS consent_gate
+--    FROM pg_proc
+--    WHERE proname IN ('claim_due_session_reminders', 'claim_due_reengagement');
+--    ⇒ consent_gate = true for both rows.
+--
+-- 3. Signatures unchanged (the app reads + the #731 probe depend on them):
+--    SELECT proname, pg_get_function_identity_arguments(oid) AS args,
+--           pg_get_function_result(oid)                      AS result
+--    FROM pg_proc
+--    WHERE proname IN ('claim_due_session_reminders', 'claim_due_reengagement');
+--    ⇒ 'text' → TABLE(user_id uuid, email text, unsubscribe_token uuid,
+--      locale text, plan_time text); and
+--      'text, integer, integer, integer, jsonb' → TABLE(user_id uuid,
+--      email text, unsubscribe_token uuid, locale text, streak_days integer,
+--      days_inactive integer, course_id text, completed_lesson_ids text[]).
+--
+-- 4. Grants unchanged — service_role ONLY:
+--    SELECT p.proname, r.rolname, has_function_privilege(r.rolname, p.oid, 'EXECUTE') ex
+--    FROM pg_proc p CROSS JOIN (VALUES ('anon'),('authenticated'),('service_role')) r(rolname)
+--    WHERE p.proname IN ('claim_due_session_reminders', 'claim_due_reengagement');
+--    ⇒ ex = true ONLY for service_role.
+--
+-- 5. #899 cap and #896 token not regressed:
+--    SELECT prosrc LIKE '%ARRAY[''reengagement_7d'', ''course_nudge'']%' AS capped,
+--           prosrc LIKE '%es.reminder_unsubscribe_token%'                AS reminder_token
+--    FROM pg_proc WHERE proname = 'claim_due_reengagement';  ⇒ both true.
+--
+-- 6. SECURITY DEFINER + pinned empty search_path:
+--    SELECT proname, prosecdef, proconfig FROM pg_proc
+--    WHERE proname IN ('claim_due_session_reminders', 'claim_due_reengagement');
+--    ⇒ prosecdef = true, proconfig = {search_path=""} for both.
+-- ============================================================================
+
+-- ============================================================================
+-- ROLLBACK (tested; not executed by the migration runner)
+-- ----------------------------------------------------------------------------
+-- Function bodies only, no data change: re-run §2 of
+-- 20260804120000_recurring_lesson_plan.sql (claim_due_session_reminders) and
+-- §3 of 20260731170000_reengagement_pipeline.sql (claim_due_reengagement) to
+-- restore the byte-wise placeholder gates. Grants and signatures are identical
+-- in both directions.
+-- ============================================================================

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -3303,11 +3303,17 @@ BEGIN
     FROM public.email_subscriptions es
     JOIN auth.users u ON u.id = es.user_id
     JOIN public.profiles p ON p.id = es.user_id
+    -- #1075: consent is asserted HERE, at claim time — the claim and the ledger
+    -- INSERT are one statement, so a flip between the learner scheduling and
+    -- the cron claiming excludes the row.
     WHERE es.reminder_opt_in = true
       AND u.email IS NOT NULL
       AND u.email <> ''
-      -- Synthetic wallet-auth addresses are not inboxes (see #779).
-      AND u.email NOT LIKE '%@wallet.superteam-lms.local'
+      -- Synthetic wallet-auth addresses are not inboxes (see #779). lower():
+      -- SQL mirror of isWalletPlaceholderEmail (#1074,
+      -- apps/web/src/lib/auth/wallet-placeholder.ts) — a differently-cased
+      -- placeholder must not slip past a byte-wise LIKE. Keep the two in step.
+      AND lower(u.email) NOT LIKE '%@wallet.superteam-lms.local'
       -- Multi-day plans: membership of the committed `days` list
       -- (`jsonb ? text` = element exists). All seven entries = daily. The claim
       -- below still caps a learner at ONE reminder per São Paulo day.
@@ -3508,11 +3514,17 @@ BEGIN
     JOIN auth.users u      ON u.id = es.user_id
     JOIN public.profiles p ON p.id = es.user_id
     LEFT JOIN public.user_xp ux ON ux.user_id = es.user_id
+    -- #1075: consent is asserted HERE, at claim time — the claim and the ledger
+    -- INSERT are one statement, so a flip between the learner becoming due and
+    -- the cron claiming excludes the row.
     WHERE es.reminder_opt_in = true
       AND u.email IS NOT NULL
       AND u.email <> ''
-      -- Synthetic wallet-auth addresses are not inboxes (see #779).
-      AND u.email NOT LIKE '%@wallet.superteam-lms.local'
+      -- Synthetic wallet-auth addresses are not inboxes (see #779). lower():
+      -- SQL mirror of isWalletPlaceholderEmail (#1074,
+      -- apps/web/src/lib/auth/wallet-placeholder.ts) — a differently-cased
+      -- placeholder must not slip past a byte-wise LIKE. Keep the two in step.
+      AND lower(u.email) NOT LIKE '%@wallet.superteam-lms.local'
   ),
   lapsed AS (
     SELECT c.*, (v_today - c.last_seen)::int AS inactive_days


### PR DESCRIPTION
Two guarantees, both enforced in SQL inside the claim RPCs (the only consent gate the send pipelines trust):

1. **No placeholder spelling is ever claimed.** The wallet-placeholder exclusion was a byte-wise `u.email NOT LIKE '%@wallet.superteam-lms.local'`, so `AbC123@Wallet.Superteam-LMS.LOCAL` sailed through both RPCs (#921's F5). It is now `lower(u.email) NOT LIKE ...`, matching `isWalletPlaceholderEmail` from #1074. The domain literal lives in exactly one place per language — `WALLET_PLACEHOLDER_EMAIL_DOMAIN` in `apps/web/src/lib/auth/wallet-placeholder.ts` and the RPC bodies — cross-referenced in both directions.

2. **Consent is asserted at claim time.** `es.reminder_opt_in = true` sits inside the claim's `WHERE`, and the claim CTE plus the ledger `INSERT` are one statement, so a learner who unsubscribes between scheduling and the cron's claim is excluded and consumes no idempotency slot. This PR does not add that predicate — it pins it: the line is marked as the #1075 gate so a future body rewrite cannot silently drop it, and the PGlite suite now proves it behaviourally for both RPCs.

**Byte diff against the current definitions.** `claim_due_session_reminders` (from `20260804120000_recurring_lesson_plan.sql` §2) and `claim_due_reengagement` (from `20260731170000_reengagement_pipeline.sql` §3) are byte-identical except, in each body:

- one line changed: `AND u.email NOT LIKE '%@wallet.superteam-lms.local'` → `AND lower(u.email) NOT LIKE '%@wallet.superteam-lms.local'`
- its one-line comment expanded to four, cross-referencing the TS predicate
- three comment lines added above the existing `WHERE es.reminder_opt_in = true`

Nothing else moves: signatures and OUT columns, SECURITY DEFINER + `SET search_path = ''`, the service_role-only REVOKE/GRANT pairs, the per-(user, kind, São Paulo day) idempotency claim, the N=14 frequency cap and its advisory lock, the #980 `days[]` eligibility read, the #896 reminder-scoped token, and `ORDER BY d.uid` are carried forward unchanged. `list_marketing_recipients` is not a claim RPC and is untouched.

**TS senders need no change.** `lib/email/reminders.ts`, `reengagement-send.ts` and `campaign.ts` take recipients exclusively from the RPCs and never re-derive consent, so the fix is entirely in SQL.

**Tests.** New `apps/web/src/lib/supabase/__tests__/email-claim-consent-recheck-execution.test.ts` runs the real migration SQL in PGlite over the full prod lineage (18 tests). Its RED block replays the same fixtures *without* this migration and shows both RPCs claiming the mixed-case placeholder. GREEN proves: neither placeholder spelling is claimed by either RPC, a row whose `reminder_opt_in` flipped off after scheduling is excluded (and gets no ledger row), and an ordinary consenting learner is still claimed with the #896 token.

The migration awaits MCP apply to prod before this merges.

Closes #1075
