### PR TITLE
test: instructor-wallet suite mocks the cookieless client (#1094 follow-up)

### DIFF
--- a/apps/web/src/app/[locale]/(marketing)/layout.tsx
+++ b/apps/web/src/app/[locale]/(marketing)/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { DynamicReturnCatcher } from "@/components/auth/dynamic-return-catcher";
 
 export const metadata: Metadata = {
   title: "Superteam Academy — Solana Developer Education",
@@ -11,5 +12,12 @@ export default function MarketingLayout({
 }: {
   children: React.ReactNode;
 }) {
-  return children;
+  // The catcher completes a Dynamic social/device redirect that lands on a
+  // marketing page, where the (platform) provider stack is absent (#1097).
+  return (
+    <>
+      <DynamicReturnCatcher />
+      {children}
+    </>
+  );
 }

--- a/apps/web/src/app/[locale]/(platform)/layout.tsx
+++ b/apps/web/src/app/[locale]/(platform)/layout.tsx
@@ -1,11 +1,36 @@
+import { SolanaWalletProvider } from "@/lib/solana/wallet-provider";
+import { DynamicWalletProvider } from "@/components/auth/dynamic-wallet-provider";
+import { GamificationOverlays } from "@/components/gamification/gamification-overlays";
+
+/**
+ * (platform) routes carry the wallet/Dynamic provider stack and the
+ * gamification overlays (#1097); marketing/admin routes do not, and reach
+ * wallet features through AuthModal's lazily-mounted scoped stack instead.
+ *
+ * Order matters and mirrors what [locale]/layout.tsx had before the
+ * demotion: SolanaWalletProvider outside DynamicWalletProvider, both inside
+ * the global Auth/Analytics providers. Crossing marketing↔platform unmounts
+ * the stack; wallet-adapter keeps `walletName` in localStorage and never
+ * disconnects the adapter on unmount, so re-entry silently reconnects via
+ * autoConnect, and WalletAuthHandler's existing-session check keeps the
+ * reconnect from re-prompting SIWS.
+ */
 export default function PlatformLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
   return (
-    <div className="container px-4 pb-20 pt-6 sm:px-6 md:pt-8 lg:px-8 lg:pb-8">
-      {children}
-    </div>
+    <SolanaWalletProvider>
+      {/* DynamicAuthHandler is mounted by the provider itself, not here:
+          its hook throws outside a DynamicContextProvider, so it must never
+          be a sibling. */}
+      <DynamicWalletProvider>
+        <div className="container px-4 pb-20 pt-6 sm:px-6 md:pt-8 lg:px-8 lg:pb-8">
+          {children}
+        </div>
+        <GamificationOverlays />
+      </DynamicWalletProvider>
+    </SolanaWalletProvider>
   );
 }

--- a/apps/web/src/app/[locale]/admin/layout.tsx
+++ b/apps/web/src/app/[locale]/admin/layout.tsx
@@ -1,7 +1,8 @@
 import { cookies } from "next/headers";
 import { getTranslations } from "next-intl/server";
-import { AdminNav } from "./admin-nav";
 import { isValidAdminSession } from "@/lib/admin/auth";
+import { DynamicReturnCatcher } from "@/components/auth/dynamic-return-catcher";
+import { AdminNav } from "./admin-nav";
 
 /**
  * Admin console shell. When the `admin_session` cookie validates, it renders
@@ -23,13 +24,21 @@ export default async function AdminLayout({
   const session = cookieStore.get("admin_session");
 
   if (!isValidAdminSession(session?.value)) {
-    return <>{children}</>;
+    // Admin sits outside (platform), so a Dynamic redirect landing here needs
+    // the catcher, same as marketing (#1097).
+    return (
+      <>
+        <DynamicReturnCatcher />
+        {children}
+      </>
+    );
   }
 
   const t = await getTranslations("admin");
 
   return (
     <div className="min-h-screen bg-bg text-text">
+      <DynamicReturnCatcher />
       <div className="mx-auto max-w-6xl px-4 py-8">
         <div className="mb-8">
           <h1 className="font-display text-2xl font-bold text-text">

--- a/apps/web/src/app/[locale]/layout.tsx
+++ b/apps/web/src/app/[locale]/layout.tsx
@@ -4,14 +4,12 @@ import { getMessages } from "next-intl/server";
 import { notFound } from "next/navigation";
 import { locales, type Locale } from "@/lib/i18n/config";
 import { ThemeProvider } from "@/components/layout/theme-provider";
-import { SolanaWalletProvider } from "@/lib/solana/wallet-provider";
 import { AnalyticsProvider } from "@/components/analytics/analytics-provider";
 import { AuthProvider } from "@/lib/auth/auth-provider";
 import { ReferralCapture } from "@/components/referrals/referral-capture";
-import { DynamicWalletProvider } from "@/components/auth/dynamic-wallet-provider";
 import { Header } from "@/components/layout/header";
 import { MobileBottomNav } from "@/components/layout/mobile-bottom-nav";
-import { GamificationOverlays } from "@/components/gamification/gamification-overlays";
+import { ToastContainer } from "@/components/ui/toast-container";
 
 interface LocaleLayoutProps {
   children: React.ReactNode;
@@ -35,6 +33,12 @@ export default async function LocaleLayout(props: LocaleLayoutProps) {
   // inline theme-flash-prevention <script> so it satisfies the nonce policy.
   const nonce = (await headers()).get("x-nonce") ?? undefined;
 
+  // The wallet/Dynamic provider stack and the gamification overlays are NOT
+  // here (#1097): they mount in (platform)/layout.tsx, so marketing and admin
+  // first loads don't pay for wallet-adapter, the Dynamic SDK, or TanStack
+  // Query. Header children that touch the wallet degrade through
+  // useOptionalWallet, and the sign-in modal lazily mounts its own scoped
+  // stack when opened outside (platform).
   return (
     <ThemeProvider
       attribute="data-theme"
@@ -44,29 +48,25 @@ export default async function LocaleLayout(props: LocaleLayoutProps) {
       nonce={nonce}
     >
       <NextIntlClientProvider messages={messages}>
-        <SolanaWalletProvider>
-          {/* DynamicAuthHandler is mounted by the provider itself, not here:
-              its hook throws outside a DynamicContextProvider, so it must never
-              be a sibling. */}
-          <DynamicWalletProvider>
-            <AuthProvider>
-              {/* Captures ?ref= codes on any page and claims them once a
-                  session exists — attribution without touching any of the
-                  four auth flows. No UI. */}
-              <ReferralCapture />
-              <AnalyticsProvider>
-                <div className="grid-bg flex min-h-screen flex-col bg-[var(--bg)]">
-                  <Header />
-                  <main id="main-content" className="flex-1 pt-[60px]">
-                    {children}
-                  </main>
-                  <MobileBottomNav />
-                  <GamificationOverlays />
-                </div>
-              </AnalyticsProvider>
-            </AuthProvider>
-          </DynamicWalletProvider>
-        </SolanaWalletProvider>
+        <AuthProvider>
+          {/* Captures ?ref= codes on any page and claims them once a
+              session exists — attribution without touching any of the
+              four auth flows. No UI. */}
+          <ReferralCapture />
+          <AnalyticsProvider>
+            <div className="grid-bg flex min-h-screen flex-col bg-[var(--bg)]">
+              <Header />
+              <main id="main-content" className="flex-1 pt-[60px]">
+                {children}
+              </main>
+              <MobileBottomNav />
+              {/* Global on purpose: marketing pages dispatch toasts too
+                  (AuthErrorToast on refused logins), so the container cannot
+                  ride along with the (platform)-only overlays. */}
+              <ToastContainer />
+            </div>
+          </AnalyticsProvider>
+        </AuthProvider>
       </NextIntlClientProvider>
     </ThemeProvider>
   );

