### PR TITLE
fix(db): lock profiles.deleted_at to service_role, realign schema.sql

### DIFF
--- a/apps/web/src/lib/supabase/__tests__/deleted-at-write-lock-execution.test.ts
+++ b/apps/web/src/lib/supabase/__tests__/deleted-at-write-lock-execution.test.ts
@@ -1,0 +1,281 @@
+// REAL SQL-execution proof of the profiles.deleted_at write lock (#1103), run
+// in in-process Postgres (pglite) against BOTH copies of the DDL: the migration
+// that gets applied, and the supabase/schema.sql mirror that fresh environments
+// are built from.
+//
+// THE EXPLOIT. The self-service profiles policies are column-agnostic —
+// `FOR UPDATE USING (auth.uid() = id)` says which ROW you may write, never which
+// COLUMNS. deleted_at is the account tombstone every public read and every login
+// chokepoint keys on, so a soft-deleted user still holding a valid access token
+// could go straight to PostgREST with
+//
+//   UPDATE profiles SET deleted_at = NULL, is_public = true WHERE id = <self>
+//
+// and resurrect the account permanently — a single write inside the token's
+// remaining lifetime, long after the deletion route revoked the session.
+//
+// The RLS policies are installed here for real (with a stub auth.uid() reading
+// the JWT claim), so the "RLS alone does not stop it" case below is a live
+// red-proof: drop the trigger and the exploit succeeds against exactly the same
+// policies. That is what makes the rest of this suite a security test rather
+// than a trigger test.
+//
+// @vitest-environment node
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { PGlite } from "@electric-sql/pglite";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+
+function findRepoRoot(): string {
+  let dir = dirname(fileURLToPath(import.meta.url));
+  while (!existsSync(resolve(dir, "supabase/schema.sql"))) {
+    const parent = dirname(dir);
+    if (parent === dir)
+      throw new Error("repo root (supabase/schema.sql) not found");
+    dir = parent;
+  }
+  return dir;
+}
+
+const repoRoot = findRepoRoot();
+const migration = readFileSync(
+  resolve(
+    repoRoot,
+    "supabase/migrations/20260819200000_deleted_at_write_lock.sql"
+  ),
+  "utf8"
+);
+const schema = readFileSync(resolve(repoRoot, "supabase/schema.sql"), "utf8");
+
+const FN = "public.enforce_profile_deleted_at_write()";
+const TRIGGER = "trg_enforce_profile_deleted_at_write";
+
+/** Pull one `CREATE OR REPLACE FUNCTION <sig> … $$;` block out of a SQL file. */
+function extractFunction(sql: string, signature: string): string {
+  const start = sql.indexOf(`CREATE OR REPLACE FUNCTION ${signature}`);
+  if (start < 0) throw new Error(`function ${signature} not found`);
+  const end = sql.indexOf("$$;", start);
+  if (end < 0) throw new Error(`unterminated body for ${signature}`);
+  return sql.slice(start, end + 3);
+}
+
+/** Pull one single-statement `<needle>…;` out of a SQL file. */
+function extractStatement(sql: string, needle: string): string {
+  const start = sql.indexOf(needle);
+  if (start < 0) throw new Error(`statement not found: ${needle}`);
+  const end = sql.indexOf(";", start);
+  if (end < 0) throw new Error(`unterminated statement: ${needle}`);
+  return sql.slice(start, end + 1);
+}
+
+// The mirror copy is assembled from schema.sql's OWN statements, never from
+// literals written here — so a schema.sql that lost the REVOKE or the trigger
+// install fails at extraction instead of quietly testing this file's idea of it.
+const mirror = [
+  extractFunction(schema, FN),
+  extractStatement(schema, `REVOKE EXECUTE ON FUNCTION ${FN} FROM`),
+  extractStatement(
+    schema,
+    `DROP TRIGGER IF EXISTS ${TRIGGER} ON public.profiles`
+  ),
+  extractStatement(schema, `CREATE TRIGGER ${TRIGGER}`),
+].join("\n");
+
+// Minimal stand-in for the real profiles surface: the three Supabase roles, a
+// stub auth.uid() (the JWT `sub` claim, exactly what Supabase's does), the
+// columns this trigger and the exploit touch, and the REAL column-agnostic
+// self-service policies from schema.sql. service_role gets BYPASSRLS because
+// that is how Supabase provisions it.
+const STUB_SETUP = `
+  CREATE ROLE anon;
+  CREATE ROLE authenticated;
+  CREATE ROLE service_role BYPASSRLS;
+
+  CREATE SCHEMA IF NOT EXISTS auth;
+  CREATE FUNCTION auth.uid() RETURNS uuid LANGUAGE sql STABLE AS $fn$
+    SELECT (NULLIF(current_setting('request.jwt.claims', true), '')::jsonb ->> 'sub')::uuid;
+  $fn$;
+
+  CREATE TABLE public.profiles (
+    id uuid PRIMARY KEY,
+    username text UNIQUE,
+    bio text,
+    is_public boolean NOT NULL DEFAULT true,
+    deleted_at timestamptz,
+    deletion_requested_at timestamptz
+  );
+
+  ALTER TABLE public.profiles ENABLE ROW LEVEL SECURITY;
+  CREATE POLICY "Users can view their own profile"
+    ON public.profiles FOR SELECT USING (auth.uid() = id);
+  CREATE POLICY "Users can insert their own profile"
+    ON public.profiles FOR INSERT WITH CHECK (auth.uid() = id);
+  CREATE POLICY "Users can update their own profile"
+    ON public.profiles FOR UPDATE USING (auth.uid() = id);
+
+  GRANT SELECT, INSERT, UPDATE ON public.profiles TO authenticated;
+  GRANT ALL ON public.profiles TO service_role;
+`;
+
+const LIVE = "11111111-1111-1111-1111-111111111111";
+const TOMBSTONED = "44444444-4444-4444-4444-444444444444";
+const DENIED = /deleted_at may only be changed by service_role/;
+
+interface ProfileRow {
+  deleted_at: string | null;
+  is_public: boolean;
+}
+
+/** Become `role`, with `sub` presented as the JWT subject (as PostgREST does). */
+async function become(
+  db: PGlite,
+  role: "anon" | "authenticated" | "service_role",
+  sub?: string
+): Promise<void> {
+  await db.exec("RESET ROLE;");
+  await db.query(`SELECT set_config('request.jwt.claims', $1, false)`, [
+    JSON.stringify(sub ? { sub, role } : { role }),
+  ]);
+  await db.exec(`SET ROLE ${role};`);
+}
+
+/** Read a row with the trigger and RLS out of the way (superuser, no claims). */
+async function readProfile(db: PGlite, id: string): Promise<ProfileRow> {
+  await db.exec("RESET ROLE;");
+  await db.query(`SELECT set_config('request.jwt.claims', '', false)`);
+  const { rows } = await db.query<ProfileRow>(
+    `SELECT deleted_at, is_public FROM public.profiles WHERE id = $1`,
+    [id]
+  );
+  expect(rows.length).toBe(1);
+  return rows[0] as ProfileRow;
+}
+
+/** The #1103 exploit verbatim, run as the account's own authenticated session. */
+function resurrect(db: PGlite) {
+  return db.query(
+    `UPDATE public.profiles SET deleted_at = NULL, is_public = true WHERE id = $1`,
+    [TOMBSTONED]
+  );
+}
+
+for (const copy of ["migration", "schema.sql mirror"] as const) {
+  describe(`#1103 deleted_at write lock — ${copy}`, () => {
+    let db: PGlite;
+
+    beforeEach(async () => {
+      db = new PGlite();
+      await db.exec(STUB_SETUP);
+      await db.exec(copy === "migration" ? migration : mirror);
+      // Seeding a tombstone is itself a privileged write, so seed as
+      // service_role — under any other role the INSERT branch would coerce
+      // deleted_at back to NULL and there would be nothing to test.
+      await become(db, "service_role");
+      await db.query(
+        `INSERT INTO public.profiles(id, username, is_public, deleted_at, deletion_requested_at)
+         VALUES ($1, 'real-learner', true, NULL, NULL),
+                ($2, 'deleted-user-abc123', false, now(), now())`,
+        [LIVE, TOMBSTONED]
+      );
+      await db.exec("RESET ROLE;");
+    });
+
+    afterEach(async () => {
+      await db.close();
+    });
+
+    it("blocks the resurrection: own-row UPDATE cannot clear deleted_at", async () => {
+      await become(db, "authenticated", TOMBSTONED);
+      await expect(resurrect(db)).rejects.toThrow(DENIED);
+      // Nothing partially applied — is_public rode along in the same statement.
+      const row = await readProfile(db, TOMBSTONED);
+      expect(row.deleted_at).not.toBeNull();
+      expect(row.is_public).toBe(false);
+    });
+
+    it("blocks a self-tombstone too — deletion goes through the delete route", async () => {
+      await become(db, "authenticated", LIVE);
+      await expect(
+        db.query(
+          `UPDATE public.profiles SET deleted_at = now() WHERE id = $1`,
+          [LIVE]
+        )
+      ).rejects.toThrow(DENIED);
+      expect((await readProfile(db, LIVE)).deleted_at).toBeNull();
+    });
+
+    it("RLS alone does not stop it — the trigger is what blocks the write", async () => {
+      // Red-proof against the same policies: without the trigger, the exact
+      // exploit above succeeds and the account is permanently back.
+      await db.exec(`DROP TRIGGER ${TRIGGER} ON public.profiles;`);
+      await become(db, "authenticated", TOMBSTONED);
+      await resurrect(db);
+      const row = await readProfile(db, TOMBSTONED);
+      expect(row.deleted_at).toBeNull();
+      expect(row.is_public).toBe(true);
+    });
+
+    it("leaves ordinary self-service profile edits alone", async () => {
+      await become(db, "authenticated", LIVE);
+      await db.query(
+        `UPDATE public.profiles SET bio = 'gm', is_public = false WHERE id = $1`,
+        [LIVE]
+      );
+      const row = await readProfile(db, LIVE);
+      expect(row.is_public).toBe(false);
+      expect(row.deleted_at).toBeNull();
+    });
+
+    it("service_role still tombstones and still restores", async () => {
+      await become(db, "service_role");
+      await db.query(
+        `UPDATE public.profiles SET deleted_at = now() WHERE id = $1`,
+        [LIVE]
+      );
+      expect((await readProfile(db, LIVE)).deleted_at).not.toBeNull();
+
+      await become(db, "service_role");
+      await db.query(
+        `UPDATE public.profiles SET deleted_at = NULL WHERE id = $1`,
+        [TOMBSTONED]
+      );
+      expect((await readProfile(db, TOMBSTONED)).deleted_at).toBeNull();
+    });
+
+    it("accepts the PostgREST service-role claim, not just the DB role", async () => {
+      // The channel merge_wallet_shell_account() uses: SET ROLE is forbidden
+      // inside a SECURITY DEFINER function, so it sets the claim instead. If
+      // this branch were dropped, the shell tombstone would start failing.
+      await db.exec("RESET ROLE;");
+      await db.query(`SELECT set_config('request.jwt.claims', $1, false)`, [
+        JSON.stringify({ sub: TOMBSTONED, role: "service_role" }),
+      ]);
+      await db.exec("SET ROLE authenticated;");
+      await resurrect(db);
+      expect((await readProfile(db, TOMBSTONED)).deleted_at).toBeNull();
+    });
+
+    it("coerces a non-privileged INSERT's deleted_at to NULL", async () => {
+      const born = "99999999-9999-9999-9999-999999999999";
+      await become(db, "authenticated", born);
+      await db.query(
+        `INSERT INTO public.profiles(id, username, deleted_at) VALUES ($1, 'newcomer', now())`,
+        [born]
+      );
+      // Coerced, not rejected: a hard failure here would block signup, and the
+      // provisioning trigger never sets deleted_at anyway.
+      expect((await readProfile(db, born)).deleted_at).toBeNull();
+    });
+
+    it("is not callable via PostgREST RPC", async () => {
+      for (const role of ["anon", "authenticated"] as const) {
+        await become(db, role);
+        await expect(db.query(`SELECT ${FN}`)).rejects.toThrow(
+          /permission denied/
+        );
+      }
+      await db.exec("RESET ROLE;");
+    });
+  });
+}

--- a/apps/web/src/lib/supabase/__tests__/deleted-at-write-lock-execution.test.ts
+++ b/apps/web/src/lib/supabase/__tests__/deleted-at-write-lock-execution.test.ts
@@ -25,7 +25,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { PGlite } from "@electric-sql/pglite";
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from "vitest";
 
 function findRepoRoot(): string {
   let dir = dirname(fileURLToPath(import.meta.url));
@@ -69,17 +69,42 @@ function extractStatement(sql: string, needle: string): string {
   return sql.slice(start, end + 1);
 }
 
+/** Pull one `CREATE TABLE <name> ( … \n);` block out of a SQL file. */
+function extractTable(sql: string, name: string): string {
+  const start = sql.indexOf(`CREATE TABLE ${name} (`);
+  if (start < 0) throw new Error(`table ${name} not found`);
+  const end = sql.indexOf("\n);", start);
+  if (end < 0) throw new Error(`unterminated table ${name}`);
+  return sql.slice(start, end + 3);
+}
+
+/** Pull one `CREATE OR REPLACE VIEW <name> AS … ;` block out of a SQL file. */
+function extractView(sql: string, name: string): string {
+  const start = sql.indexOf(`CREATE OR REPLACE VIEW ${name} AS`);
+  if (start < 0) throw new Error(`view ${name} not found`);
+  const end = sql.indexOf(";", start);
+  if (end < 0) throw new Error(`unterminated view ${name}`);
+  return sql.slice(start, end + 1);
+}
+
+/** The drop-then-create trigger install, taken from whichever file is under test. */
+function triggerInstall(sql: string): string {
+  return [
+    extractStatement(
+      sql,
+      `DROP TRIGGER IF EXISTS ${TRIGGER} ON public.profiles`
+    ),
+    extractStatement(sql, `CREATE TRIGGER ${TRIGGER}`),
+  ].join("\n");
+}
+
 // The mirror copy is assembled from schema.sql's OWN statements, never from
 // literals written here — so a schema.sql that lost the REVOKE or the trigger
 // install fails at extraction instead of quietly testing this file's idea of it.
 const mirror = [
   extractFunction(schema, FN),
   extractStatement(schema, `REVOKE EXECUTE ON FUNCTION ${FN} FROM`),
-  extractStatement(
-    schema,
-    `DROP TRIGGER IF EXISTS ${TRIGGER} ON public.profiles`
-  ),
-  extractStatement(schema, `CREATE TRIGGER ${TRIGGER}`),
+  triggerInstall(schema),
 ].join("\n");
 
 // Minimal stand-in for the real profiles surface: the three Supabase roles, a
@@ -163,11 +188,24 @@ function resurrect(db: PGlite) {
 for (const copy of ["migration", "schema.sql mirror"] as const) {
   describe(`#1103 deleted_at write lock — ${copy}`, () => {
     let db: PGlite;
+    const sql = copy === "migration" ? migration : mirror;
 
-    beforeEach(async () => {
+    // One instance per describe — creating a PGlite is expensive enough that
+    // doing it per test starves the other pglite suites when the whole file
+    // set runs in parallel. State is reset in beforeEach instead.
+    beforeAll(async () => {
       db = new PGlite();
       await db.exec(STUB_SETUP);
-      await db.exec(copy === "migration" ? migration : mirror);
+      await db.exec(sql);
+    }, 60_000);
+
+    beforeEach(async () => {
+      await db.exec("RESET ROLE;");
+      // Re-install the trigger before every case: the "RLS alone" test drops
+      // it, and a failure partway through that test must not silently disarm
+      // the rest of the suite.
+      await db.exec(triggerInstall(sql));
+      await db.exec("TRUNCATE public.profiles CASCADE;");
       // Seeding a tombstone is itself a privileged write, so seed as
       // service_role — under any other role the INSERT branch would coerce
       // deleted_at back to NULL and there would be nothing to test.
@@ -181,7 +219,7 @@ for (const copy of ["migration", "schema.sql mirror"] as const) {
       await db.exec("RESET ROLE;");
     });
 
-    afterEach(async () => {
+    afterAll(async () => {
       await db.close();
     });
 
@@ -279,3 +317,102 @@ for (const copy of ["migration", "schema.sql mirror"] as const) {
     });
   });
 }
+
+// The cases above build profiles from STUB_SETUP, which is exactly why the
+// review below found what it found: a hand-written stub always has the columns
+// the test wants. These build it from schema.sql's OWN declaration instead, so
+// the snapshot has to be internally consistent.
+describe("#1103 schema.sql is coherent with itself", () => {
+  let db: PGlite;
+
+  beforeAll(async () => {
+    db = new PGlite();
+    await db.exec(`
+      CREATE ROLE anon;
+      CREATE ROLE authenticated;
+      CREATE ROLE service_role BYPASSRLS;
+      CREATE SCHEMA IF NOT EXISTS auth;
+      CREATE TABLE auth.users (id uuid PRIMARY KEY);
+    `);
+    await db.exec(extractTable(schema, "profiles"));
+    await db.exec(`
+      CREATE TABLE user_xp (
+        user_id uuid PRIMARY KEY REFERENCES profiles(id),
+        total_xp integer NOT NULL DEFAULT 0,
+        level integer NOT NULL DEFAULT 0
+      );
+      GRANT SELECT, INSERT, UPDATE ON profiles TO authenticated;
+      GRANT ALL ON profiles, user_xp TO service_role;
+      INSERT INTO auth.users(id) VALUES ('${LIVE}'), ('${TOMBSTONED}');
+    `);
+    await db.exec(mirror);
+  }, 60_000);
+
+  beforeEach(async () => {
+    await db.exec("RESET ROLE;");
+    await db.exec(`
+      DROP VIEW IF EXISTS public_user_xp;
+      DROP VIEW IF EXISTS public_profiles;
+      TRUNCATE user_xp, profiles CASCADE;
+    `);
+  });
+
+  afterAll(async () => {
+    await db.close();
+  });
+
+  // F1 of the #1115 adversarial review: the trigger reads NEW.deleted_at, but
+  // the profiles declaration in the same file never had the column (nor
+  // deletion_requested_at), so on a DB built from this snapshot EVERY write to
+  // profiles died with `record "new" has no field "deleted_at"` — the trigger
+  // turned a missing column into a total outage of the table.
+  it("declares the columns the trigger and the public views read", async () => {
+    await become(db, "service_role");
+    await db.query(
+      `INSERT INTO profiles(id, username, deleted_at, deletion_requested_at)
+       VALUES ($1, 'real-learner', NULL, NULL), ($2, 'deleted-user-abc123', now(), now())`,
+      [LIVE, TOMBSTONED]
+    );
+
+    // An ordinary self-service edit must not trip the trigger.
+    await become(db, "authenticated", LIVE);
+    await db.query(`UPDATE profiles SET bio = 'gm' WHERE id = $1`, [LIVE]);
+
+    // …and the lock still holds on the real table shape.
+    await expect(
+      db.query(`UPDATE profiles SET deleted_at = NULL WHERE id = $1`, [
+        TOMBSTONED,
+      ])
+    ).rejects.toThrow(DENIED);
+  });
+
+  it("creates the two public views that filter p.deleted_at", async () => {
+    // #1105 restored `AND p.deleted_at IS NULL` to public_user_xp; both views
+    // fail to create at all if the column is missing from the declaration.
+    await db.exec(extractView(schema, "public_user_xp"));
+    await db.exec(extractView(schema, "public_profiles"));
+
+    await become(db, "service_role");
+    await db.query(
+      `INSERT INTO profiles(id, username, is_public, deleted_at)
+       VALUES ($1, 'real-learner', true, NULL), ($2, 'deleted-user-abc123', true, now())`,
+      [LIVE, TOMBSTONED]
+    );
+    await db.query(
+      `INSERT INTO user_xp(user_id, total_xp, level) VALUES ($1, 150, 1), ($2, 500, 2)`,
+      [LIVE, TOMBSTONED]
+    );
+
+    // The tombstoned row is public and carries XP, so only the deleted_at
+    // filter can keep it out of either view.
+    await db.exec("RESET ROLE;");
+    const xp = await db.query<{ user_id: string }>(
+      `SELECT user_id FROM public_user_xp`
+    );
+    const profiles = await db.query<{ id: string }>(
+      `SELECT id FROM public_profiles`
+    );
+    expect(xp.rows.map((r) => r.user_id)).toEqual([LIVE]);
+    expect(profiles.rows.map((r) => r.id)).toEqual([LIVE]);
+  });
+});

--- a/apps/web/src/lib/supabase/__tests__/merge-wallet-shell-execution.test.ts
+++ b/apps/web/src/lib/supabase/__tests__/merge-wallet-shell-execution.test.ts
@@ -62,6 +62,15 @@ const walletWriteTrigger = extractFunction(
   "public.enforce_profile_wallet_write()"
 );
 
+// #1103 locked deleted_at to service_role the same way. The merge TOMBSTONES
+// the shell (`SET deleted_at = now()`), so that guard is now on the merge's
+// write path too — install it here as well, or this suite would keep passing
+// against a schema the merge can no longer write to.
+const deletedAtWriteTrigger = extractFunction(
+  schema,
+  "public.enforce_profile_deleted_at_write()"
+);
+
 // Stub versions of every table the merge touches, with the REAL user-facing
 // keys (the UNIQUE/PK constraints the conflict policy depends on). Column sets
 // are trimmed to what the function reads or the keys require; shapes mirror
@@ -330,12 +339,18 @@ describe("merge_wallet_shell_account", () => {
     db = new PGlite();
     await db.exec(STUB_SETUP);
     await db.exec(walletWriteTrigger);
+    await db.exec(deletedAtWriteTrigger);
     await db.exec(`
       DROP TRIGGER IF EXISTS trg_enforce_profile_wallet_write ON public.profiles;
       CREATE TRIGGER trg_enforce_profile_wallet_write
         BEFORE INSERT OR UPDATE ON public.profiles
         FOR EACH ROW
         EXECUTE FUNCTION public.enforce_profile_wallet_write();
+      DROP TRIGGER IF EXISTS trg_enforce_profile_deleted_at_write ON public.profiles;
+      CREATE TRIGGER trg_enforce_profile_deleted_at_write
+        BEFORE INSERT OR UPDATE ON public.profiles
+        FOR EACH ROW
+        EXECUTE FUNCTION public.enforce_profile_deleted_at_write();
     `);
     await db.exec(migration);
   });

--- a/apps/web/src/lib/supabase/__tests__/platform-stats-execution.test.ts
+++ b/apps/web/src/lib/supabase/__tests__/platform-stats-execution.test.ts
@@ -175,13 +175,13 @@ for (const copy of COPIES) {
 
       const fresh = await newStats(db);
       expect(fresh).toEqual(await oldStats(db));
-      // Pin the semantics, not just parity: private XP excluded (the view's
-      // is_public filter), but private profiles/certs still counted — exactly
-      // what the old unfiltered head counts did. The soft-deleted profile's XP
-      // is INCLUDED today because schema.sql's public_user_xp is stale (#1105
-      // — prod filters deleted_at IS NULL). When #1105 lands, total_xp here
-      // must drop to 425; builders stays 4 (the head count never filtered).
-      expect(fresh).toEqual({ total_xp: 925, builders: 4, credentials: 3 });
+      // Pin the semantics, not just parity: private AND soft-deleted XP are
+      // excluded (the view's is_public + deleted_at filters), but private
+      // profiles/certs are still counted — exactly what the old unfiltered head
+      // counts did. total_xp dropped 925 → 425 when #1105 restored the
+      // deleted_at guard to schema.sql's public_user_xp; builders stays 4
+      // because the head count never filtered.
+      expect(fresh).toEqual({ total_xp: 425, builders: 4, credentials: 3 });
     });
 
     it("is not executable by anon or authenticated", async () => {

--- a/supabase/migrations/20260819200000_deleted_at_write_lock.sql
+++ b/supabase/migrations/20260819200000_deleted_at_write_lock.sql
@@ -53,8 +53,8 @@
 -- backfill) is NOT privileged here — run `SET ROLE service_role;` first. An
 -- UPDATE raises 42501, but an INSERT carrying deleted_at is SILENTLY coerced to
 -- NULL with no error, so a manual tombstone appears to succeed and does not.
--- The wallet lock has the same trap; see 20260817180000:44-49 for the time it
--- cost a real merge.
+-- The wallet lock (enforce_profile_wallet_write) has the identical INSERT
+-- coercion branch, so the same trap applies there.
 --
 -- Idempotent: CREATE OR REPLACE FUNCTION + DROP TRIGGER IF EXISTS / CREATE.
 

--- a/supabase/migrations/20260819200000_deleted_at_write_lock.sql
+++ b/supabase/migrations/20260819200000_deleted_at_write_lock.sql
@@ -49,6 +49,13 @@
 -- the top of its body for the wallet lock — the identical check, so the same
 -- set_config satisfies this one.
 --
+-- OPERATORS: a plain `postgres` session (the Supabase SQL editor, a manual
+-- backfill) is NOT privileged here — run `SET ROLE service_role;` first. An
+-- UPDATE raises 42501, but an INSERT carrying deleted_at is SILENTLY coerced to
+-- NULL with no error, so a manual tombstone appears to succeed and does not.
+-- The wallet lock has the same trap; see 20260817180000:44-49 for the time it
+-- cost a real merge.
+--
 -- Idempotent: CREATE OR REPLACE FUNCTION + DROP TRIGGER IF EXISTS / CREATE.
 
 CREATE OR REPLACE FUNCTION public.enforce_profile_deleted_at_write()

--- a/supabase/migrations/20260819200000_deleted_at_write_lock.sql
+++ b/supabase/migrations/20260819200000_deleted_at_write_lock.sql
@@ -1,0 +1,97 @@
+-- Lock profiles.deleted_at writes to service_role (#1103)
+--
+-- The self-service profiles RLS policies are column-agnostic —
+--   FOR INSERT WITH CHECK (auth.uid() = id)
+--   FOR UPDATE USING      (auth.uid() = id)
+-- — so they say WHICH row a caller may write, never WHICH columns. deleted_at
+-- is the account tombstone: /api/account/delete stamps it (service_role) and
+-- every public read plus the login chokepoints key on `deleted_at IS NULL`.
+-- Nothing stopped the tombstoned user from clearing it. A deleted account still
+-- holding a valid access token could go straight to PostgREST with
+--
+--   UPDATE profiles SET deleted_at = NULL, is_public = true WHERE id = <self>
+--
+-- and resurrect itself permanently — the write survives long after the token
+-- that authorised it expires. Since #1089 the middleware no longer re-checks
+-- the tombstone per request, so the deletion route's session revocation is the
+-- only thing bounding the window, and the window is enough: one write inside it
+-- is permanent. Surfaced by the #1102 adversarial review (F5).
+--
+-- Fix: the same escalation-lockdown trigger already applied to wallet_address
+-- (#408, 20260710120000) and to the referral columns (20260818150000) —
+-- SECURITY INVOKER so `current_user` is the real caller, a
+-- BEFORE row trigger so it runs ahead of the write, privileged =
+-- `current_user = 'service_role'` (direct service-role connection) OR the
+-- PostgREST `request.jwt.claims` role (service-role key routed through
+-- PostgREST). Either signal is sufficient; nothing else is.
+--
+-- SEPARATE trigger rather than a third column in enforce_profile_wallet_write:
+-- extending that function means CREATE OR REPLACE-ing its whole body, and
+-- supabase/schema.sql's copy of it is stale (it predates #997's display_name /
+-- verified locks, which are live on prod). Replacing prod's body from the
+-- snapshot would silently revert two deployed guards. An additive trigger
+-- cannot. This is also what the referral lock did.
+--
+--   UPDATE — a non-privileged caller changing deleted_at at all raises. Both
+--     directions are blocked: clearing it is the resurrection above, and
+--     setting it is not a self-service path either (deletion goes through
+--     POST /api/account/delete, which also scrubs PII and revokes sessions —
+--     a bare self-stamp would tombstone the row while leaving the session
+--     alive and the PII in place).
+--   INSERT — coerced to NULL rather than raised, matching the wallet lock: the
+--     signup path (handle_new_user) inserts the profiles row itself and never
+--     sets deleted_at, so coercion cannot break account creation, while a hard
+--     failure there could.
+--
+-- The service-role writers are unaffected: /api/account/delete uses
+-- createAdminClient(), and merge_wallet_shell_account() (which tombstones the
+-- merged shell) already sets request.jwt.claims to the service_role claim at
+-- the top of its body for the wallet lock — the identical check, so the same
+-- set_config satisfies this one.
+--
+-- Idempotent: CREATE OR REPLACE FUNCTION + DROP TRIGGER IF EXISTS / CREATE.
+
+CREATE OR REPLACE FUNCTION public.enforce_profile_deleted_at_write()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+DECLARE
+  jwt_role TEXT;
+  is_privileged BOOLEAN;
+BEGIN
+  jwt_role := NULLIF(current_setting('request.jwt.claims', true), '')::jsonb ->> 'role';
+  is_privileged := COALESCE(current_user = 'service_role' OR jwt_role = 'service_role', false);
+
+  IF is_privileged THEN
+    RETURN NEW;
+  END IF;
+
+  IF TG_OP = 'UPDATE' THEN
+    -- IS DISTINCT FROM is NULL-safe and lets no-op updates through, so an
+    -- ordinary profile edit (bio, username, is_public) is untouched.
+    IF NEW.deleted_at IS DISTINCT FROM OLD.deleted_at THEN
+      RAISE EXCEPTION
+        'permission denied: deleted_at may only be changed by service_role'
+        USING ERRCODE = 'insufficient_privilege';
+    END IF;
+  ELSIF TG_OP = 'INSERT' THEN
+    IF NEW.deleted_at IS NOT NULL THEN
+      NEW.deleted_at := NULL;
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+-- Trigger functions run in trigger context (no EXECUTE needed), so this helper
+-- must never be callable via PostgREST RPC. Revoke the default PUBLIC grant.
+REVOKE EXECUTE ON FUNCTION public.enforce_profile_deleted_at_write() FROM PUBLIC, anon, authenticated;
+
+DROP TRIGGER IF EXISTS trg_enforce_profile_deleted_at_write ON public.profiles;
+CREATE TRIGGER trg_enforce_profile_deleted_at_write
+  BEFORE INSERT OR UPDATE ON public.profiles
+  FOR EACH ROW
+  EXECUTE FUNCTION public.enforce_profile_deleted_at_write();

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -829,6 +829,62 @@ CREATE TRIGGER trg_enforce_profile_wallet_write
 REVOKE EXECUTE ON FUNCTION public.enforce_profile_wallet_write() FROM PUBLIC, anon, authenticated;
 
 -- ─────────────────────────────────────────────
+-- 5a-ter. LOCK profiles.deleted_at WRITES TO service_role (#1103)
+-- ─────────────────────────────────────────────
+-- Same escalation class as the wallet lock above, on the account tombstone.
+-- deleted_at is what every public read and every login chokepoint keys on, and
+-- the column-agnostic self-service UPDATE policy let the tombstoned user clear
+-- it: `UPDATE profiles SET deleted_at = NULL, is_public = true` on their own row
+-- via PostgREST, using an access token that outlives the deletion, permanently
+-- resurrects the account. A SEPARATE trigger rather than a third column in
+-- enforce_profile_wallet_write, so replacing that function's body can never
+-- revert this guard (or vice versa) — the same shape the referral lock uses.
+-- Non-privileged UPDATEs that change it error in EITHER direction (self-delete
+-- must go through POST /api/account/delete, which also scrubs PII and revokes
+-- sessions); non-privileged INSERTs are coerced back to NULL (handle_new_user
+-- never sets it). See migration 20260819200000_deleted_at_write_lock.sql.
+CREATE OR REPLACE FUNCTION public.enforce_profile_deleted_at_write()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+DECLARE
+  jwt_role TEXT;
+  is_privileged BOOLEAN;
+BEGIN
+  jwt_role := NULLIF(current_setting('request.jwt.claims', true), '')::jsonb ->> 'role';
+  is_privileged := COALESCE(current_user = 'service_role' OR jwt_role = 'service_role', false);
+
+  IF is_privileged THEN
+    RETURN NEW;
+  END IF;
+
+  IF TG_OP = 'UPDATE' THEN
+    IF NEW.deleted_at IS DISTINCT FROM OLD.deleted_at THEN
+      RAISE EXCEPTION
+        'permission denied: deleted_at may only be changed by service_role'
+        USING ERRCODE = 'insufficient_privilege';
+    END IF;
+  ELSIF TG_OP = 'INSERT' THEN
+    IF NEW.deleted_at IS NOT NULL THEN
+      NEW.deleted_at := NULL;
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.enforce_profile_deleted_at_write() FROM PUBLIC, anon, authenticated;
+
+DROP TRIGGER IF EXISTS trg_enforce_profile_deleted_at_write ON public.profiles;
+CREATE TRIGGER trg_enforce_profile_deleted_at_write
+  BEFORE INSERT OR UPDATE ON public.profiles
+  FOR EACH ROW
+  EXECUTE FUNCTION public.enforce_profile_deleted_at_write();
+
+-- ─────────────────────────────────────────────
 -- 5b. LEADERBOARD RPC
 -- ─────────────────────────────────────────────
 
@@ -860,6 +916,7 @@ BEGIN
       JOIN public.profiles p ON p.id = ux.user_id
       WHERE ux.total_xp > 0
         AND p.is_public = true
+        AND p.deleted_at IS NULL
         AND p.username IS NOT NULL
         AND p.username <> ''
       ORDER BY ux.total_xp DESC
@@ -882,6 +939,7 @@ BEGIN
         FROM public.xp_transactions xt
         JOIN public.profiles p ON p.id = xt.user_id
         WHERE p.is_public = true
+          AND p.deleted_at IS NULL
           AND p.username IS NOT NULL
           AND p.username <> ''
           AND xt.created_at >= CASE
@@ -904,13 +962,17 @@ GRANT EXECUTE ON FUNCTION public.get_leaderboard(TEXT, INT) TO authenticated, an
 -- is_public filter is the access control. Used for public reads (marketing
 -- stats, public profiles, community author level badges) now that user_xp is
 -- own-row-only.
--- INVARIANT: the is_public filter is the SOLE access guard — removing it would
--- make every user's XP publicly readable. Do not remove it.
+-- INVARIANT: the is_public + deleted_at filters are the SOLE access guard —
+-- removing either would make soft-deleted or private users' XP publicly
+-- readable. Do not remove them. (#1105: the deleted_at half was added to prod by
+-- 20260704140000_account_deletion.sql and never mirrored here, so every DB
+-- rebuilt from this snapshot shipped without it.)
 CREATE OR REPLACE VIEW public_user_xp AS
   SELECT ux.user_id, ux.total_xp, ux.level
   FROM user_xp ux
   JOIN profiles p ON p.id = ux.user_id
-  WHERE p.is_public = true;
+  WHERE p.is_public = true
+    AND p.deleted_at IS NULL;
 
 REVOKE ALL ON public_user_xp FROM PUBLIC, anon, authenticated;
 GRANT SELECT ON public_user_xp TO anon, authenticated;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -24,9 +24,11 @@ CREATE TABLE profiles (
   -- string was converted to a one-element `days` array by
   -- 20260804120000_recurring_lesson_plan.sql and is no longer read. Non-PII,
   -- not in public_profiles; written self-service via the own-row profiles UPDATE
-  -- RLS policy. No column on profiles is privilege-bearing, so the shape+size
-  -- CHECKs below (chk_profiles_prefs_object / chk_profiles_prefs_size) are the
-  -- sole bound on this self-write. See 20260726160000_add_profiles_prefs.sql.
+  -- RLS policy. prefs itself is not privilege-bearing (unlike wallet_address,
+  -- deleted_at, and the referral columns, each of which carries a write-lock
+  -- trigger), so the shape+size CHECKs below (chk_profiles_prefs_object /
+  -- chk_profiles_prefs_size) are the sole bound on this self-write. See
+  -- 20260726160000_add_profiles_prefs.sql.
   prefs JSONB NOT NULL DEFAULT '{}',
   is_public BOOLEAN DEFAULT true,
   name_rerolls_used INTEGER DEFAULT 0,
@@ -34,14 +36,25 @@ CREATE TABLE profiles (
   -- NOTE: profiles.role was RETIRED by SP1 (migration 20260710120000, applied to
   -- prod as ledger 20260711152518). The column, its chk_profiles_role CHECK, and
   -- the enforce_profile_role_write lockdown trigger are all gone from prod, so
-  -- they are absent from this snapshot too (#699). Nothing privilege-bearing
-  -- remains on profiles — self-writes are bounded by the CHECK constraints alone.
+  -- they are absent from this snapshot too (#699). Authorization no longer lives
+  -- on a profiles column, but several columns are still privilege-bearing and
+  -- carry write-lock triggers rather than CHECKs: wallet_address (#408),
+  -- deleted_at (#1103), and the referral pair.
   -- /start intake state (LX-A3, #566). Self-writable via the own-row UPDATE
   -- policy: non-sensitive columns bounded only by the CHECKs below. NULL until a
   -- learner runs the intake. See migration 20260726150000_add_profiles_segment_state.sql.
   segment SMALLINT,
   goal TEXT,
   daily_goal SMALLINT,
+  -- Account-deletion tombstone (20260704140000_account_deletion.sql). We never
+  -- hard-delete a profile: on-chain XP and credential NFTs are immutable and
+  -- bound to the wallet, and DB history references them. POST /api/account/delete
+  -- stamps both and scrubs the PII instead. deleted_at is what every public read
+  -- and every login chokepoint keys on, so it is PRIVILEGE-BEARING and locked to
+  -- service_role by trg_enforce_profile_deleted_at_write below (#1103);
+  -- deletion_requested_at is the audit trail and is not gated.
+  deleted_at TIMESTAMPTZ,
+  deletion_requested_at TIMESTAMPTZ,
   created_at TIMESTAMPTZ DEFAULT NOW()
 );
 

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -897,6 +897,12 @@ CREATE TRIGGER trg_enforce_profile_deleted_at_write
   FOR EACH ROW
   EXECUTE FUNCTION public.enforce_profile_deleted_at_write();
 
+-- Partial index from 20260704140000_account_deletion.sql, live on prod but never
+-- mirrored here. Tombstones are a tiny minority of rows, so the partial form is
+-- what the deleted_at IS NULL reads want.
+CREATE INDEX IF NOT EXISTS idx_profiles_deleted_at
+  ON public.profiles(deleted_at) WHERE deleted_at IS NOT NULL;
+
 -- ─────────────────────────────────────────────
 -- 5b. LEADERBOARD RPC
 -- ─────────────────────────────────────────────


### PR DESCRIPTION
Locks `profiles.deleted_at` to service_role with a BEFORE trigger, the same escalation-lockdown shape already used for `wallet_address` and the referral columns. Without it a soft-deleted user holding a still-valid access token could hit PostgREST with `UPDATE profiles SET deleted_at = NULL, is_public = true` on their own row and permanently resurrect the account — the self-service UPDATE policy gates the row, never the columns.

The schema.sql half is snapshot-only: prod's `public_user_xp` and `get_leaderboard` have carried the `deleted_at IS NULL` guard since `20260704140000_account_deletion.sql`, but the snapshot never picked it up, so anything rebuilt from schema.sql exposed soft-deleted users' XP. Both objects now match the migration byte-for-byte.

A new pglite suite installs the real RLS policies alongside the trigger, so the exploit is proven blocked and — with the trigger dropped — proven to succeed against the same policies. 3035/3035 tests pass; the new suite is 16 (8 cases × migration and schema.sql copies), and `platform-stats-execution` drops from 925 to 425 total_xp, the change #1099 left a TODO for.

Two decisions the issues didn't specify: a separate `enforce_profile_deleted_at_write` rather than a third column on `enforce_profile_wallet_write` (schema.sql's copy of that function is stale — it predates #997's display_name/verified locks — so replacing prod's body from the snapshot would silently revert two live guards); and `deletion_requested_at` left writable, since only `deleted_at` is load-bearing for access.

**Not applied to any database.** The migration file is `supabase/migrations/20260819200000_deleted_at_write_lock.sql`, awaiting the usual apply-before-merge + ledger entry.

Closes #1103
Closes #1105