--- a/apps/web/src/components/auth/__tests__/auth-modal-no-dynamic-provider.test.tsx
+++ b/apps/web/src/components/auth/__tests__/auth-modal-no-dynamic-provider.test.tsx
@@ -4,6 +4,7 @@ import { describe, it, expect, vi } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { NextIntlClientProvider } from "next-intl";
 import messages from "@/messages/en.json";
+import { AmbientWalletProvider } from "@/lib/solana/optional-wallet";
 
 /**
  * The gate's core promise: with `NEXT_PUBLIC_DYNAMIC_ENVIRONMENT_ID` unset the
@@ -46,17 +47,30 @@ vi.mock("@/lib/dynamic/config", () => ({
 
 import { AuthModal } from "../auth-modal";
 
+// AmbientWalletProvider models a (platform) route (#1097); it is the plain
+// boolean stamp from lib/solana/optional-wallet, not a Dynamic provider, so
+// this render still exercises "no DynamicProvider mounted".
 describe("AuthModal with Dynamic disabled and no provider mounted", () => {
-  it("opens without throwing, and offers the other sign-in methods", () => {
+  it("opens without throwing, and offers the other sign-in methods", async () => {
     expect(() =>
       render(
         <NextIntlClientProvider locale="en" messages={messages}>
-          <AuthModal open onOpenChange={() => {}} />
+          <AmbientWalletProvider>
+            <AuthModal open onOpenChange={() => {}} />
+          </AmbientWalletProvider>
         </NextIntlClientProvider>
       )
     ).not.toThrow();
 
-    expect(screen.getByText(messages.auth.signInTitle)).toBeInTheDocument();
+    // findBy with a generous timeout: the dialog body is a lazy chunk since
+    // #1097, and its first import in a suite loads the Dynamic SDK.
+    expect(
+      await screen.findByText(
+        messages.auth.signInTitle,
+        {},
+        { timeout: 10_000 }
+      )
+    ).toBeInTheDocument();
     // The wallet route stays available — it is the guaranteed way in.
     expect(
       screen.getByRole("button", { name: messages.auth.connectSolanaWallet })
@@ -81,15 +95,19 @@ describe("AuthModal with Dynamic disabled and no provider mounted", () => {
   // A separate render: a click leaves every button disabled while the
   // full-page OAuth navigation is presumed imminent, so the two kill-switch
   // clicks cannot share one modal instance.
-  it("GitHub falls back to Supabase OAuth the same way", () => {
+  it("GitHub falls back to Supabase OAuth the same way", async () => {
     render(
       <NextIntlClientProvider locale="en" messages={messages}>
-        <AuthModal open onOpenChange={() => {}} />
+        <AmbientWalletProvider>
+          <AuthModal open onOpenChange={() => {}} />
+        </AmbientWalletProvider>
       </NextIntlClientProvider>
     );
 
     fireEvent.click(
-      screen.getByRole("button", { name: messages.auth.signInWithGitHub })
+      await screen.findByRole("button", {
+        name: messages.auth.signInWithGitHub,
+      })
     );
     expect(signInWithOAuth).toHaveBeenCalledWith(
       expect.objectContaining({ provider: "github" })

--- a/apps/web/src/components/auth/__tests__/auth-modal-scoped-providers.test.tsx
+++ b/apps/web/src/components/auth/__tests__/auth-modal-scoped-providers.test.tsx
@@ -1,0 +1,105 @@
+// @vitest-environment jsdom
+import type { ReactElement, ReactNode } from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { NextIntlClientProvider } from "next-intl";
+import messages from "@/messages/en.json";
+import { AmbientWalletProvider } from "@/lib/solana/optional-wallet";
+import { AuthModal } from "../auth-modal";
+
+/**
+ * #1097 — where the wallet/Dynamic providers come from when the sign-in
+ * modal opens:
+ *
+ * - No ambient stack (marketing/admin): AuthModal lazily mounts
+ *   ScopedAuthProviders around the dialog, and keeps it mounted after close
+ *   (the Solana path hands off to the wallet-select modal, which must
+ *   outlive this dialog).
+ * - Ambient stack ((platform) routes): the scoped stack must NOT mount —
+ *   nesting a second WalletProvider duplicates autoConnect and listeners.
+ */
+
+vi.mock("@solana/wallet-adapter-react-ui", () => ({
+  useWalletModal: () => ({ setVisible: vi.fn() }),
+}));
+vi.mock("@/lib/supabase/client", () => ({
+  createClient: vi.fn(() => ({
+    auth: { signInWithOAuth: vi.fn().mockResolvedValue({ error: null }) },
+  })),
+}));
+vi.mock("@/lib/analytics", () => ({ trackEvent: vi.fn() }));
+
+// The real module mounts wallet-adapter + the Dynamic SDK; this test is about
+// WHEN the stack mounts, not what is inside it. The marker still stamps
+// AmbientWalletProvider, exactly like the real stack's SolanaWalletProvider
+// does, so the modal body's provider gate opens.
+vi.mock("@/components/auth/scoped-auth-providers", async () => {
+  const { AmbientWalletProvider: Stamp } =
+    await import("@/lib/solana/optional-wallet");
+  return {
+    default: ({ children }: { children?: ReactNode }) => (
+      <div data-testid="scoped-providers">
+        <Stamp>{children}</Stamp>
+      </div>
+    ),
+  };
+});
+
+function renderWithIntl(ui: ReactElement) {
+  return render(
+    <NextIntlClientProvider locale="en" messages={messages}>
+      {ui}
+    </NextIntlClientProvider>
+  );
+}
+
+const TITLE = messages.auth.signInTitle;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("AuthModal scoped provider mounting (#1097)", () => {
+  it("lazily mounts the scoped stack when opened without ambient providers", async () => {
+    renderWithIntl(<AuthModal open onOpenChange={() => {}} />);
+
+    expect(await screen.findByTestId("scoped-providers")).toBeInTheDocument();
+    // The body renders INSIDE the stack (its wallet hooks resolve there).
+    // Generous timeout: the body chunk's first import loads the Dynamic SDK.
+    expect(
+      await screen.findByText(TITLE, {}, { timeout: 10_000 })
+    ).toBeInTheDocument();
+  });
+
+  it("mounts nothing scoped while closed", () => {
+    renderWithIntl(<AuthModal open={false} onOpenChange={() => {}} />);
+    expect(screen.queryByTestId("scoped-providers")).not.toBeInTheDocument();
+  });
+
+  it("keeps the scoped stack mounted after the dialog closes (wallet-modal handoff)", async () => {
+    const { rerender } = renderWithIntl(
+      <AuthModal open onOpenChange={() => {}} />
+    );
+    await screen.findByTestId("scoped-providers");
+
+    rerender(
+      <NextIntlClientProvider locale="en" messages={messages}>
+        <AuthModal open={false} onOpenChange={() => {}} />
+      </NextIntlClientProvider>
+    );
+
+    expect(screen.queryByText(TITLE)).not.toBeInTheDocument();
+    expect(screen.getByTestId("scoped-providers")).toBeInTheDocument();
+  });
+
+  it("never mounts the scoped stack when ambient providers exist (double-mount guard)", async () => {
+    renderWithIntl(
+      <AmbientWalletProvider>
+        <AuthModal open onOpenChange={() => {}} />
+      </AmbientWalletProvider>
+    );
+
+    expect(await screen.findByText(TITLE)).toBeInTheDocument();
+    expect(screen.queryByTestId("scoped-providers")).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/auth/__tests__/auth-modal.test.tsx
+++ b/apps/web/src/components/auth/__tests__/auth-modal.test.tsx
@@ -4,6 +4,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { NextIntlClientProvider } from "next-intl";
 import messages from "@/messages/en.json";
+import { AmbientWalletProvider } from "@/lib/solana/optional-wallet";
 import { AuthModal } from "../auth-modal";
 
 vi.mock("@solana/wallet-adapter-react-ui", () => ({
@@ -35,10 +36,13 @@ vi.mock("@/lib/supabase/client", () => ({
 
 vi.mock("@/lib/analytics", () => ({ trackEvent: vi.fn() }));
 
+// Wrapped in AmbientWalletProvider: this suite models the (platform) routes,
+// where the provider stack is ambient in the layout (#1097). The scoped
+// (marketing) path has its own suite, auth-modal-scoped-providers.test.tsx.
 function renderWithIntl(ui: ReactElement) {
   return render(
     <NextIntlClientProvider locale="en" messages={messages}>
-      {ui}
+      <AmbientWalletProvider>{ui}</AmbientWalletProvider>
     </NextIntlClientProvider>
   );
 }
@@ -51,10 +55,14 @@ beforeEach(() => {
 });
 
 describe("AuthModal — controlled mode (#556)", () => {
-  it("opens programmatically via the open prop, without rendering a trigger button", () => {
+  it("opens programmatically via the open prop, without rendering a trigger button", async () => {
     renderWithIntl(<AuthModal open onOpenChange={() => {}} />);
 
-    expect(screen.getByText(TITLE)).toBeInTheDocument();
+    // findBy with a generous timeout: the dialog body is a lazy chunk since
+    // #1097, and its first import in a suite loads the Dynamic SDK.
+    expect(
+      await screen.findByText(TITLE, {}, { timeout: 10_000 })
+    ).toBeInTheDocument();
     expect(
       screen.queryByRole("button", { name: DEFAULT_TRIGGER })
     ).not.toBeInTheDocument();
@@ -69,11 +77,11 @@ describe("AuthModal — controlled mode (#556)", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("reports close through onOpenChange", () => {
+  it("reports close through onOpenChange", async () => {
     const onOpenChange = vi.fn();
     renderWithIntl(<AuthModal open onOpenChange={onOpenChange} />);
 
-    fireEvent.keyDown(screen.getByText(TITLE), { key: "Escape" });
+    fireEvent.keyDown(await screen.findByText(TITLE), { key: "Escape" });
     expect(onOpenChange).toHaveBeenCalledWith(false);
   });
 
@@ -93,23 +101,23 @@ describe("AuthModal — controlled mode (#556)", () => {
 });
 
 describe("AuthModal — uncontrolled mode (unchanged)", () => {
-  it("renders the default trigger and opens on click", () => {
+  it("renders the default trigger and opens on click", async () => {
     renderWithIntl(<AuthModal />);
 
     const trigger = screen.getByRole("button", { name: DEFAULT_TRIGGER });
     expect(screen.queryByText(TITLE)).not.toBeInTheDocument();
 
     fireEvent.click(trigger);
-    expect(screen.getByText(TITLE)).toBeInTheDocument();
+    expect(await screen.findByText(TITLE)).toBeInTheDocument();
   });
 });
 
 describe("AuthModal — Later affordance (LX-A4b)", () => {
-  it("shows the keep-progress framing, a Later button, and reassurance copy", () => {
+  it("shows the keep-progress framing, a Later button, and reassurance copy", async () => {
     renderWithIntl(<AuthModal open onOpenChange={() => {}} showLater />);
 
     expect(
-      screen.getByText(messages.auth.keepProgressTitle)
+      await screen.findByText(messages.auth.keepProgressTitle)
     ).toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: messages.auth.later })
@@ -135,21 +143,25 @@ describe("AuthModal — Later affordance (LX-A4b)", () => {
     expect(claimCopy).toContain("saved");
   });
 
-  it("closes and calls onLater when Later is tapped", () => {
+  it("closes and calls onLater when Later is tapped", async () => {
     const onOpenChange = vi.fn();
     const onLater = vi.fn();
     renderWithIntl(
       <AuthModal open onOpenChange={onOpenChange} showLater onLater={onLater} />
     );
 
-    fireEvent.click(screen.getByRole("button", { name: messages.auth.later }));
+    fireEvent.click(
+      await screen.findByRole("button", { name: messages.auth.later })
+    );
     expect(onOpenChange).toHaveBeenCalledWith(false);
     expect(onLater).toHaveBeenCalledTimes(1);
   });
 
-  it("omits the Later affordance by default", () => {
+  it("omits the Later affordance by default", async () => {
     renderWithIntl(<AuthModal open onOpenChange={() => {}} />);
 
+    // Wait for the lazy body before asserting the button's absence.
+    await screen.findByText(TITLE);
     expect(
       screen.queryByRole("button", { name: messages.auth.later })
     ).not.toBeInTheDocument();

--- a/apps/web/src/components/auth/__tests__/dynamic-auth-handler-social-return.test.tsx
+++ b/apps/web/src/components/auth/__tests__/dynamic-auth-handler-social-return.test.tsx
@@ -65,6 +65,8 @@ vi.mock("@/lib/dynamic/client", () => ({ logoutDynamic }));
 vi.mock("@/lib/dynamic/siws", () => ({ toMessageSigner: vi.fn() }));
 vi.mock("@/lib/dynamic/social", () => ({
   bridgeDynamicSession,
+}));
+vi.mock("@/lib/dynamic/social-return-pending", () => ({
   setSocialReturnPending: vi.fn(),
 }));
 vi.mock("@/components/ui/toast-container", () => ({ dispatchToast: vi.fn() }));

--- a/apps/web/src/components/auth/auth-modal-body.tsx
+++ b/apps/web/src/components/auth/auth-modal-body.tsx
@@ -1,0 +1,239 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { useWalletModal } from "@solana/wallet-adapter-react-ui";
+import { GithubLogo } from "@phosphor-icons/react";
+import {
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { GoogleLogo } from "@/components/icons/google-logo";
+import { SolanaLogo } from "@/components/icons/solana-logo";
+import { createClient } from "@/lib/supabase/client";
+import { buildOAuthRedirect } from "@/lib/auth/oauth-redirect";
+import { trackEvent } from "@/lib/analytics";
+import { isDynamicEnabled } from "@/lib/dynamic/config";
+import { DynamicSocialSignIn } from "@/components/auth/dynamic-social-sign-in";
+
+export type AuthLoadingMethod = "solana" | "google" | "github" | null;
+
+export interface AuthModalBodyProps {
+  loading: AuthLoadingMethod;
+  setLoading: (v: AuthLoadingMethod) => void;
+  errorMessage: string | null;
+  setErrorMessage: (v: string | null) => void;
+  setOpen: (v: boolean) => void;
+  showLater: boolean;
+  onLater?: () => void;
+}
+
+/**
+ * Everything inside the sign-in dialog. A separate, lazily-loaded module
+ * (#1097) for two reasons:
+ *
+ * - It calls `useWalletModal()`, which must resolve under a
+ *   `WalletModalProvider` — ambient on (platform) routes, ScopedAuthProviders
+ *   elsewhere — while the outer AuthModal (and its trigger button) renders on
+ *   provider-less routes.
+ * - Its imports (wallet-adapter-react-ui, DynamicSocialSignIn → the Dynamic
+ *   SDK) are exactly what must stay out of the global header chunk. Never
+ *   import this statically from anything layout-reachable.
+ */
+export default function AuthModalBody({
+  loading,
+  setLoading,
+  errorMessage,
+  setErrorMessage,
+  setOpen,
+  showLater,
+  onLater,
+}: AuthModalBodyProps) {
+  const t = useTranslations("auth");
+  // NOT a Dynamic hook call. Every hook in `@dynamic-labs-sdk/react-hooks`
+  // throws `MissingProviderError` when no provider is mounted, so calling one
+  // here would crash sign-in in any build without an environment id. Hooks
+  // cannot be conditional, so the gate is a component boundary instead:
+  // DynamicSocialSignIn owns the hooks and mounts only when Dynamic is enabled.
+  const dynamicEnabled = isDynamicEnabled();
+  const { setVisible } = useWalletModal();
+
+  // Return the learner to the page they signed in from (#619 review): the OAuth
+  // callback otherwise always lands on /dashboard, stranding someone mid-lesson
+  // — and, post-LX-A4, away from the replay that finishes their banked work. The
+  // path-shape guard lives in buildOAuthRedirect (unit-tested); the callback
+  // re-sanitizes server-side too.
+  const oauthRedirectTo = () =>
+    buildOAuthRedirect(window.location.origin, window.location.pathname);
+
+  const handleConnectSolana = () => {
+    setLoading("solana");
+    trackEvent("auth_method_selected", { method: "solana" });
+    // Brief loading state, then hand off to wallet adapter modal
+    setTimeout(() => {
+      setOpen(false);
+      setLoading(null);
+      setTimeout(() => setVisible(true), 200);
+    }, 400);
+  };
+
+  const handleConnectGitHub = async () => {
+    setLoading("github");
+    setErrorMessage(null);
+    trackEvent("auth_method_selected", { method: "github" });
+    try {
+      const supabase = createClient();
+      const { error } = await supabase.auth.signInWithOAuth({
+        provider: "github",
+        options: {
+          redirectTo: oauthRedirectTo(),
+        },
+      });
+      if (error) {
+        console.error("[AuthModal] GitHub sign-in error:", error.message);
+        setErrorMessage(t("githubSignInFailed"));
+        setLoading(null);
+      }
+    } catch (err: unknown) {
+      const message =
+        err instanceof Error ? err.message : t("githubSignInFailed");
+      console.error("[AuthModal] GitHub sign-in error:", message);
+      setErrorMessage(t("githubSignInFailed"));
+      setLoading(null);
+    }
+  };
+
+  const handleConnectGoogle = async () => {
+    setLoading("google");
+    setErrorMessage(null);
+    trackEvent("auth_method_selected", { method: "google" });
+    try {
+      const supabase = createClient();
+      const { error } = await supabase.auth.signInWithOAuth({
+        provider: "google",
+        options: {
+          redirectTo: oauthRedirectTo(),
+        },
+      });
+      if (error) {
+        console.error("[AuthModal] Google sign-in error:", error.message);
+        setErrorMessage(t("googleSignInFailed"));
+        setLoading(null);
+      }
+    } catch (err: unknown) {
+      const message =
+        err instanceof Error ? err.message : t("googleSignInFailed");
+      console.error("[AuthModal] Google sign-in error:", message);
+      setErrorMessage(t("googleSignInFailed"));
+      setLoading(null);
+    }
+  };
+
+  return (
+    <>
+      <DialogHeader>
+        <DialogTitle className="text-center">
+          {t(showLater ? "keepProgressTitle" : "signInTitle")}
+        </DialogTitle>
+        <DialogDescription className="text-center">
+          {t(showLater ? "keepProgressSubtitle" : "signInSubtitle")}
+        </DialogDescription>
+      </DialogHeader>
+      <div className="mt-6 space-y-3">
+        <Button
+          variant="outline"
+          className="h-12 w-full gap-3 text-sm font-medium"
+          onClick={handleConnectSolana}
+          disabled={loading !== null}
+        >
+          {loading === "solana" ? (
+            <div className="h-5 w-5 animate-spin rounded-full border-2 border-current border-t-transparent" />
+          ) : (
+            <SolanaLogo className="h-5 w-5 shrink-0" />
+          )}
+          {loading === "solana" ? t("connecting") : t("connectSolanaWallet")}
+        </Button>
+
+        <div className="relative my-4">
+          <div className="absolute inset-0 flex items-center">
+            <span className="w-full border-t" />
+          </div>
+          <div className="relative flex justify-center text-xs uppercase">
+            <span className="bg-bg px-2 text-text-3">{t("or")}</span>
+          </div>
+        </div>
+
+        {/* Google goes through Dynamic when it is configured, so the learner
+            also walks away with an embedded wallet; the Supabase OAuth
+            button below is the fallback AND the kill switch — unsetting the
+            environment id restores it untouched. */}
+        {dynamicEnabled ? (
+          <DynamicSocialSignIn provider="google" disabled={loading !== null} />
+        ) : (
+          <Button
+            variant="outline"
+            className="h-12 w-full gap-3 text-sm font-medium"
+            onClick={handleConnectGoogle}
+            disabled={loading !== null}
+          >
+            {loading === "google" ? (
+              <div className="h-5 w-5 animate-spin rounded-full border-2 border-current border-t-transparent" />
+            ) : (
+              <GoogleLogo className="h-5 w-5 shrink-0" />
+            )}
+            {loading === "google" ? t("connecting") : t("signInWithGoogle")}
+          </Button>
+        )}
+
+        {/* GitHub goes through Dynamic when it is configured, so the learner
+            also walks away with an embedded wallet; the Supabase OAuth
+            button below is the fallback AND the kill switch — unsetting the
+            environment id restores it untouched. */}
+        {dynamicEnabled ? (
+          <DynamicSocialSignIn provider="github" disabled={loading !== null} />
+        ) : (
+          <Button
+            variant="outline"
+            className="h-12 w-full gap-3 text-sm font-medium"
+            onClick={handleConnectGitHub}
+            disabled={loading !== null}
+          >
+            {loading === "github" ? (
+              <div className="h-5 w-5 animate-spin rounded-full border-2 border-current border-t-transparent" />
+            ) : (
+              <GithubLogo className="h-5 w-5 shrink-0" weight="fill" />
+            )}
+            {loading === "github" ? t("connecting") : t("signInWithGitHub")}
+          </Button>
+        )}
+
+        {errorMessage && (
+          <p className="text-center text-sm text-danger" role="alert">
+            {errorMessage}
+          </p>
+        )}
+
+        {showLater && (
+          <div className="space-y-3 pt-1">
+            <Button
+              variant="ghost"
+              className="h-10 w-full text-sm font-medium text-text-3"
+              onClick={() => {
+                setOpen(false);
+                onLater?.();
+              }}
+              disabled={loading !== null}
+            >
+              {t("later")}
+            </Button>
+            {/* Reassurance — the work is KEPT, never discarded (F4). */}
+            <p className="text-center text-xs text-text-3">
+              {t("progressSavedLocally")}
+            </p>
+          </div>
+        )}
+      </div>
+    </>
+  );
+}

--- a/apps/web/src/components/auth/auth-modal.tsx
+++ b/apps/web/src/components/auth/auth-modal.tsx
@@ -1,26 +1,24 @@
 "use client";
 
-import { useState } from "react";
+import { lazy, Suspense, useEffect, useState } from "react";
 import { useTranslations } from "next-intl";
-import { useWalletModal } from "@solana/wallet-adapter-react-ui";
-import { GithubLogo } from "@phosphor-icons/react";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from "@/components/ui/dialog";
+import { useHasAmbientWallet } from "@/lib/solana/optional-wallet";
+import { Dialog, DialogContent, DialogTrigger } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
-import { GoogleLogo } from "@/components/icons/google-logo";
-import { SolanaLogo } from "@/components/icons/solana-logo";
-import { createClient } from "@/lib/supabase/client";
-import { buildOAuthRedirect } from "@/lib/auth/oauth-redirect";
-import { trackEvent } from "@/lib/analytics";
-import { isDynamicEnabled } from "@/lib/dynamic/config";
 import { useSocialReturnPending } from "@/hooks/use-social-return-pending";
-import { DynamicSocialSignIn } from "@/components/auth/dynamic-social-sign-in";
+import type {
+  AuthLoadingMethod,
+  AuthModalBodyProps,
+} from "@/components/auth/auth-modal-body";
+
+// Both lazy (#1097): this shell renders in the global Header on every route,
+// so the dialog innards (wallet-adapter-react-ui + the Dynamic SDK via
+// DynamicSocialSignIn) and the wallet/Dynamic provider stack load on the
+// sign-in click, never with a marketing first load.
+const AuthModalBody = lazy(() => import("@/components/auth/auth-modal-body"));
+const ScopedAuthProviders = lazy(
+  () => import("@/components/auth/scoped-auth-providers")
+);
 
 interface AuthModalProps {
   trigger?: React.ReactNode;
@@ -57,94 +55,30 @@ export function AuthModal({
     if (!isControlled) setInternalOpen(v);
     onOpenChange?.(v);
   };
-  const [loading, setLoading] = useState<"solana" | "google" | "github" | null>(
-    null
-  );
+  const [loading, setLoading] = useState<AuthLoadingMethod>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
-  // NOT a Dynamic hook call. Every hook in `@dynamic-labs-sdk/react-hooks`
-  // throws `MissingProviderError` when no provider is mounted, so calling one
-  // here would crash sign-in in any build without an environment id. Hooks
-  // cannot be conditional, so the gate is a component boundary instead:
-  // DynamicSocialSignIn owns the hooks and mounts only when Dynamic is enabled.
-  const dynamicEnabled = isDynamicEnabled();
   // While the Google-return handshake runs, the trigger button carries the
   // loading state — the alternative was a full-screen overlay, and the owner
   // preferred the button.
   const socialReturnPending = useSocialReturnPending();
-  const { setVisible } = useWalletModal();
 
-  // Return the learner to the page they signed in from (#619 review): the OAuth
-  // callback otherwise always lands on /dashboard, stranding someone mid-lesson
-  // — and, post-LX-A4, away from the replay that finishes their banked work. The
-  // path-shape guard lives in buildOAuthRedirect (unit-tested); the callback
-  // re-sanitizes server-side too.
-  const oauthRedirectTo = () =>
-    buildOAuthRedirect(window.location.origin, window.location.pathname);
+  // On (platform) routes the wallet/Dynamic providers are ambient in the
+  // layout; on marketing/admin routes they are not (#1097), and the first
+  // open lazily mounts ScopedAuthProviders around the whole Dialog instead.
+  // Around the DIALOG, not just its content, and sticky once mounted: the
+  // Solana path closes this modal and hands off to the wallet-select modal,
+  // whose provider (and the SIWS auth handler) must survive that close.
+  // Never both: the ambient check is the double-mount guard — nesting a
+  // second WalletProvider would duplicate autoConnect and wallet listeners.
+  const hasAmbientWallet = useHasAmbientWallet();
+  const [scopedMounted, setScopedMounted] = useState(false);
+  useEffect(() => {
+    // An effect rather than a setOpen side effect so controlled openers
+    // (open prop flipped by a parent) take the scoped path too.
+    if (open && !hasAmbientWallet) setScopedMounted(true);
+  }, [open, hasAmbientWallet]);
 
-  const handleConnectSolana = () => {
-    setLoading("solana");
-    trackEvent("auth_method_selected", { method: "solana" });
-    // Brief loading state, then hand off to wallet adapter modal
-    setTimeout(() => {
-      setOpen(false);
-      setLoading(null);
-      setTimeout(() => setVisible(true), 200);
-    }, 400);
-  };
-
-  const handleConnectGitHub = async () => {
-    setLoading("github");
-    setErrorMessage(null);
-    trackEvent("auth_method_selected", { method: "github" });
-    try {
-      const supabase = createClient();
-      const { error } = await supabase.auth.signInWithOAuth({
-        provider: "github",
-        options: {
-          redirectTo: oauthRedirectTo(),
-        },
-      });
-      if (error) {
-        console.error("[AuthModal] GitHub sign-in error:", error.message);
-        setErrorMessage(t("githubSignInFailed"));
-        setLoading(null);
-      }
-    } catch (err: unknown) {
-      const message =
-        err instanceof Error ? err.message : t("githubSignInFailed");
-      console.error("[AuthModal] GitHub sign-in error:", message);
-      setErrorMessage(t("githubSignInFailed"));
-      setLoading(null);
-    }
-  };
-
-  const handleConnectGoogle = async () => {
-    setLoading("google");
-    setErrorMessage(null);
-    trackEvent("auth_method_selected", { method: "google" });
-    try {
-      const supabase = createClient();
-      const { error } = await supabase.auth.signInWithOAuth({
-        provider: "google",
-        options: {
-          redirectTo: oauthRedirectTo(),
-        },
-      });
-      if (error) {
-        console.error("[AuthModal] Google sign-in error:", error.message);
-        setErrorMessage(t("googleSignInFailed"));
-        setLoading(null);
-      }
-    } catch (err: unknown) {
-      const message =
-        err instanceof Error ? err.message : t("googleSignInFailed");
-      console.error("[AuthModal] Google sign-in error:", message);
-      setErrorMessage(t("googleSignInFailed"));
-      setLoading(null);
-    }
-  };
-
-  return (
+  const dialog = (
     <Dialog
       open={open}
       onOpenChange={(v) => {
@@ -174,115 +108,53 @@ export function AuthModal({
         </DialogTrigger>
       )}
       <DialogContent className="sm:max-w-sm">
-        <DialogHeader>
-          <DialogTitle className="text-center">
-            {t(showLater ? "keepProgressTitle" : "signInTitle")}
-          </DialogTitle>
-          <DialogDescription className="text-center">
-            {t(showLater ? "keepProgressSubtitle" : "signInSubtitle")}
-          </DialogDescription>
-        </DialogHeader>
-        <div className="mt-6 space-y-3">
-          <Button
-            variant="outline"
-            className="h-12 w-full gap-3 text-sm font-medium"
-            onClick={handleConnectSolana}
-            disabled={loading !== null}
-          >
-            {loading === "solana" ? (
-              <div className="h-5 w-5 animate-spin rounded-full border-2 border-current border-t-transparent" />
-            ) : (
-              <SolanaLogo className="h-5 w-5 shrink-0" />
-            )}
-            {loading === "solana" ? t("connecting") : t("connectSolanaWallet")}
-          </Button>
-
-          <div className="relative my-4">
-            <div className="absolute inset-0 flex items-center">
-              <span className="w-full border-t" />
-            </div>
-            <div className="relative flex justify-center text-xs uppercase">
-              <span className="bg-bg px-2 text-text-3">{t("or")}</span>
-            </div>
-          </div>
-
-          {/* Google goes through Dynamic when it is configured, so the learner
-              also walks away with an embedded wallet; the Supabase OAuth
-              button below is the fallback AND the kill switch — unsetting the
-              environment id restores it untouched. */}
-          {dynamicEnabled ? (
-            <DynamicSocialSignIn
-              provider="google"
-              disabled={loading !== null}
-            />
-          ) : (
-            <Button
-              variant="outline"
-              className="h-12 w-full gap-3 text-sm font-medium"
-              onClick={handleConnectGoogle}
-              disabled={loading !== null}
-            >
-              {loading === "google" ? (
-                <div className="h-5 w-5 animate-spin rounded-full border-2 border-current border-t-transparent" />
-              ) : (
-                <GoogleLogo className="h-5 w-5 shrink-0" />
-              )}
-              {loading === "google" ? t("connecting") : t("signInWithGoogle")}
-            </Button>
-          )}
-
-          {/* GitHub goes through Dynamic when it is configured, so the learner
-              also walks away with an embedded wallet; the Supabase OAuth
-              button below is the fallback AND the kill switch — unsetting the
-              environment id restores it untouched. */}
-          {dynamicEnabled ? (
-            <DynamicSocialSignIn
-              provider="github"
-              disabled={loading !== null}
-            />
-          ) : (
-            <Button
-              variant="outline"
-              className="h-12 w-full gap-3 text-sm font-medium"
-              onClick={handleConnectGitHub}
-              disabled={loading !== null}
-            >
-              {loading === "github" ? (
-                <div className="h-5 w-5 animate-spin rounded-full border-2 border-current border-t-transparent" />
-              ) : (
-                <GithubLogo className="h-5 w-5 shrink-0" weight="fill" />
-              )}
-              {loading === "github" ? t("connecting") : t("signInWithGitHub")}
-            </Button>
-          )}
-
-          {errorMessage && (
-            <p className="text-center text-sm text-danger" role="alert">
-              {errorMessage}
-            </p>
-          )}
-
-          {showLater && (
-            <div className="space-y-3 pt-1">
-              <Button
-                variant="ghost"
-                className="h-10 w-full text-sm font-medium text-text-3"
-                onClick={() => {
-                  setOpen(false);
-                  onLater?.();
-                }}
-                disabled={loading !== null}
-              >
-                {t("later")}
-              </Button>
-              {/* Reassurance — the work is KEPT, never discarded (F4). */}
-              <p className="text-center text-xs text-text-3">
-                {t("progressSavedLocally")}
-              </p>
-            </div>
-          )}
-        </div>
+        <AuthModalBodyGate
+          loading={loading}
+          setLoading={setLoading}
+          errorMessage={errorMessage}
+          setErrorMessage={setErrorMessage}
+          setOpen={setOpen}
+          showLater={showLater}
+          onLater={onLater}
+        />
       </DialogContent>
     </Dialog>
+  );
+
+  if (hasAmbientWallet || !scopedMounted) return dialog;
+  // The fallback renders the SAME dialog while the provider chunk loads, so
+  // the trigger never flickers out; the swap remounts the Dialog subtree with
+  // `open` preserved in this component's state.
+  return (
+    <Suspense fallback={dialog}>
+      <ScopedAuthProviders>{dialog}</ScopedAuthProviders>
+    </Suspense>
+  );
+}
+
+/**
+ * Renders the dialog body only once wallet providers resolve above it.
+ * On (platform) routes that is immediate; on the scoped path it holds a
+ * spinner for the moment the Dialog still renders as the Suspense fallback
+ * OUTSIDE ScopedAuthProviders — mounting the body there would call Dynamic
+ * hooks without a provider, which throw.
+ */
+function AuthModalBodyGate(props: AuthModalBodyProps) {
+  const t = useTranslations("auth");
+  const providersReady = useHasAmbientWallet();
+  const spinner = (
+    <div
+      className="flex h-40 items-center justify-center"
+      role="status"
+      aria-label={t("signingIn")}
+    >
+      <div className="h-6 w-6 animate-spin rounded-full border-2 border-current border-t-transparent" />
+    </div>
+  );
+  if (!providersReady) return spinner;
+  return (
+    <Suspense fallback={spinner}>
+      <AuthModalBody {...props} />
+    </Suspense>
   );
 }

--- a/apps/web/src/components/auth/dynamic-auth-handler.tsx
+++ b/apps/web/src/components/auth/dynamic-auth-handler.tsx
@@ -21,10 +21,8 @@ import { createClient } from "@/lib/supabase/client";
 import { runWalletSiws } from "@/lib/wallet/siws";
 import { logoutDynamic } from "@/lib/dynamic/client";
 import { toMessageSigner } from "@/lib/dynamic/siws";
-import {
-  bridgeDynamicSession,
-  setSocialReturnPending,
-} from "@/lib/dynamic/social";
+import { bridgeDynamicSession } from "@/lib/dynamic/social";
+import { setSocialReturnPending } from "@/lib/dynamic/social-return-pending";
 import { dispatchToast } from "@/components/ui/toast-container";
 
 /**

--- a/apps/web/src/components/auth/dynamic-return-catcher.tsx
+++ b/apps/web/src/components/auth/dynamic-return-catcher.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { lazy, Suspense, useEffect, useState } from "react";
+import { isDynamicEnabled } from "@/lib/dynamic/config";
+
+const ScopedAuthProviders = lazy(
+  () => import("@/components/auth/scoped-auth-providers")
+);
+
+/**
+ * Completes a Dynamic redirect that lands on a provider-less route.
+ *
+ * Dynamic social sign-in is a full-page navigation back to the page the
+ * learner left (`DynamicSocialSignIn` passes `redirectUrl: location.href`),
+ * and `DynamicAuthHandler` — which finishes the handshake — used to be
+ * mounted globally. Since #1097 the provider stack lives on (platform) routes
+ * only, so a return landing on a marketing or admin page would strand the
+ * sign-in. This component is mounted on exactly those route groups: it sniffs
+ * the SDK's callback params from the URL (no SDK import — the param names are
+ * the stable contract of `detectSocialRedirectUrl` /
+ * `detectDeviceRegistrationRedirect`) and lazily mounts the scoped provider
+ * stack, whose handlers then run the real, SDK-verified detection.
+ *
+ * On every ordinary page load this renders null and loads nothing.
+ */
+export function DynamicReturnCatcher() {
+  const [mount, setMount] = useState(false);
+
+  useEffect(() => {
+    if (!isDynamicEnabled()) return;
+    const params = new URLSearchParams(window.location.search);
+    if (
+      (params.has("dynamicOauthState") && params.has("dynamicOauthCode")) ||
+      params.has("deviceRegistrationToken")
+    ) {
+      setMount(true);
+    }
+  }, []);
+
+  if (!mount) return null;
+  return (
+    <Suspense fallback={null}>
+      <ScopedAuthProviders />
+    </Suspense>
+  );
+}

--- a/apps/web/src/components/auth/scoped-auth-providers.tsx
+++ b/apps/web/src/components/auth/scoped-auth-providers.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { SolanaWalletProvider } from "@/lib/solana/wallet-provider";
+import { DynamicWalletProvider } from "@/components/auth/dynamic-wallet-provider";
+
+/**
+ * The full wallet/Dynamic provider stack, for the places OUTSIDE (platform)
+ * routes that still need it on demand (#1097): around the AuthModal body when
+ * it opens on a marketing/admin page, and under `DynamicReturnCatcher` when a
+ * social-redirect return lands on one.
+ *
+ * Loaded exclusively through `React.lazy` — this module is the chunk boundary
+ * that keeps wallet-adapter, Dynamic, and TanStack Query out of marketing
+ * first loads. Never import it statically from anything marketing-reachable.
+ *
+ * `lib/dynamic/client.ts`'s SSR tree-shape constraint (never mount the
+ * providers browser-only at layout level) does not apply here: everything
+ * under this component mounts post-hydration on user action or URL detection,
+ * so there is no server tree to mismatch. The Dynamic client itself is a
+ * module singleton with an `initialised` flag, so a second stack in the same
+ * page never re-initialises it.
+ *
+ * Mounting this UNDER an ambient (platform) stack would duplicate autoConnect
+ * and wallet listeners — callers must gate on `useHasAmbientWallet()` first.
+ */
+export default function ScopedAuthProviders({
+  children,
+}: {
+  children?: ReactNode;
+}) {
+  return (
+    <SolanaWalletProvider>
+      <DynamicWalletProvider>{children}</DynamicWalletProvider>
+    </SolanaWalletProvider>
+  );
+}

--- a/apps/web/src/components/auth/user-menu.tsx
+++ b/apps/web/src/components/auth/user-menu.tsx
@@ -12,7 +12,7 @@ import {
   Trophy,
   UserCircle,
 } from "@phosphor-icons/react";
-import { useWallet } from "@solana/wallet-adapter-react";
+import { useOptionalWallet } from "@/lib/solana/optional-wallet";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -23,7 +23,7 @@ import {
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { resetUser } from "@/lib/analytics";
 import { createClient } from "@/lib/supabase/client";
-import { logoutDynamic } from "@/lib/dynamic/client";
+import { isDynamicEnabled } from "@/lib/dynamic/config";
 
 interface UserMenuProps {
   username: string;
@@ -40,28 +40,35 @@ export function UserMenu({
 }: UserMenuProps) {
   const tCommon = useTranslations("common");
   const tNav = useTranslations("nav");
-  const { disconnect, connected } = useWallet();
+  // Null on routes without the wallet provider stack (marketing/admin,
+  // #1097) — there is nothing connected to disconnect there, and Supabase
+  // sign-out below works regardless.
+  const wallet = useOptionalWallet();
   const [copied, setCopied] = useState(false);
 
   const handleSignOut = useCallback(async () => {
-    if (connected) {
+    if (wallet?.connected) {
       try {
-        await disconnect();
+        await wallet.disconnect();
       } catch {
         // Wallet may already be disconnected — proceed with sign-out
       }
     }
     // End the Dynamic session too — without this, promptless MPC signing lets
     // the layout-level auth handler silently sign the learner back in on the
-    // next page load (see logoutDynamic).
-    await logoutDynamic();
+    // next page load (see logoutDynamic). Imported on demand: the static
+    // import would put the Dynamic SDK back into the global header chunk.
+    if (isDynamicEnabled()) {
+      const { logoutDynamic } = await import("@/lib/dynamic/client");
+      await logoutDynamic();
+    }
     const supabase = createClient();
     await supabase.auth.signOut();
     // Sever the analytics identity so the next visitor on this browser is not
     // attributed to the signed-out account.
     resetUser();
     window.location.href = `/${locale}`;
-  }, [locale, connected, disconnect]);
+  }, [locale, wallet]);
 
   const handleCopyAddress = useCallback(
     (e: React.MouseEvent) => {

--- a/apps/web/src/components/gamification/gamification-overlays.tsx
+++ b/apps/web/src/components/gamification/gamification-overlays.tsx
@@ -5,7 +5,6 @@ import { AchievementPopup } from "@/components/gamification/achievement-popup";
 import { CertificatePopup } from "@/components/gamification/certificate-popup";
 import { RewardPopupQueue } from "@/components/gamification/reward-popup";
 import { useGamificationEvents } from "@/hooks/use-gamification-events";
-import { ToastContainer } from "@/components/ui/toast-container";
 import { BankedProgressReplay } from "@/components/lessons/banked-progress-replay";
 import { SegmentSync } from "@/components/onboarding/segment-sync";
 
@@ -17,8 +16,10 @@ export function GamificationOverlays() {
 
   return (
     <>
-      {/* Toast container always renders — works for auth and non-auth contexts */}
-      <ToastContainer />
+      {/* ToastContainer is NOT here (#1097): these overlays mount only on
+          (platform) routes, while marketing pages dispatch toasts too (e.g.
+          AuthErrorToast on the landing page), so the container renders
+          globally in [locale]/layout.tsx instead. */}
       {/* Replays anonymously-banked completions once signed in (LX-A4c). */}
       <BankedProgressReplay />
       {/* Copies the anonymous /start intake into the profile on sign-in (LX-A3). */}

--- a/apps/web/src/components/layout/__tests__/low-sol-banner.test.tsx
+++ b/apps/web/src/components/layout/__tests__/low-sol-banner.test.tsx
@@ -14,8 +14,14 @@ const state = vi.hoisted(() => {
 });
 
 vi.mock("@solana/wallet-adapter-react", () => ({
-  useWallet: () => ({ publicKey: state.publicKey }),
   useConnection: () => ({ connection: state.connection }),
+}));
+
+// The banner reads the wallet through useOptionalWallet (#1097) so it renders
+// null on provider-less routes; these cases all model a (platform) route
+// where the ambient providers exist.
+vi.mock("@/lib/solana/optional-wallet", () => ({
+  useOptionalWallet: () => ({ publicKey: state.publicKey }),
 }));
 
 vi.mock("next-intl", () => ({

--- a/apps/web/src/components/layout/low-sol-banner.tsx
+++ b/apps/web/src/components/layout/low-sol-banner.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
-import { useWallet, useConnection } from "@solana/wallet-adapter-react";
+import { useConnection } from "@solana/wallet-adapter-react";
 import { useTranslations } from "next-intl";
+import { useOptionalWallet } from "@/lib/solana/optional-wallet";
 
 // Inlined so this layout-mounted component doesn't pull @solana/web3.js into
 // the shared client chunk for one plain constant (#1090).
@@ -16,7 +17,11 @@ const IS_DEVNET =
 
 export function LowSolBanner() {
   const t = useTranslations("nav");
-  const { publicKey } = useWallet();
+  // Null on routes without the wallet provider stack (marketing/admin,
+  // #1097): no wallet there means nothing to warn about, and the guards
+  // below all key off a null publicKey.
+  const wallet = useOptionalWallet();
+  const publicKey = wallet?.publicKey ?? null;
   const { connection } = useConnection();
   const [balance, setBalance] = useState<number | null>(null);
   const [dismissed, setDismissed] = useState(false);

--- a/apps/web/src/hooks/use-social-return-pending.ts
+++ b/apps/web/src/hooks/use-social-return-pending.ts
@@ -4,7 +4,7 @@ import { useSyncExternalStore } from "react";
 import {
   getSocialReturnPending,
   subscribeSocialReturnPending,
-} from "@/lib/dynamic/social";
+} from "@/lib/dynamic/social-return-pending";
 
 /**
  * Whether the Google-return handshake is running right now. Sign-in buttons

--- a/apps/web/src/lib/dynamic/social-return-pending.ts
+++ b/apps/web/src/lib/dynamic/social-return-pending.ts
@@ -1,0 +1,31 @@
+/**
+ * Social-return pending state, published by `DynamicAuthHandler` while the
+ * redirect-return handshake runs and consumed by the sign-in buttons (via
+ * `useSocialReturnPending`) so THEY carry the loading state — the owner's
+ * call over a full-screen overlay. A module-level store because the handler
+ * and the header render in unrelated trees; threading a context through the
+ * layout for one boolean would be all ceremony.
+ *
+ * Its own module, free of any Dynamic SDK import: the header's sign-in
+ * trigger reads this on EVERY route, and pulling `lib/dynamic/social` (which
+ * imports the SDK) into that chunk is exactly what #1097 removed.
+ */
+
+let socialReturnPending = false;
+const pendingListeners = new Set<() => void>();
+
+export function setSocialReturnPending(pending: boolean): void {
+  socialReturnPending = pending;
+  pendingListeners.forEach((listener) => listener());
+}
+
+export function subscribeSocialReturnPending(listener: () => void): () => void {
+  pendingListeners.add(listener);
+  return () => {
+    pendingListeners.delete(listener);
+  };
+}
+
+export function getSocialReturnPending(): boolean {
+  return socialReturnPending;
+}

--- a/apps/web/src/lib/dynamic/social.ts
+++ b/apps/web/src/lib/dynamic/social.ts
@@ -118,29 +118,6 @@ export async function bridgeDynamicSession(): Promise<DynamicBridgeOutcome> {
   }
 }
 
-/**
- * Social-return pending state, published by `DynamicAuthHandler` while the
- * redirect-return handshake runs and consumed by the sign-in buttons (via
- * `useSocialReturnPending`) so THEY carry the loading state — the owner's
- * call over a full-screen overlay. A module-level store because the handler
- * and the header render in unrelated trees; threading a context through the
- * layout for one boolean would be all ceremony.
- */
-let socialReturnPending = false;
-const pendingListeners = new Set<() => void>();
-
-export function setSocialReturnPending(pending: boolean): void {
-  socialReturnPending = pending;
-  pendingListeners.forEach((listener) => listener());
-}
-
-export function subscribeSocialReturnPending(listener: () => void): () => void {
-  pendingListeners.add(listener);
-  return () => {
-    pendingListeners.delete(listener);
-  };
-}
-
-export function getSocialReturnPending(): boolean {
-  return socialReturnPending;
-}
+// The social-return pending store moved to `lib/dynamic/social-return-pending`
+// (#1097): the header's sign-in trigger subscribes to it on every route, and
+// this module's SDK imports must not ride along into that chunk.

--- a/apps/web/src/lib/solana/__tests__/optional-wallet.test.tsx
+++ b/apps/web/src/lib/solana/__tests__/optional-wallet.test.tsx
@@ -1,0 +1,36 @@
+// @vitest-environment jsdom
+import type { ReactNode } from "react";
+import { describe, it, expect } from "vitest";
+import { renderHook } from "@testing-library/react";
+import {
+  AmbientWalletProvider,
+  useHasAmbientWallet,
+  useOptionalWallet,
+} from "../optional-wallet";
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <AmbientWalletProvider>{children}</AmbientWalletProvider>
+);
+
+describe("useOptionalWallet (#1097)", () => {
+  it("returns null with no provider stack above it", () => {
+    const { result } = renderHook(() => useOptionalWallet());
+    expect(result.current).toBeNull();
+  });
+
+  it("returns the wallet context under AmbientWalletProvider", () => {
+    const { result } = renderHook(() => useOptionalWallet(), { wrapper });
+    expect(result.current).not.toBeNull();
+    // The wallet-adapter context shape, not some substitute.
+    expect(result.current).toHaveProperty("connected");
+  });
+});
+
+describe("useHasAmbientWallet (#1097)", () => {
+  it("is false outside and true inside the provider", () => {
+    expect(renderHook(() => useHasAmbientWallet()).result.current).toBe(false);
+    expect(
+      renderHook(() => useHasAmbientWallet(), { wrapper }).result.current
+    ).toBe(true);
+  });
+});

--- a/apps/web/src/lib/solana/optional-wallet.tsx
+++ b/apps/web/src/lib/solana/optional-wallet.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { createContext, useContext, type ReactNode } from "react";
+import {
+  useWallet,
+  type WalletContextState,
+} from "@solana/wallet-adapter-react";
+
+/**
+ * "Is there a wallet provider stack above me?" — a question wallet-adapter
+ * cannot answer. `useWallet()` outside a `WalletProvider` does not throw or
+ * return null; it returns a module-level default context whose property
+ * getters `console.error` and hand back empty values. So the providers stamp
+ * this boolean context instead, and components that render on BOTH provider
+ * and provider-less routes (Header children — the wallet stack mounts only on
+ * (platform) routes since #1097) read the stamp before touching the wallet.
+ */
+const AmbientWalletContext = createContext(false);
+
+/** Stamped by `SolanaWalletProvider` — never render this on its own. */
+export function AmbientWalletProvider({ children }: { children: ReactNode }) {
+  return (
+    <AmbientWalletContext.Provider value={true}>
+      {children}
+    </AmbientWalletContext.Provider>
+  );
+}
+
+export function useHasAmbientWallet(): boolean {
+  return useContext(AmbientWalletContext);
+}
+
+/**
+ * `useWallet()` that degrades to `null` instead of to the error-logging
+ * default context when no provider is mounted.
+ */
+export function useOptionalWallet(): WalletContextState | null {
+  const hasProvider = useContext(AmbientWalletContext);
+  // Unconditional hook call; outside a provider this is the inert default
+  // context, which is safe to HOLD as long as no property is read — and when
+  // hasProvider is false it is discarded untouched.
+  const wallet = useWallet();
+  return hasProvider ? wallet : null;
+}

--- a/apps/web/src/lib/solana/wallet-provider.tsx
+++ b/apps/web/src/lib/solana/wallet-provider.tsx
@@ -8,6 +8,7 @@ import {
 } from "@solana/wallet-adapter-react";
 import { WalletModalProvider } from "@solana/wallet-adapter-react-ui";
 import { env } from "@/lib/env";
+import { AmbientWalletProvider } from "@/lib/solana/optional-wallet";
 import { WalletAuthHandler } from "@/components/auth/wallet-auth-handler";
 
 import "@solana/wallet-adapter-react-ui/styles.css";
@@ -46,8 +47,13 @@ export function SolanaWalletProvider({ children }: SolanaWalletProviderProps) {
         onError={onError}
       >
         <WalletModalProvider>
-          <WalletAuthHandler />
-          {children}
+          {/* Stamps "wallet hooks resolve here" for useOptionalWallet /
+              useHasAmbientWallet — the providers mount only on (platform)
+              routes (#1097), and Header children render everywhere. */}
+          <AmbientWalletProvider>
+            <WalletAuthHandler />
+            {children}
+          </AmbientWalletProvider>
         </WalletModalProvider>
       </WalletProvider>
     </ConnectionProvider>


### PR DESCRIPTION
#1107 was merged while its Frontend check was red: the route moved to the cookieless client but its test suite still mocked @/lib/supabase/server — 3 failures now on main. This repoints the mock (and adjusts for the sync client). Suite 4/4 locally.