### PR TITLE
fix(auth): free the SIWS overlay and the OAuth buttons from the lazy chunks

### DIFF
--- a/apps/web/src/__tests__/provider-free-import-graph.test.ts
+++ b/apps/web/src/__tests__/provider-free-import-graph.test.ts
@@ -1,0 +1,129 @@
+import { readFileSync, existsSync, statSync } from "fs";
+import path from "path";
+import { describe, it, expect } from "vitest";
+
+/**
+ * #1097's actual deliverable, as a test: marketing first loads must not carry
+ * wallet-adapter, the Dynamic SDK, or TanStack Query. Those live behind
+ * `React.lazy` boundaries — `scoped-auth-providers` and `auth-modal-body` —
+ * and one careless static import from anything the Header renders undoes the
+ * whole demotion silently, since the app still works, just 300 kB heavier.
+ *
+ * Walks the STATIC import graph (dynamic `import()` is the boundary, so it is
+ * deliberately not followed; `import type` is erased at build and likewise
+ * skipped) from the four entry points a marketing page mounts, and fails if
+ * any forbidden package is reachable.
+ */
+
+const SRC = path.resolve(__dirname, "..");
+
+const ENTRY_POINTS = [
+  "components/layout/header.tsx",
+  "components/auth/auth-modal.tsx",
+  "components/auth/user-menu.tsx",
+  "app/[locale]/(marketing)/landing-client.tsx",
+];
+
+const FORBIDDEN = [
+  "@solana/wallet-adapter-base",
+  "@solana/wallet-adapter-react",
+  "@solana/wallet-adapter-react-ui",
+  "@solana/wallet-adapter-wallets",
+  "@dynamic-labs-sdk/client",
+  "@dynamic-labs-sdk/react-hooks",
+  "@dynamic-labs-sdk/solana",
+  "@tanstack/react-query",
+];
+
+/** `import … from "x"` / `export … from "x"`, minus `import type`. */
+const IMPORT_RE =
+  /(?:^|\n)\s*(?:import|export)(?!\s+type\s)(?:[\s\S]*?from\s*)?["']([^"']+)["']/g;
+
+function readImports(file: string): string[] {
+  const source = readFileSync(file, "utf8");
+  const found: string[] = [];
+  for (const match of source.matchAll(IMPORT_RE)) {
+    const specifier = match[1];
+    if (specifier) found.push(specifier);
+  }
+  return found;
+}
+
+function resolveLocal(specifier: string, fromFile: string): string | null {
+  const base = specifier.startsWith("@/")
+    ? path.join(SRC, specifier.slice(2))
+    : specifier.startsWith(".")
+      ? path.resolve(path.dirname(fromFile), specifier)
+      : null;
+  if (base === null) return null; // a package, not a local module
+
+  for (const candidate of [
+    base,
+    `${base}.ts`,
+    `${base}.tsx`,
+    path.join(base, "index.ts"),
+    path.join(base, "index.tsx"),
+  ]) {
+    if (existsSync(candidate) && statSync(candidate).isFile()) return candidate;
+  }
+  return null; // css, json, or something with no module body to walk
+}
+
+/** Every package name statically reachable from `entry`, with one path each. */
+function reachablePackages(entry: string): Map<string, string[]> {
+  const packages = new Map<string, string[]>();
+  const seen = new Set<string>();
+  const queue: { file: string; trail: string[] }[] = [
+    { file: path.join(SRC, entry), trail: [entry] },
+  ];
+
+  while (queue.length > 0) {
+    const { file, trail } = queue.shift()!;
+    if (seen.has(file)) continue;
+    seen.add(file);
+
+    for (const specifier of readImports(file)) {
+      const local = resolveLocal(specifier, file);
+      if (local) {
+        queue.push({
+          file: local,
+          trail: [...trail, path.relative(SRC, local)],
+        });
+      } else if (!specifier.startsWith(".") && !specifier.startsWith("@/")) {
+        if (!packages.has(specifier)) packages.set(specifier, trail);
+      }
+    }
+  }
+  return packages;
+}
+
+describe("marketing entry points stay free of the wallet/Dynamic stack (#1097)", () => {
+  it.each(ENTRY_POINTS)("%s", (entry) => {
+    expect(existsSync(path.join(SRC, entry))).toBe(true);
+    const packages = reachablePackages(entry);
+
+    const offenders = FORBIDDEN.filter((pkg) =>
+      [...packages.keys()].some(
+        (found) => found === pkg || found.startsWith(`${pkg}/`)
+      )
+    ).map((pkg) => {
+      const via = [...packages.entries()].find(
+        ([found]) => found === pkg || found.startsWith(`${pkg}/`)
+      );
+      return `${pkg} via ${via?.[1].join(" -> ")}`;
+    });
+
+    expect(offenders).toEqual([]);
+  });
+
+  it("still finds the forbidden packages where they legitimately live", () => {
+    // Guards the walker itself: if the regex or the resolver silently stopped
+    // matching, every assertion above would pass vacuously.
+    const packages = reachablePackages(
+      "components/auth/scoped-auth-providers.tsx"
+    );
+    const names = [...packages.keys()];
+    expect(names).toContain("@solana/wallet-adapter-react");
+    expect(names.some((n) => n.startsWith("@dynamic-labs-sdk/"))).toBe(true);
+  });
+});

--- a/apps/web/src/__tests__/provider-free-import-graph.test.ts
+++ b/apps/web/src/__tests__/provider-free-import-graph.test.ts
@@ -11,13 +11,18 @@ import { describe, it, expect } from "vitest";
  *
  * Walks the STATIC import graph (dynamic `import()` is the boundary, so it is
  * deliberately not followed; `import type` is erased at build and likewise
- * skipped) from the four entry points a marketing page mounts, and fails if
- * any forbidden package is reachable.
+ * skipped) from the entry points a marketing page mounts, and fails if any
+ * forbidden package is reachable.
  */
 
 const SRC = path.resolve(__dirname, "..");
 
 const ENTRY_POINTS = [
+  // The layouts come first because they are where the stack LIVED before
+  // #1097, and they render the Header on every marketing route — a guard that
+  // starts at the Header alone never sees a provider re-added above it.
+  "app/[locale]/layout.tsx",
+  "app/[locale]/(marketing)/layout.tsx",
   "components/layout/header.tsx",
   "components/auth/auth-modal.tsx",
   "components/auth/user-menu.tsx",
@@ -35,18 +40,33 @@ const FORBIDDEN = [
   "@tanstack/react-query",
 ];
 
-/** `import … from "x"` / `export … from "x"`, minus `import type`. */
+/**
+ * `import … from "x"`, `export … from "x"`, and BARE `import "x"` — minus
+ * `import type`/`export type`, which are erased at build.
+ *
+ * The bare form matters twice over: a side-effect import of a forbidden
+ * package is invisible without it, and so is a side-effect import of a LOCAL
+ * module, which takes that module's whole subtree out of the walk with it.
+ *
+ * The clause between the keyword and `from` is restricted to what can
+ * actually appear there (identifiers, braces, commas, `*`, whitespace) so a
+ * match can never run past the end of a statement and swallow the next one.
+ */
 const IMPORT_RE =
-  /(?:^|\n)\s*(?:import|export)(?!\s+type\s)(?:[\s\S]*?from\s*)?["']([^"']+)["']/g;
+  /(?:^|\n)\s*(?:import|export)\b(?!\s+type\b)(?:[\w\s,{}*$]*?\bfrom\s*)?\s*["']([^"']+)["']/g;
 
-function readImports(file: string): string[] {
-  const source = readFileSync(file, "utf8");
+/** Exported for its own tests — the walker is only as good as this. */
+export function parseImports(source: string): string[] {
   const found: string[] = [];
   for (const match of source.matchAll(IMPORT_RE)) {
     const specifier = match[1];
     if (specifier) found.push(specifier);
   }
   return found;
+}
+
+function readImports(file: string): string[] {
+  return parseImports(readFileSync(file, "utf8"));
 }
 
 function resolveLocal(specifier: string, fromFile: string): string | null {
@@ -116,6 +136,14 @@ describe("marketing entry points stay free of the wallet/Dynamic stack (#1097)",
     expect(offenders).toEqual([]);
   });
 
+  it("covers the layouts that render the Header, not just the Header", () => {
+    // The stack lived in these two files before #1097, so a regression lands
+    // here first. Asserting membership keeps a future trim from quietly
+    // reopening that door.
+    expect(ENTRY_POINTS).toContain("app/[locale]/layout.tsx");
+    expect(ENTRY_POINTS).toContain("app/[locale]/(marketing)/layout.tsx");
+  });
+
   it("still finds the forbidden packages where they legitimately live", () => {
     // Guards the walker itself: if the regex or the resolver silently stopped
     // matching, every assertion above would pass vacuously.
@@ -125,5 +153,81 @@ describe("marketing entry points stay free of the wallet/Dynamic stack (#1097)",
     const names = [...packages.keys()];
     expect(names).toContain("@solana/wallet-adapter-react");
     expect(names.some((n) => n.startsWith("@dynamic-labs-sdk/"))).toBe(true);
+  });
+});
+
+describe("the import scanner itself", () => {
+  it("sees bare side-effect imports — of a package and of a local module", () => {
+    // Both were invisible before: the regex required a `from`. A package
+    // imported this way went unreported, and a LOCAL module imported this way
+    // was never enqueued, hiding its entire subtree.
+    expect(parseImports('import "@solana/wallet-adapter-react";')).toEqual([
+      "@solana/wallet-adapter-react",
+    ]);
+    expect(
+      parseImports('import "@/components/auth/scoped-auth-providers";')
+    ).toEqual(["@/components/auth/scoped-auth-providers"]);
+    expect(parseImports('import "./styles.css";')).toEqual(["./styles.css"]);
+  });
+
+  it("still reads the ordinary forms", () => {
+    expect(
+      parseImports(
+        [
+          'import Default from "a";',
+          'import { named, other as alias } from "b";',
+          'import * as ns from "c";',
+          'import Mixed, { thing } from "d";',
+          "import {\n  multi,\n  line,\n} from 'e';",
+        ].join("\n")
+      )
+    ).toEqual(["a", "b", "c", "d", "e"]);
+  });
+
+  it("follows barrel re-exports and skips type-only ones", () => {
+    expect(
+      parseImports(
+        [
+          'export * from "barrel";',
+          'export { thing } from "named-barrel";',
+          'export type { Only } from "types-only";',
+          'export type * from "types-star";',
+        ].join("\n")
+      )
+    ).toEqual(["barrel", "named-barrel"]);
+  });
+
+  it("skips `import type`, which is erased at build", () => {
+    expect(
+      parseImports(
+        [
+          'import type { Props } from "erased";',
+          'import type Default from "also-erased";',
+          'import typeahead from "not-a-type-import";',
+        ].join("\n")
+      )
+    ).toEqual(["not-a-type-import"]);
+  });
+
+  it("does not follow dynamic import(), which is the chunk boundary", () => {
+    expect(
+      parseImports(
+        [
+          'const m = await import("dynamic");',
+          "lazy(() => import('also-dynamic'));",
+          'import("at-line-start");',
+        ].join("\n")
+      )
+    ).toEqual([]);
+  });
+
+  it("never lets one statement swallow the next", () => {
+    // The clause charset stops at `;` and `(`, so a bare import followed by a
+    // real one cannot be matched as a single span that loses the first.
+    expect(
+      parseImports(
+        ['import "side-effect";', 'import x from "real";'].join("\n")
+      )
+    ).toEqual(["side-effect", "real"]);
   });
 });

--- a/apps/web/src/__tests__/provider-free-import-graph.test.ts
+++ b/apps/web/src/__tests__/provider-free-import-graph.test.ts
@@ -55,8 +55,68 @@ const FORBIDDEN = [
 const IMPORT_RE =
   /(?:^|\n)\s*(?:import|export)\b(?!\s+type\b)(?:[\w\s,{}*$]*?\bfrom\s*)?\s*["']([^"']+)["']/g;
 
+/**
+ * Blanks out comments, preserving newlines so the line anchoring above still
+ * lines up. A comment ANYWHERE inside an import clause — `import { // why\n
+ * useWallet } from "pkg"`, or `import { X } /* c *\/ from "pkg"` — otherwise
+ * makes the whole statement invisible, because the clause charset cannot
+ * cross `/`. That is an entirely ordinary thing to write, Prettier preserves
+ * it, and for a LOCAL import it would silently drop that module's whole
+ * subtree from the walk.
+ *
+ * Quote-aware, so a `//` inside a string is left alone. It does not model
+ * regex literals or template-literal substitutions; neither can appear in an
+ * import statement, and the walker's own guard test would catch a miss.
+ */
+function stripComments(source: string): string {
+  let out = "";
+  let quote: string | null = null;
+  let i = 0;
+  while (i < source.length) {
+    const c = source[i];
+    const next = source[i + 1];
+    if (quote !== null) {
+      if (c === "\\") {
+        out += c + (next ?? "");
+        i += 2;
+        continue;
+      }
+      if (c === quote) quote = null;
+      out += c;
+      i += 1;
+      continue;
+    }
+    if (c === '"' || c === "'" || c === "`") {
+      quote = c;
+      out += c;
+      i += 1;
+      continue;
+    }
+    if (c === "/" && next === "/") {
+      while (i < source.length && source[i] !== "\n") i += 1;
+      continue;
+    }
+    if (c === "/" && next === "*") {
+      i += 2;
+      while (
+        i < source.length &&
+        !(source[i] === "*" && source[i + 1] === "/")
+      ) {
+        if (source[i] === "\n") out += "\n"; // keep line anchoring intact
+        i += 1;
+      }
+      i += 2;
+      continue;
+    }
+    out += c;
+    i += 1;
+  }
+  return out;
+}
+
 /** Exported for its own tests — the walker is only as good as this. */
-export function parseImports(source: string): string[] {
+export function parseImports(rawSource: string): string[] {
+  const source = stripComments(rawSource);
   const found: string[] = [];
   for (const match of source.matchAll(IMPORT_RE)) {
     const specifier = match[1];
@@ -219,6 +279,47 @@ describe("the import scanner itself", () => {
         ].join("\n")
       )
     ).toEqual([]);
+  });
+
+  it("sees through comments inside an import clause", () => {
+    // Proved blind before: a comment anywhere in the clause made the whole
+    // statement invisible, because the clause charset cannot cross `/`.
+    expect(
+      parseImports(
+        'import {\n  // needed for the wallet chip\n  useWallet,\n} from "@solana/wallet-adapter-react";'
+      )
+    ).toEqual(["@solana/wallet-adapter-react"]);
+    expect(parseImports('import { X } /* why */ from "pkg";')).toEqual(["pkg"]);
+    expect(parseImports('import /* default */ X from "pkg";')).toEqual(["pkg"]);
+    // Worst case: a commented LOCAL import drops that module's whole subtree.
+    expect(parseImports('import { a } from "@/lib/thing"; // keep\n')).toEqual([
+      "@/lib/thing",
+    ]);
+    expect(
+      parseImports(
+        '/*\n * A block comment above.\n */\nimport x from "after-block";'
+      )
+    ).toEqual(["after-block"]);
+  });
+
+  it("does not mistake a `//` inside a string for a comment", () => {
+    expect(
+      parseImports(
+        ['const u = "https://example.com";', 'import x from "real";'].join("\n")
+      )
+    ).toEqual(["real"]);
+  });
+
+  it("ignores imports that are themselves commented out", () => {
+    expect(
+      parseImports(
+        [
+          '// import dead from "commented-out";',
+          '/* import alsoDead from "block-commented"; */',
+          'import live from "live";',
+        ].join("\n")
+      )
+    ).toEqual(["live"]);
   });
 
   it("never lets one statement swallow the next", () => {

--- a/apps/web/src/app/[locale]/layout.tsx
+++ b/apps/web/src/app/[locale]/layout.tsx
@@ -36,9 +36,10 @@ export default async function LocaleLayout(props: LocaleLayoutProps) {
   // The wallet/Dynamic provider stack and the gamification overlays are NOT
   // here (#1097): they mount in (platform)/layout.tsx, so marketing and admin
   // first loads don't pay for wallet-adapter, the Dynamic SDK, or TanStack
-  // Query. Header children that touch the wallet degrade through
-  // useOptionalWallet, and the sign-in modal lazily mounts its own scoped
-  // stack when opened outside (platform).
+  // Query. The Header sits ABOVE that stack, so its wallet consumers cannot
+  // reach it through context and read the module-level ambient store instead
+  // (lib/solana/ambient-wallet-store.ts); the sign-in modal lazily mounts its
+  // own scoped stack when opened outside (platform).
   return (
     <ThemeProvider
       attribute="data-theme"

--- a/apps/web/src/components/auth/__tests__/auth-modal-chunk-failure.test.tsx
+++ b/apps/web/src/components/auth/__tests__/auth-modal-chunk-failure.test.tsx
@@ -65,9 +65,13 @@ describe("AuthModal when the body chunk fails to load", () => {
     renderWithIntl(<AuthModal open onOpenChange={() => {}} />);
 
     fireEvent.click(
-      await screen.findByRole("button", {
-        name: messages.auth.signInWithGoogle,
-      })
+      await screen.findByRole(
+        "button",
+        {
+          name: messages.auth.signInWithGoogle,
+        },
+        { timeout: 5000 }
+      )
     );
     await waitFor(() =>
       expect(signInWithOAuth).toHaveBeenCalledWith(
@@ -95,9 +99,9 @@ describe("AuthModal when the body chunk fails to load", () => {
 
     // Await the fallback: asserting before the lazy import rejects would pass
     // against the spinner, whatever the copy says.
-    expect(await screen.findByRole("alert")).toHaveTextContent(
-      messages.auth.optionsLoadFailed
-    );
+    expect(
+      await screen.findByRole("alert", undefined, { timeout: 5000 })
+    ).toHaveTextContent(messages.auth.optionsLoadFailed);
     expect(
       screen.queryByText(messages.auth.authFailed)
     ).not.toBeInTheDocument();
@@ -114,9 +118,13 @@ describe("AuthModal when the body chunk fails to load", () => {
     });
     renderWithIntl(<AuthModal open onOpenChange={() => {}} />);
 
-    const google = await screen.findByRole("button", {
-      name: messages.auth.signInWithGoogle,
-    });
+    const google = await screen.findByRole(
+      "button",
+      {
+        name: messages.auth.signInWithGoogle,
+      },
+      { timeout: 5000 }
+    );
     fireEvent.click(google);
     await waitFor(() =>
       expect(
@@ -152,17 +160,25 @@ describe("AuthModal when the body chunk fails to load", () => {
   it("offers a retry that re-attempts the chunk", async () => {
     renderWithIntl(<AuthModal open onOpenChange={() => {}} />);
 
-    const retry = await screen.findByRole("button", {
-      name: messages.auth.retry,
-    });
+    const retry = await screen.findByRole(
+      "button",
+      {
+        name: messages.auth.retry,
+      },
+      { timeout: 5000 }
+    );
     fireEvent.click(retry);
 
     // The import still fails, so we land back on the same fallback rather than
     // on a blank dialog — and Google is still there.
     expect(
-      await screen.findByRole("button", {
-        name: messages.auth.signInWithGoogle,
-      })
+      await screen.findByRole(
+        "button",
+        {
+          name: messages.auth.signInWithGoogle,
+        },
+        { timeout: 5000 }
+      )
     ).toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/auth/__tests__/auth-modal-chunk-failure.test.tsx
+++ b/apps/web/src/components/auth/__tests__/auth-modal-chunk-failure.test.tsx
@@ -5,6 +5,8 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { NextIntlClientProvider } from "next-intl";
 import messages from "@/messages/en.json";
+import ptBR from "@/messages/pt-BR.json";
+import es from "@/messages/es.json";
 
 /**
  * A dead chunk must cost the wallet path only (#1109 review).
@@ -81,8 +83,70 @@ describe("AuthModal when the body chunk fails to load", () => {
       screen.queryByRole("button", { name: messages.auth.connectSolanaWallet })
     ).not.toBeInTheDocument();
     expect(
-      screen.getByText(messages.auth.authFailed, { selector: "p" })
+      screen.getByText(messages.auth.optionsLoadFailed, { selector: "p" })
     ).toBeInTheDocument();
+  });
+
+  it("does not blame the wallet for a chunk that failed to download", async () => {
+    // `authFailed` reads "Wallet authentication failed. Please try again…" —
+    // but no wallet was involved and nothing was attempted, and this is the
+    // first thing a screen reader announces when the modal opens.
+    renderWithIntl(<AuthModal open onOpenChange={() => {}} />);
+
+    // Await the fallback: asserting before the lazy import rejects would pass
+    // against the spinner, whatever the copy says.
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      messages.auth.optionsLoadFailed
+    );
+    expect(
+      screen.queryByText(messages.auth.authFailed)
+    ).not.toBeInTheDocument();
+    for (const locale of [messages, ptBR, es]) {
+      expect(locale.auth.optionsLoadFailed).not.toMatch(
+        /wallet|carteira|billetera/i
+      );
+    }
+  });
+
+  it("drops a stale error when the retry lands, and stays out of reach mid-sign-in", async () => {
+    signInWithOAuth.mockResolvedValueOnce({
+      error: { message: "provider is down" },
+    });
+    renderWithIntl(<AuthModal open onOpenChange={() => {}} />);
+
+    const google = await screen.findByRole("button", {
+      name: messages.auth.signInWithGoogle,
+    });
+    fireEvent.click(google);
+    await waitFor(() =>
+      expect(
+        screen.getByText(messages.auth.googleSignInFailed)
+      ).toBeInTheDocument()
+    );
+
+    // The retry re-attempts the chunk; it must not leave the previous
+    // failure sitting above a fresh button set.
+    fireEvent.click(screen.getByRole("button", { name: messages.auth.retry }));
+    await waitFor(() =>
+      expect(
+        screen.getByText(messages.auth.optionsLoadFailed)
+      ).toBeInTheDocument()
+    );
+    expect(
+      screen.queryByText(messages.auth.googleSignInFailed)
+    ).not.toBeInTheDocument();
+
+    // …and while an OAuth redirect is in flight, Retry would remount the
+    // chunk out from under it.
+    signInWithOAuth.mockImplementationOnce(() => new Promise(() => {}));
+    fireEvent.click(
+      screen.getByRole("button", { name: messages.auth.signInWithGoogle })
+    );
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: messages.auth.retry })
+      ).toBeDisabled()
+    );
   });
 
   it("offers a retry that re-attempts the chunk", async () => {

--- a/apps/web/src/components/auth/__tests__/auth-modal-chunk-failure.test.tsx
+++ b/apps/web/src/components/auth/__tests__/auth-modal-chunk-failure.test.tsx
@@ -1,0 +1,104 @@
+// @vitest-environment jsdom
+/* eslint-disable import/order -- vi.mock factories are hoisted above imports. */
+import type { ReactElement } from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { NextIntlClientProvider } from "next-intl";
+import messages from "@/messages/en.json";
+
+/**
+ * A dead chunk must cost the wallet path only (#1109 review).
+ *
+ * Google and GitHub sign-in need nothing but Supabase — no wallet-adapter, no
+ * Dynamic SDK, no provider above them. Before this, a body chunk that failed
+ * to load (blocked CDN, stale deploy after a redeploy, offline) replaced the
+ * whole modal with a "Try again", so the two methods that never needed the
+ * lazy stack became unreachable.
+ */
+
+const { signInWithOAuth } = vi.hoisted(() => ({
+  signInWithOAuth: vi.fn().mockResolvedValue({ error: null }),
+}));
+
+vi.mock("@/lib/supabase/client", () => ({
+  createClient: () => ({ auth: { signInWithOAuth } }),
+}));
+vi.mock("@/lib/analytics", () => ({ trackEvent: vi.fn() }));
+vi.mock("@/lib/dynamic/config", () => ({
+  isDynamicEnabled: () => false,
+  getDynamicEnvironmentId: () => null,
+}));
+vi.mock("@solana/wallet-adapter-react-ui", () => ({
+  useWalletModal: () => ({ setVisible: vi.fn() }),
+}));
+// What a 404'd chunk looks like to React.lazy: the import rejects. The
+// "[vitest] There was an error when mocking a module" lines this factory
+// prints ARE the simulated failure, not a broken test.
+vi.mock("@/components/auth/auth-modal-body", () => {
+  throw new Error("Failed to fetch dynamically imported module");
+});
+
+import { AuthModal } from "../auth-modal";
+
+function renderWithIntl(ui: ReactElement) {
+  return render(
+    <NextIntlClientProvider locale="en" messages={messages}>
+      {ui}
+    </NextIntlClientProvider>
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // React logs every boundary-caught error; the boundary is the point here.
+  vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("AuthModal when the body chunk fails to load", () => {
+  it("still offers Google and GitHub through Supabase OAuth", async () => {
+    renderWithIntl(<AuthModal open onOpenChange={() => {}} />);
+
+    fireEvent.click(
+      await screen.findByRole("button", {
+        name: messages.auth.signInWithGoogle,
+      })
+    );
+    await waitFor(() =>
+      expect(signInWithOAuth).toHaveBeenCalledWith(
+        expect.objectContaining({ provider: "google" })
+      )
+    );
+
+    expect(
+      screen.getByRole("button", { name: messages.auth.signInWithGitHub })
+    ).toBeInTheDocument();
+    // The wallet path is the only casualty, and the failure says so.
+    expect(
+      screen.queryByRole("button", { name: messages.auth.connectSolanaWallet })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByText(messages.auth.authFailed, { selector: "p" })
+    ).toBeInTheDocument();
+  });
+
+  it("offers a retry that re-attempts the chunk", async () => {
+    renderWithIntl(<AuthModal open onOpenChange={() => {}} />);
+
+    const retry = await screen.findByRole("button", {
+      name: messages.auth.retry,
+    });
+    fireEvent.click(retry);
+
+    // The import still fails, so we land back on the same fallback rather than
+    // on a blank dialog — and Google is still there.
+    expect(
+      await screen.findByRole("button", {
+        name: messages.auth.signInWithGoogle,
+      })
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/auth/__tests__/auth-modal-no-dynamic-provider.test.tsx
+++ b/apps/web/src/components/auth/__tests__/auth-modal-no-dynamic-provider.test.tsx
@@ -45,6 +45,12 @@ vi.mock("@/lib/dynamic/config", () => ({
 }));
 
 import { publishAmbientWallet } from "@/lib/solana/ambient-wallet-store";
+// Preloads the chunk AuthModal reaches through React.lazy, so the assertions
+// below meet a module that is already in the registry instead of racing a
+// cold transform of the (deliberately unmocked) SDK graph — the #1109 flake.
+// The gate this suite guards is unaffected: `isDynamicEnabled()` is false, so
+// DynamicSocialSignIn still never renders.
+import "@/components/auth/auth-modal-body";
 import { AuthModal } from "../auth-modal";
 
 // A live ambient registration models a (platform) route (#1097); it is the
@@ -64,7 +70,7 @@ afterEach(() => {
 });
 
 describe("AuthModal with Dynamic disabled and no provider mounted", () => {
-  it("opens without throwing, and offers the other sign-in methods", { timeout: 15_000 }, async () => {
+  it("opens without throwing, and offers the other sign-in methods", async () => {
     expect(() =>
       render(
         <NextIntlClientProvider locale="en" messages={messages}>
@@ -73,24 +79,15 @@ describe("AuthModal with Dynamic disabled and no provider mounted", () => {
       )
     ).not.toThrow();
 
-    // findBy with a generous timeout: the dialog body is a lazy chunk since
-    // #1097, and its first import in a suite loads the Dynamic SDK.
+    // findBy, not getBy: the body is still a React.lazy boundary.
     expect(
-      await screen.findByText(
-        messages.auth.signInTitle,
-        {},
-        { timeout: 10_000 }
-      )
+      await screen.findByText(messages.auth.signInTitle, {})
     ).toBeInTheDocument();
     // The wallet route stays available — it is the guaranteed way in.
-    // findBy with a generous timeout: the body chunk's first import in this
-    // suite loads the (unmocked) Dynamic SDK.
     expect(
-      await screen.findByRole(
-        "button",
-        { name: messages.auth.connectSolanaWallet },
-        { timeout: 10_000 }
-      )
+      await screen.findByRole("button", {
+        name: messages.auth.connectSolanaWallet,
+      })
     ).toBeInTheDocument();
     // ...and the email button is absent rather than broken.
     expect(
@@ -112,7 +109,7 @@ describe("AuthModal with Dynamic disabled and no provider mounted", () => {
   // A separate render: a click leaves every button disabled while the
   // full-page OAuth navigation is presumed imminent, so the two kill-switch
   // clicks cannot share one modal instance.
-  it("GitHub falls back to Supabase OAuth the same way", { timeout: 15_000 }, async () => {
+  it("GitHub falls back to Supabase OAuth the same way", async () => {
     render(
       <NextIntlClientProvider locale="en" messages={messages}>
         <AuthModal open onOpenChange={() => {}} />
@@ -120,11 +117,9 @@ describe("AuthModal with Dynamic disabled and no provider mounted", () => {
     );
 
     fireEvent.click(
-      await screen.findByRole(
-        "button",
-        { name: messages.auth.signInWithGitHub },
-        { timeout: 10_000 }
-      )
+      await screen.findByRole("button", {
+        name: messages.auth.signInWithGitHub,
+      })
     );
     expect(signInWithOAuth).toHaveBeenCalledWith(
       expect.objectContaining({ provider: "github" })

--- a/apps/web/src/components/auth/__tests__/auth-modal-scoped-providers.test.tsx
+++ b/apps/web/src/components/auth/__tests__/auth-modal-scoped-providers.test.tsx
@@ -8,6 +8,9 @@ import {
   publishAmbientWallet,
   setWalletReturnCaptureActive,
 } from "@/lib/solana/ambient-wallet-store";
+// Preloads the chunk AuthModal reaches through React.lazy, so these
+// assertions never race a cold transform of its graph (#1109 flake).
+import "@/components/auth/auth-modal-body";
 import { AuthModal } from "../auth-modal";
 
 /**
@@ -34,8 +37,8 @@ vi.mock("@/lib/analytics", () => ({ trackEvent: vi.fn() }));
 
 // The real module mounts wallet-adapter + the Dynamic SDK; this suite is
 // about WHEN the stack mounts, not what is inside it. Like the real stack's
-// registrar, the fake registers itself in the ambient store on mount so the
-// modal's body gate opens.
+// registrar, the fake registers itself in the ambient store on mount, which
+// is what the Solana button waits on.
 vi.mock("@/components/auth/scoped-auth-providers", async () => {
   const { publishAmbientWallet: publish } =
     await import("@/lib/solana/ambient-wallet-store");
@@ -83,134 +86,97 @@ afterEach(() => {
 });
 
 describe("AuthModal scoped provider mounting (#1097)", () => {
-  it(
-    "lazily mounts the scoped stack when opened with no live stack, and the body renders once it registers",
-    { timeout: 15_000 },
-    async () => {
-      renderWithIntl(<AuthModal open onOpenChange={() => {}} />);
+  it("lazily mounts the scoped stack when opened with no live stack, and the body renders once it registers", async () => {
+    renderWithIntl(<AuthModal open onOpenChange={() => {}} />);
 
-      expect(await screen.findByTestId("scoped-providers")).toBeInTheDocument();
-      // Generous timeout: the body chunk's first import loads the Dynamic SDK.
-      expect(
-        await screen.findByRole(
-          "button",
-          { name: CONNECT_WALLET },
-          { timeout: 10_000 }
-        )
-      ).toBeInTheDocument();
-    }
-  );
+    expect(await screen.findByTestId("scoped-providers")).toBeInTheDocument();
+    expect(
+      await screen.findByRole("button", { name: CONNECT_WALLET })
+    ).toBeInTheDocument();
+  });
 
   it("mounts nothing scoped while closed", () => {
     renderWithIntl(<AuthModal open={false} onOpenChange={() => {}} />);
     expect(screen.queryByTestId("scoped-providers")).not.toBeInTheDocument();
   });
 
-  it(
-    "keeps the scoped stack mounted after the dialog closes (wallet-modal handoff)",
-    { timeout: 15_000 },
-    async () => {
-      const { rerender } = renderWithIntl(
-        <AuthModal open onOpenChange={() => {}} />
-      );
-      await screen.findByTestId("scoped-providers");
+  it("keeps the scoped stack mounted after the dialog closes (wallet-modal handoff)", async () => {
+    const { rerender } = renderWithIntl(
+      <AuthModal open onOpenChange={() => {}} />
+    );
+    await screen.findByTestId("scoped-providers");
 
-      rerender(
-        <NextIntlClientProvider locale="en" messages={messages}>
-          <AuthModal open={false} onOpenChange={() => {}} />
-        </NextIntlClientProvider>
-      );
+    rerender(
+      <NextIntlClientProvider locale="en" messages={messages}>
+        <AuthModal open={false} onOpenChange={() => {}} />
+      </NextIntlClientProvider>
+    );
+
+    expect(
+      screen.queryByText(messages.auth.signInTitle)
+    ).not.toBeInTheDocument();
+    expect(screen.getByTestId("scoped-providers")).toBeInTheDocument();
+  });
+
+  it("never mounts the scoped stack when a live stack is registered (double-mount guard)", async () => {
+    const unregister = fakeAmbient();
+    try {
+      renderWithIntl(<AuthModal open onOpenChange={() => {}} />);
 
       expect(
-        screen.queryByText(messages.auth.signInTitle)
-      ).not.toBeInTheDocument();
-      expect(screen.getByTestId("scoped-providers")).toBeInTheDocument();
-    }
-  );
-
-  it(
-    "never mounts the scoped stack when a live stack is registered (double-mount guard)",
-    { timeout: 15_000 },
-    async () => {
-      const unregister = fakeAmbient();
-      try {
-        renderWithIntl(<AuthModal open onOpenChange={() => {}} />);
-
-        expect(
-          await screen.findByRole(
-            "button",
-            { name: CONNECT_WALLET },
-            { timeout: 10_000 }
-          )
-        ).toBeInTheDocument();
-        expect(
-          screen.queryByTestId("scoped-providers")
-        ).not.toBeInTheDocument();
-      } finally {
-        unregister();
-      }
-    }
-  );
-
-  it(
-    "disarms its own stack when another one registers while mounted (NEW-2: navigation with the modal open)",
-    { timeout: 15_000 },
-    async () => {
-      renderWithIntl(<AuthModal open onOpenChange={() => {}} />);
-      await screen.findByTestId("scoped-providers");
-
-      // The learner navigates to a (platform) route with the dialog up: the
-      // layout's stack registers as a second live stack…
-      const unregister = fakeAmbient();
-      try {
-        // …and the modal drops its own, converging back to one stack while the
-        // body keeps rendering against the newcomer.
-        await waitFor(() =>
-          expect(
-            screen.queryByTestId("scoped-providers")
-          ).not.toBeInTheDocument()
-        );
-        expect(
-          await screen.findByRole(
-            "button",
-            { name: CONNECT_WALLET },
-            { timeout: 10_000 }
-          )
-        ).toBeInTheDocument();
-      } finally {
-        unregister();
-      }
-    }
-  );
-
-  it(
-    "does not arm while the catcher's capture window is open (F4), then renders the body once that stack registers",
-    { timeout: 15_000 },
-    async () => {
-      setWalletReturnCaptureActive();
-      renderWithIntl(<AuthModal open onOpenChange={() => {}} />);
-
-      // The modal shows the standing-up spinner and must not start its own
-      // stack while the catcher's is on the way.
+        await screen.findByRole("button", { name: CONNECT_WALLET })
+      ).toBeInTheDocument();
       expect(screen.queryByTestId("scoped-providers")).not.toBeInTheDocument();
-
-      // The catcher's stack registers (this also clears the capture flag)…
-      const unregister = fakeAmbient();
-      try {
-        // …and the body proceeds against it, still with no modal-owned stack.
-        expect(
-          await screen.findByRole(
-            "button",
-            { name: CONNECT_WALLET },
-            { timeout: 10_000 }
-          )
-        ).toBeInTheDocument();
-        expect(
-          screen.queryByTestId("scoped-providers")
-        ).not.toBeInTheDocument();
-      } finally {
-        unregister();
-      }
+    } finally {
+      unregister();
     }
-  );
+  });
+
+  it("disarms its own stack when another one registers while mounted (NEW-2: navigation with the modal open)", async () => {
+    renderWithIntl(<AuthModal open onOpenChange={() => {}} />);
+    await screen.findByTestId("scoped-providers");
+
+    // The learner navigates to a (platform) route with the dialog up: the
+    // layout's stack registers as a second live stack…
+    const unregister = fakeAmbient();
+    try {
+      // …and the modal drops its own, converging back to one stack while the
+      // body keeps rendering against the newcomer.
+      await waitFor(() =>
+        expect(screen.queryByTestId("scoped-providers")).not.toBeInTheDocument()
+      );
+      expect(
+        await screen.findByRole("button", { name: CONNECT_WALLET })
+      ).toBeInTheDocument();
+    } finally {
+      unregister();
+    }
+  });
+
+  it("does not arm while the catcher's capture window is open (F4), then renders the body once that stack registers", async () => {
+    setWalletReturnCaptureActive();
+    renderWithIntl(<AuthModal open onOpenChange={() => {}} />);
+
+    // No modal-owned stack while the catcher's is on the way…
+    expect(screen.queryByTestId("scoped-providers")).not.toBeInTheDocument();
+    // …but the buttons that need no stack are already there (#1109 review):
+    // this used to be a full-body spinner.
+    expect(
+      await screen.findByRole("button", {
+        name: messages.auth.signInWithGoogle,
+      })
+    ).toBeEnabled();
+
+    // The catcher's stack registers (this also clears the capture flag)…
+    const unregister = fakeAmbient();
+    try {
+      // …and the body proceeds against it, still with no modal-owned stack.
+      expect(
+        await screen.findByRole("button", { name: CONNECT_WALLET })
+      ).toBeInTheDocument();
+      expect(screen.queryByTestId("scoped-providers")).not.toBeInTheDocument();
+    } finally {
+      unregister();
+    }
+  });
 });

--- a/apps/web/src/components/auth/__tests__/auth-modal-scoped-providers.test.tsx
+++ b/apps/web/src/components/auth/__tests__/auth-modal-scoped-providers.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import type { ReactElement } from "react";
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { NextIntlClientProvider } from "next-intl";
 import messages from "@/messages/en.json";
 import {
@@ -151,6 +151,34 @@ describe("AuthModal scoped provider mounting (#1097)", () => {
     } finally {
       unregister();
     }
+  });
+
+  it("clears a stuck loading state when the dialog closes (#1126)", async () => {
+    // In the capture window no stack of ours will ever register, so the Solana
+    // click pins `loading` — which lives in the shell while the body's
+    // `awaitingStack` is a ref inside the lazy chunk. A body remount orphaned
+    // it permanently, and `onOpenChange` refuses to close while it is truthy.
+    setWalletReturnCaptureActive();
+    const controlled = (open: boolean) => (
+      <NextIntlClientProvider locale="en" messages={messages}>
+        <AuthModal open={open} onOpenChange={() => {}} />
+      </NextIntlClientProvider>
+    );
+    const { rerender } = render(controlled(true));
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: CONNECT_WALLET })
+    );
+    expect(
+      await screen.findByRole("button", { name: messages.auth.connecting })
+    ).toBeDisabled();
+
+    rerender(controlled(false));
+    rerender(controlled(true));
+
+    expect(
+      await screen.findByRole("button", { name: CONNECT_WALLET })
+    ).toBeEnabled();
   });
 
   it("does not arm while the catcher's capture window is open (F4), then renders the body once that stack registers", async () => {

--- a/apps/web/src/components/auth/__tests__/auth-modal-siws-takeover.test.tsx
+++ b/apps/web/src/components/auth/__tests__/auth-modal-siws-takeover.test.tsx
@@ -1,0 +1,191 @@
+// @vitest-environment jsdom
+/* eslint-disable import/order -- vi.mock factories are hoisted above imports. */
+import type { ReactElement } from "react";
+import { useState } from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { NextIntlClientProvider } from "next-intl";
+import messages from "@/messages/en.json";
+
+/**
+ * The dialog and the SIWS overlay CAN coexist, and used to fight (#1109
+ * follow-up).
+ *
+ * Since #1097 opening the sign-in dialog is what mounts the wallet stack, and
+ * `SolanaWalletProvider` sets `autoConnect`, so a returning signed-out learner
+ * whose wallet name is still in localStorage reconnects the instant the stack
+ * mounts — firing SIWS with the dialog still open. Radix marks the body
+ * `pointer-events: none` for a modal dialog, and the body-portalled overlay
+ * inherits it: Retry and Dismiss render over a full-screen scrim and neither
+ * one can be clicked. Before this PR the overlay at least painted UNDER the
+ * dialog, so the learner kept a working dialog; the portal fix alone made that
+ * window strictly worse.
+ *
+ * The handler now raises a flag the modal watches, and the modal closes —
+ * the same handoff the manual wallet path already does.
+ */
+
+vi.mock("@solana/wallet-adapter-react", () => ({
+  useWallet: () => ({
+    connected: true,
+    publicKey: {
+      toBase58: () => "TestWa11etPubkey1111111111111111111111111111",
+    },
+    signMessage: vi.fn(async () => new Uint8Array([1, 2, 3])),
+    signIn: undefined,
+  }),
+}));
+vi.mock("@/lib/supabase/client", () => ({
+  createClient: () => ({
+    auth: {
+      getUser: async () => ({ data: { user: null } }),
+      signInWithOAuth: vi.fn().mockResolvedValue({ error: null }),
+    },
+  }),
+}));
+vi.mock("@/lib/analytics", () => ({ trackEvent: vi.fn() }));
+vi.mock("@/lib/dynamic/config", () => ({
+  isDynamicEnabled: () => false,
+  getDynamicEnvironmentId: () => null,
+}));
+
+// Stands in for the real scoped stack: mounts the real WalletAuthHandler (the
+// component under test) and registers in the ambient store the way
+// SolanaWalletProvider's registrar does. What it deliberately does NOT do is
+// pull in wallet-adapter's providers, which jsdom cannot run.
+vi.mock("@/components/auth/scoped-auth-providers", async () => {
+  const { publishAmbientWallet } =
+    await import("@/lib/solana/ambient-wallet-store");
+  const { useEffect } = await import("react");
+  const { WalletAuthHandler } = await import("../wallet-auth-handler");
+  return {
+    default: function FakeScopedStack() {
+      useEffect(
+        () =>
+          publishAmbientWallet({
+            connected: true,
+            publicKey: "TestWa11etPubkey1111111111111111111111111111",
+            disconnect: async () => {},
+            openWalletModal: () => {},
+          }),
+        []
+      );
+      return <WalletAuthHandler />;
+    },
+  };
+});
+
+import "@/components/auth/auth-modal-body";
+import { AuthModal } from "../auth-modal";
+
+/** Controlled the way the landing hero and the Enroll CTA drive it. */
+function ControlledModal({ onClose }: { onClose: () => void }) {
+  const [open, setOpen] = useState(true);
+  return (
+    <AuthModal
+      open={open}
+      onOpenChange={(v) => {
+        setOpen(v);
+        if (!v) onClose();
+      }}
+    />
+  );
+}
+
+function renderWithIntl(ui: ReactElement) {
+  return render(
+    <NextIntlClientProvider locale="en" messages={messages}>
+      {ui}
+    </NextIntlClientProvider>
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("SIWS firing while the sign-in dialog is open", () => {
+  it("closes the dialog so the overlay's buttons are reachable", async () => {
+    // The nonce never settles, so the overlay stays on "authenticating".
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => new Promise<Response>(() => {}))
+    );
+    const onClose = vi.fn();
+
+    renderWithIntl(<ControlledModal onClose={onClose} />);
+
+    await screen.findByTestId("siws-overlay");
+    await waitFor(() => expect(onClose).toHaveBeenCalledTimes(1));
+    await waitFor(() =>
+      expect(
+        screen.queryByText(messages.auth.signInTitle)
+      ).not.toBeInTheDocument()
+    );
+
+    // The proof the regression is gone: Radix's modal body lock is lifted, so
+    // the overlay does not inherit `pointer-events: none`.
+    expect(document.body.style.pointerEvents).not.toBe("none");
+  });
+
+  it("leaves Retry and Dismiss clickable when SIWS fails under the open dialog", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = typeof input === "string" ? input : String(input);
+        if (url.includes("/api/auth/nonce")) {
+          return {
+            ok: true,
+            json: async () => ({ nonce: "test-nonce", domain: "localhost" }),
+          } as Response;
+        }
+        return {
+          ok: false,
+          json: async () => ({ error: "serverError" }),
+        } as Response;
+      })
+    );
+
+    renderWithIntl(<ControlledModal onClose={vi.fn()} />);
+
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent(messages.auth.authFailed);
+
+    // Both were rendered before this fix too — and both were inert, because
+    // the dialog was still open and the body still had pointer-events: none.
+    await waitFor(() =>
+      expect(document.body.style.pointerEvents).not.toBe("none")
+    );
+    expect(
+      screen.getByRole("button", { name: messages.auth.retry })
+    ).toBeEnabled();
+    expect(
+      screen.getByRole("button", { name: messages.auth.dismiss })
+    ).toBeEnabled();
+    expect(
+      screen.queryByText(messages.auth.signInTitle)
+    ).not.toBeInTheDocument();
+  });
+
+  it("opts the overlay out of an inherited body lock", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => new Promise<Response>(() => {}))
+    );
+    renderWithIntl(<ControlledModal onClose={vi.fn()} />);
+
+    // jsdom loads no stylesheet, so this can only assert the class, not the
+    // computed value. It covers the dialog's exit-animation window — the
+    // content is still mounted, and the body still locked, for as long as the
+    // close animation runs — and any other modal that is up when SIWS fires.
+    expect(await screen.findByTestId("siws-overlay")).toHaveClass(
+      "pointer-events-auto"
+    );
+  });
+});

--- a/apps/web/src/components/auth/__tests__/auth-modal-siws-takeover.test.tsx
+++ b/apps/web/src/components/auth/__tests__/auth-modal-siws-takeover.test.tsx
@@ -3,7 +3,7 @@
 import type { ReactElement } from "react";
 import { useState } from "react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import { NextIntlClientProvider } from "next-intl";
 import messages from "@/messages/en.json";
 
@@ -25,13 +25,17 @@ import messages from "@/messages/en.json";
  * the same handoff the manual wallet path already does.
  */
 
+const walletState = vi.hoisted(() => ({
+  signMessage: vi.fn(async () => new Uint8Array([1, 2, 3])),
+}));
+
 vi.mock("@solana/wallet-adapter-react", () => ({
   useWallet: () => ({
     connected: true,
     publicKey: {
       toBase58: () => "TestWa11etPubkey1111111111111111111111111111",
     },
-    signMessage: vi.fn(async () => new Uint8Array([1, 2, 3])),
+    signMessage: walletState.signMessage,
     signIn: undefined,
   }),
 }));
@@ -102,10 +106,20 @@ function renderWithIntl(ui: ReactElement) {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  walletState.signMessage.mockImplementation(
+    async () => new Uint8Array([1, 2, 3])
+  );
   vi.spyOn(console, "error").mockImplementation(() => {});
 });
 
 afterEach(() => {
+  // Unmount FIRST, while the wallet mock is still in place. RTL registers its
+  // own cleanup at import time, so LIFO ordering runs this hook before it —
+  // restoring mocks here would tear the mock out from under the unmount, and
+  // WalletAuthHandler's SIWS claim is released in an effect cleanup. A claim
+  // that leaks is module-level state: the next test in this file would see a
+  // spurious siwsActive and the dialog would close for the wrong reason.
+  cleanup();
   vi.restoreAllMocks();
   vi.unstubAllGlobals();
 });
@@ -171,6 +185,38 @@ describe("SIWS firing while the sign-in dialog is open", () => {
     expect(
       screen.queryByText(messages.auth.signInTitle)
     ).not.toBeInTheDocument();
+  });
+
+  it("says so when the learner declines, instead of emptying the screen", async () => {
+    // The compounding case. A returning learner clicks Sign in, their wallet
+    // auto-reconnects and pops a signature prompt they never asked for, and
+    // they refuse it. Dismissing silently was fine while the dialog stayed up
+    // BEHIND the overlay — Google and GitHub were still in front of them. It
+    // closes now, so silence would leave nothing at all.
+    walletState.signMessage.mockRejectedValueOnce(new Error("User rejected"));
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({ nonce: "test-nonce", domain: "localhost" }),
+      }))
+    );
+
+    renderWithIntl(<ControlledModal onClose={vi.fn()} />);
+
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent(messages.auth.signatureDeclined);
+    // Retry is the one that matters: `hasTriedAuth` only resets on DISCONNECT,
+    // so re-opening the modal and re-picking the same connected wallet would
+    // not re-fire SIWS.
+    expect(
+      screen.getByRole("button", { name: messages.auth.retry })
+    ).toBeEnabled();
+    expect(
+      screen.getByRole("button", { name: messages.auth.dismiss })
+    ).toBeEnabled();
+    // Not the wallet-failure copy — they chose this.
+    expect(alert).not.toHaveTextContent(messages.auth.authFailed);
   });
 
   it("opts the overlay out of an inherited body lock", async () => {

--- a/apps/web/src/components/auth/__tests__/auth-modal-stack-failure.test.tsx
+++ b/apps/web/src/components/auth/__tests__/auth-modal-stack-failure.test.tsx
@@ -1,0 +1,92 @@
+// @vitest-environment jsdom
+/* eslint-disable import/order -- vi.mock factories are hoisted above imports. */
+import type { ReactElement } from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { NextIntlClientProvider } from "next-intl";
+import messages from "@/messages/en.json";
+
+/**
+ * The other half of the dead-chunk story (#1109 review): the STACK chunk
+ * fails while the body loads fine. Only the Solana button depended on that
+ * stack, so it is the only thing that may break — and it must say so instead
+ * of spinning forever on a handoff that will never happen.
+ *
+ * This models a marketing route: nothing is registered in the ambient store,
+ * so opening the modal arms the scoped stack.
+ */
+
+const { signInWithOAuth } = vi.hoisted(() => ({
+  signInWithOAuth: vi.fn().mockResolvedValue({ error: null }),
+}));
+
+vi.mock("@/lib/supabase/client", () => ({
+  createClient: () => ({ auth: { signInWithOAuth } }),
+}));
+vi.mock("@/lib/analytics", () => ({ trackEvent: vi.fn() }));
+vi.mock("@/lib/dynamic/config", () => ({
+  isDynamicEnabled: () => false,
+  getDynamicEnvironmentId: () => null,
+}));
+// The scoped stack's chunk 404s. The "[vitest] There was an error when
+// mocking a module" lines this factory prints ARE the simulated failure.
+vi.mock("@/components/auth/scoped-auth-providers", () => {
+  throw new Error("Failed to fetch dynamically imported module");
+});
+
+// Preloads the chunk AuthModal reaches through React.lazy: only the STACK
+// chunk is meant to fail here, and a cold body transform would otherwise race
+// these assertions.
+import "@/components/auth/auth-modal-body";
+import { AuthModal } from "../auth-modal";
+
+function renderWithIntl(ui: ReactElement) {
+  return render(
+    <NextIntlClientProvider locale="en" messages={messages}>
+      {ui}
+    </NextIntlClientProvider>
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("AuthModal when the provider-stack chunk fails to load", () => {
+  it("keeps Google and GitHub working", async () => {
+    renderWithIntl(<AuthModal open onOpenChange={() => {}} />);
+
+    fireEvent.click(
+      await screen.findByRole("button", {
+        name: messages.auth.signInWithGoogle,
+      })
+    );
+    await waitFor(() =>
+      expect(signInWithOAuth).toHaveBeenCalledWith(
+        expect.objectContaining({ provider: "google" })
+      )
+    );
+  });
+
+  it("fails the wallet button loudly instead of hanging on 'Connecting…'", async () => {
+    renderWithIntl(<AuthModal open onOpenChange={() => {}} />);
+
+    fireEvent.click(
+      await screen.findByRole("button", {
+        name: messages.auth.connectSolanaWallet,
+      })
+    );
+
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent(messages.auth.authFailed);
+    // …and the button is usable again rather than stuck in its loading state.
+    expect(
+      screen.getByRole("button", { name: messages.auth.connectSolanaWallet })
+    ).toBeEnabled();
+  });
+});

--- a/apps/web/src/components/auth/__tests__/auth-modal-stack-failure.test.tsx
+++ b/apps/web/src/components/auth/__tests__/auth-modal-stack-failure.test.tsx
@@ -62,9 +62,13 @@ describe("AuthModal when the provider-stack chunk fails to load", () => {
     renderWithIntl(<AuthModal open onOpenChange={() => {}} />);
 
     fireEvent.click(
-      await screen.findByRole("button", {
-        name: messages.auth.signInWithGoogle,
-      })
+      await screen.findByRole(
+        "button",
+        {
+          name: messages.auth.signInWithGoogle,
+        },
+        { timeout: 5000 }
+      )
     );
     await waitFor(() =>
       expect(signInWithOAuth).toHaveBeenCalledWith(
@@ -77,12 +81,18 @@ describe("AuthModal when the provider-stack chunk fails to load", () => {
     renderWithIntl(<AuthModal open onOpenChange={() => {}} />);
 
     fireEvent.click(
-      await screen.findByRole("button", {
-        name: messages.auth.connectSolanaWallet,
-      })
+      await screen.findByRole(
+        "button",
+        {
+          name: messages.auth.connectSolanaWallet,
+        },
+        { timeout: 5000 }
+      )
     );
 
-    const alert = await screen.findByRole("alert");
+    const alert = await screen.findByRole("alert", undefined, {
+      timeout: 5000,
+    });
     expect(alert).toHaveTextContent(messages.auth.authFailed);
     // …and the button is usable again rather than stuck in its loading state.
     expect(

--- a/apps/web/src/components/auth/__tests__/auth-modal-wallet-handoff.test.tsx
+++ b/apps/web/src/components/auth/__tests__/auth-modal-wallet-handoff.test.tsx
@@ -5,7 +5,10 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, fireEvent, act } from "@testing-library/react";
 import { NextIntlClientProvider } from "next-intl";
 import messages from "@/messages/en.json";
-import { publishAmbientWallet } from "@/lib/solana/ambient-wallet-store";
+import {
+  publishAmbientWallet,
+  setSiwsActive,
+} from "@/lib/solana/ambient-wallet-store";
 // Preloads the chunk AuthModal reaches through React.lazy — see auth-modal.test.tsx.
 import "@/components/auth/auth-modal-body";
 import { AuthModal } from "../auth-modal";
@@ -35,7 +38,17 @@ vi.mock("@/lib/dynamic/config", () => ({
 /** Controlled the way real callers drive it, so `setOpen(false)` lands. */
 function ControlledModal() {
   const [open, setOpen] = useState(true);
-  return <AuthModal open={open} onOpenChange={setOpen} />;
+  return (
+    <>
+      {/* Stands in for a controlled parent driving the dialog out from under
+          the handoff — a route change, or the enroll flow giving up. Reached
+          by testid, since Radix aria-hides everything outside an open modal. */}
+      <button data-testid="outside-toggle" onClick={() => setOpen((v) => !v)}>
+        toggle from outside
+      </button>
+      <AuthModal open={open} onOpenChange={setOpen} />
+    </>
+  );
 }
 
 function renderWithIntl(ui: ReactElement) {
@@ -50,6 +63,9 @@ const CONNECT_WALLET = messages.auth.connectSolanaWallet;
 
 let openWalletModal: ReturnType<typeof vi.fn<() => void>>;
 let unregister: (() => void) | null = null;
+// Released in cleanup, never inline: the flag is module-level state, so a
+// test that fails before its own release would leak it into every test after.
+let releaseSiws: (() => void) | null = null;
 
 function liveStack() {
   openWalletModal = vi.fn();
@@ -93,6 +109,8 @@ beforeEach(() => {
 afterEach(() => {
   unregister?.();
   unregister = null;
+  releaseSiws?.();
+  releaseSiws = null;
   vi.useRealTimers();
 });
 
@@ -149,6 +167,50 @@ describe("AuthModal wallet handoff", () => {
       messages.auth.authFailed
     );
     expect(screen.getByText(messages.auth.signInTitle)).toBeInTheDocument();
+  });
+
+  it("stands down when SIWS takes the screen mid-handoff", async () => {
+    // autoConnect can reconnect a remembered wallet while this handoff is
+    // still on its timers. The picker would then open ON TOP of the SIWS
+    // overlay and bury its Retry and Dismiss — the exact bug this PR exists
+    // to fix, re-created through a different modal.
+    const button = await openAndFindWalletButton();
+
+    vi.useFakeTimers();
+    fireEvent.click(button);
+    await advance(150);
+    releaseSiws = setSiwsActive({});
+    await advance(1000);
+
+    expect(openWalletModal).not.toHaveBeenCalled();
+    // The dialog still gets out of the way — that part is by design.
+    expect(
+      screen.queryByText(messages.auth.signInTitle)
+    ).not.toBeInTheDocument();
+  });
+
+  it("leaves no error behind when the dialog closes mid-handoff", async () => {
+    const button = await openAndFindWalletButton();
+
+    vi.useFakeTimers();
+    fireEvent.click(button);
+    // Closed behind the handoff's back, and the stack goes with it.
+    fireEvent.click(screen.getByTestId("outside-toggle"));
+    unregister?.();
+    unregister = null;
+    await advance(1000);
+    await flush();
+
+    expect(openWalletModal).not.toHaveBeenCalled();
+
+    // Re-opening must not greet the learner with an error written while they
+    // were not looking.
+    fireEvent.click(screen.getByTestId("outside-toggle"));
+    vi.useRealTimers();
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
   });
 
   it("never pops the picker open after AuthModal unmounts", async () => {

--- a/apps/web/src/components/auth/__tests__/auth-modal-wallet-handoff.test.tsx
+++ b/apps/web/src/components/auth/__tests__/auth-modal-wallet-handoff.test.tsx
@@ -1,0 +1,167 @@
+// @vitest-environment jsdom
+import type { ReactElement } from "react";
+import { useState } from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import { NextIntlClientProvider } from "next-intl";
+import messages from "@/messages/en.json";
+import { publishAmbientWallet } from "@/lib/solana/ambient-wallet-store";
+// Preloads the chunk AuthModal reaches through React.lazy — see auth-modal.test.tsx.
+import "@/components/auth/auth-modal-body";
+import { AuthModal } from "../auth-modal";
+
+/**
+ * The Solana button's handoff: a brief loading state, then close the dialog
+ * and open the wallet-select modal of whichever stack is live (#1109 review).
+ *
+ * It runs on two timers, and both were unguarded. If the stack unregistered
+ * inside the 600 ms window the picker never opened and the learner got no
+ * error at all — they clicked Connect, saw a spinner, and the modal vanished.
+ * If AuthModal unmounted inside it, the picker popped open unbidden on
+ * whatever route they had moved to.
+ */
+
+vi.mock("@/lib/supabase/client", () => ({
+  createClient: vi.fn(() => ({
+    auth: { signInWithOAuth: vi.fn().mockResolvedValue({ error: null }) },
+  })),
+}));
+vi.mock("@/lib/analytics", () => ({ trackEvent: vi.fn() }));
+vi.mock("@/lib/dynamic/config", () => ({
+  isDynamicEnabled: () => false,
+  getDynamicEnvironmentId: () => null,
+}));
+
+/** Controlled the way real callers drive it, so `setOpen(false)` lands. */
+function ControlledModal() {
+  const [open, setOpen] = useState(true);
+  return <AuthModal open={open} onOpenChange={setOpen} />;
+}
+
+function renderWithIntl(ui: ReactElement) {
+  return render(
+    <NextIntlClientProvider locale="en" messages={messages}>
+      {ui}
+    </NextIntlClientProvider>
+  );
+}
+
+const CONNECT_WALLET = messages.auth.connectSolanaWallet;
+
+let openWalletModal: ReturnType<typeof vi.fn<() => void>>;
+let unregister: (() => void) | null = null;
+
+function liveStack() {
+  openWalletModal = vi.fn();
+  unregister = publishAmbientWallet({
+    connected: false,
+    publicKey: null,
+    disconnect: async () => {},
+    openWalletModal,
+  });
+}
+
+/** Runs the timers React's effects are waiting on, inside act(). */
+async function advance(ms: number) {
+  await act(async () => {
+    vi.advanceTimersByTime(ms);
+  });
+}
+
+/**
+ * Lets pending microtasks (React.lazy, state flushes) settle. `findBy*` is not
+ * an option here: its waitFor polls on real timers, which fake timers freeze.
+ */
+async function flush() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+/** Opens the dialog, waits for the lazy body, and returns the Solana button. */
+async function openAndFindWalletButton() {
+  renderWithIntl(<ControlledModal />);
+  return screen.findByRole("button", { name: CONNECT_WALLET });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  liveStack();
+});
+
+afterEach(() => {
+  unregister?.();
+  unregister = null;
+  vi.useRealTimers();
+});
+
+describe("AuthModal wallet handoff", () => {
+  it("closes and opens the wallet picker on the happy path", async () => {
+    const button = await openAndFindWalletButton();
+
+    vi.useFakeTimers();
+    fireEvent.click(button);
+    await advance(400);
+    expect(
+      screen.queryByText(messages.auth.signInTitle)
+    ).not.toBeInTheDocument();
+
+    // The picker opens AFTER the close, so its timer has to outlive the body,
+    // which unmounts with the dialog.
+    expect(openWalletModal).not.toHaveBeenCalled();
+    await advance(200);
+    expect(openWalletModal).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports a stack that vanished before the close, and keeps the dialog open", async () => {
+    const button = await openAndFindWalletButton();
+
+    vi.useFakeTimers();
+    fireEvent.click(button);
+    unregister?.();
+    unregister = null;
+    await advance(400);
+    await flush();
+
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      messages.auth.authFailed
+    );
+    expect(screen.getByText(messages.auth.signInTitle)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: CONNECT_WALLET })).toBeEnabled();
+    await advance(400);
+    expect(openWalletModal).not.toHaveBeenCalled();
+  });
+
+  it("re-opens with the failure when the stack vanishes inside the close window", async () => {
+    const button = await openAndFindWalletButton();
+
+    vi.useFakeTimers();
+    fireEvent.click(button);
+    await advance(400);
+    unregister?.();
+    unregister = null;
+    await advance(200);
+    await flush();
+
+    expect(openWalletModal).not.toHaveBeenCalled();
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      messages.auth.authFailed
+    );
+    expect(screen.getByText(messages.auth.signInTitle)).toBeInTheDocument();
+  });
+
+  it("never pops the picker open after AuthModal unmounts", async () => {
+    const { unmount } = renderWithIntl(<ControlledModal />);
+    const button = await screen.findByRole("button", { name: CONNECT_WALLET });
+
+    vi.useFakeTimers();
+    fireEvent.click(button);
+    await advance(400);
+    // The learner navigates away with the handoff in flight.
+    unmount();
+    await advance(1000);
+
+    expect(openWalletModal).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/auth/__tests__/auth-modal.test.tsx
+++ b/apps/web/src/components/auth/__tests__/auth-modal.test.tsx
@@ -5,6 +5,13 @@ import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { NextIntlClientProvider } from "next-intl";
 import messages from "@/messages/en.json";
 import { publishAmbientWallet } from "@/lib/solana/ambient-wallet-store";
+// Preloads the chunk AuthModal reaches through React.lazy. Without it every
+// assertion on the dialog body races a cold transform of the module's graph
+// (the Dynamic SDK), which under full-suite load blew past even a 10s
+// findBy timeout — two of four runs, #1109 review. Importing the same
+// specifier here puts it in the registry at collect time, so the lazy import
+// resolves in a microtask and the default timeouts hold.
+import "@/components/auth/auth-modal-body";
 import { AuthModal } from "../auth-modal";
 
 const dynamicState = vi.hoisted(() => ({
@@ -83,76 +90,58 @@ afterEach(() => {
 });
 
 describe("AuthModal — one error placement (#1077)", () => {
-  it(
-    "renders a Dynamic button failure at modal level, not inline under the button",
-    { timeout: 15_000 },
-    async () => {
-      dynamicState.enabled = true;
-      dynamicState.redirectMock.mockRejectedValueOnce(new Error("no settings"));
-      vi.spyOn(console, "error").mockImplementation(() => {});
+  it("renders a Dynamic button failure at modal level, not inline under the button", async () => {
+    dynamicState.enabled = true;
+    dynamicState.redirectMock.mockRejectedValueOnce(new Error("no settings"));
+    vi.spyOn(console, "error").mockImplementation(() => {});
 
-      renderWithIntl(<AuthModal open onOpenChange={() => {}} />);
-      // findBy with a generous timeout: the dialog body is a lazy chunk since
-      // #1097, and its first import in a suite is slow.
-      fireEvent.click(
-        await screen.findByRole(
-          "button",
-          { name: messages.auth.signInWithGoogle },
-          { timeout: 10_000 }
-        )
-      );
+    renderWithIntl(<AuthModal open onOpenChange={() => {}} />);
+    // findBy, not getBy: the body is still a React.lazy boundary, so it
+    // lands one microtask after the dialog chrome.
+    fireEvent.click(
+      await screen.findByRole("button", {
+        name: messages.auth.signInWithGoogle,
+      })
+    );
 
-      const alert = await screen.findByRole("alert");
-      expect(alert).toHaveTextContent(messages.auth.googleSignInFailed);
-      // Modal-level style (text-sm), the same channel Supabase fallbacks use.
-      expect(alert.className).toContain("text-sm");
-      expect(screen.getAllByRole("alert")).toHaveLength(1);
-    }
-  );
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent(messages.auth.googleSignInFailed);
+    // Modal-level style (text-sm), the same channel Supabase fallbacks use.
+    expect(alert.className).toContain("text-sm");
+    expect(screen.getAllByRole("alert")).toHaveLength(1);
+  });
 
-  it(
-    "clears the modal-level error when a new Dynamic attempt starts",
-    { timeout: 15_000 },
-    async () => {
-      dynamicState.enabled = true;
-      dynamicState.redirectMock.mockRejectedValueOnce(new Error("no settings"));
-      vi.spyOn(console, "error").mockImplementation(() => {});
+  it("clears the modal-level error when a new Dynamic attempt starts", async () => {
+    dynamicState.enabled = true;
+    dynamicState.redirectMock.mockRejectedValueOnce(new Error("no settings"));
+    vi.spyOn(console, "error").mockImplementation(() => {});
 
-      renderWithIntl(<AuthModal open onOpenChange={() => {}} />);
-      const googleButton = await screen.findByRole(
-        "button",
-        { name: messages.auth.signInWithGoogle },
-        { timeout: 10_000 }
-      );
-      fireEvent.click(googleButton);
-      await screen.findByRole("alert");
+    renderWithIntl(<AuthModal open onOpenChange={() => {}} />);
+    const googleButton = await screen.findByRole("button", {
+      name: messages.auth.signInWithGoogle,
+    });
+    fireEvent.click(googleButton);
+    await screen.findByRole("alert");
 
-      // Next attempt resolves (never navigates in jsdom) — the stale error goes.
-      fireEvent.click(googleButton);
-      await waitFor(() =>
-        expect(screen.queryByRole("alert")).not.toBeInTheDocument()
-      );
-    }
-  );
+    // Next attempt resolves (never navigates in jsdom) — the stale error goes.
+    fireEvent.click(googleButton);
+    await waitFor(() =>
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument()
+    );
+  });
 });
 
 describe("AuthModal — controlled mode (#556)", () => {
-  it(
-    "opens programmatically via the open prop, without rendering a trigger button",
-    { timeout: 15_000 },
-    async () => {
-      renderWithIntl(<AuthModal open onOpenChange={() => {}} />);
+  it("opens programmatically via the open prop, without rendering a trigger button", async () => {
+    renderWithIntl(<AuthModal open onOpenChange={() => {}} />);
 
-      // findBy with a generous timeout: the dialog body is a lazy chunk since
-      // #1097, and its first import in a suite loads the Dynamic SDK.
-      expect(
-        await screen.findByText(TITLE, {}, { timeout: 10_000 })
-      ).toBeInTheDocument();
-      expect(
-        screen.queryByRole("button", { name: DEFAULT_TRIGGER })
-      ).not.toBeInTheDocument();
-    }
-  );
+    // findBy, not getBy: the body is still a React.lazy boundary, so it
+    // lands one microtask after the dialog chrome.
+    expect(await screen.findByText(TITLE, {})).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: DEFAULT_TRIGGER })
+    ).not.toBeInTheDocument();
+  });
 
   it("renders nothing while closed in controlled mode (no stray sign-in button)", () => {
     renderWithIntl(<AuthModal open={false} onOpenChange={() => {}} />);
@@ -163,7 +152,7 @@ describe("AuthModal — controlled mode (#556)", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("reports close through onOpenChange", { timeout: 15_000 }, async () => {
+  it("reports close through onOpenChange", async () => {
     const onOpenChange = vi.fn();
     renderWithIntl(<AuthModal open onOpenChange={onOpenChange} />);
 
@@ -187,45 +176,33 @@ describe("AuthModal — controlled mode (#556)", () => {
 });
 
 describe("AuthModal — uncontrolled mode (unchanged)", () => {
-  it(
-    "renders the default trigger and opens on click",
-    { timeout: 15_000 },
-    async () => {
-      renderWithIntl(<AuthModal />);
+  it("renders the default trigger and opens on click", async () => {
+    renderWithIntl(<AuthModal />);
 
-      const trigger = screen.getByRole("button", { name: DEFAULT_TRIGGER });
-      expect(screen.queryByText(TITLE)).not.toBeInTheDocument();
+    const trigger = screen.getByRole("button", { name: DEFAULT_TRIGGER });
+    expect(screen.queryByText(TITLE)).not.toBeInTheDocument();
 
-      fireEvent.click(trigger);
-      expect(await screen.findByText(TITLE)).toBeInTheDocument();
-    }
-  );
+    fireEvent.click(trigger);
+    expect(await screen.findByText(TITLE)).toBeInTheDocument();
+  });
 });
 
 describe("AuthModal — Later affordance (LX-A4b)", () => {
-  it(
-    "shows the keep-progress framing, a Later button, and reassurance copy",
-    { timeout: 15_000 },
-    async () => {
-      renderWithIntl(<AuthModal open onOpenChange={() => {}} showLater />);
+  it("shows the keep-progress framing, a Later button, and reassurance copy", async () => {
+    renderWithIntl(<AuthModal open onOpenChange={() => {}} showLater />);
 
-      expect(
-        await screen.findByText(messages.auth.keepProgressTitle)
-      ).toBeInTheDocument();
-      // The Later button and reassurance copy live in the LAZY body (the title is
-      // Dialog-header chrome, outside it) — findBy, or CI load flakes this.
-      expect(
-        await screen.findByRole(
-          "button",
-          { name: messages.auth.later },
-          { timeout: 10_000 }
-        )
-      ).toBeInTheDocument();
-      expect(
-        screen.getByText(messages.auth.progressSavedLocally)
-      ).toBeInTheDocument();
-    }
-  );
+    expect(
+      await screen.findByText(messages.auth.keepProgressTitle)
+    ).toBeInTheDocument();
+    // The Later button and reassurance copy live in the LAZY body (the title is
+    // Dialog-header chrome, outside it) — hence findBy.
+    expect(
+      await screen.findByRole("button", { name: messages.auth.later })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(messages.auth.progressSavedLocally)
+    ).toBeInTheDocument();
+  });
 
   it("never uses discard/lose/delete language (F4) — progress is framed as kept", () => {
     const claimCopy = [
@@ -243,30 +220,21 @@ describe("AuthModal — Later affordance (LX-A4b)", () => {
     expect(claimCopy).toContain("saved");
   });
 
-  it(
-    "closes and calls onLater when Later is tapped",
-    { timeout: 15_000 },
-    async () => {
-      const onOpenChange = vi.fn();
-      const onLater = vi.fn();
-      renderWithIntl(
-        <AuthModal
-          open
-          onOpenChange={onOpenChange}
-          showLater
-          onLater={onLater}
-        />
-      );
+  it("closes and calls onLater when Later is tapped", async () => {
+    const onOpenChange = vi.fn();
+    const onLater = vi.fn();
+    renderWithIntl(
+      <AuthModal open onOpenChange={onOpenChange} showLater onLater={onLater} />
+    );
 
-      fireEvent.click(
-        await screen.findByRole("button", { name: messages.auth.later })
-      );
-      expect(onOpenChange).toHaveBeenCalledWith(false);
-      expect(onLater).toHaveBeenCalledTimes(1);
-    }
-  );
+    fireEvent.click(
+      await screen.findByRole("button", { name: messages.auth.later })
+    );
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(onLater).toHaveBeenCalledTimes(1);
+  });
 
-  it("omits the Later affordance by default", { timeout: 15_000 }, async () => {
+  it("omits the Later affordance by default", async () => {
     renderWithIntl(<AuthModal open onOpenChange={() => {}} />);
 
     // Wait for the lazy body before asserting the button's absence.

--- a/apps/web/src/components/auth/__tests__/wallet-auth-overlay-portal.test.tsx
+++ b/apps/web/src/components/auth/__tests__/wallet-auth-overlay-portal.test.tsx
@@ -1,0 +1,121 @@
+// @vitest-environment jsdom
+/* eslint-disable import/order -- vi.mock factories are hoisted above imports. */
+import type { ReactElement } from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { NextIntlClientProvider } from "next-intl";
+import messages from "@/messages/en.json";
+
+/**
+ * The SIWS overlay must escape the Header (#1109 follow-up).
+ *
+ * Since #1097 the provider stack — and with it WalletAuthHandler — mounts
+ * under the Header on marketing routes, inside a bar carrying
+ * `backdrop-blur-md`. A non-`none` backdrop-filter is a containing block for
+ * `position: fixed` descendants, so an in-tree `fixed inset-0` overlay is
+ * clipped to the 57px nav strip: the spinner renders as a band across the nav
+ * and the error branch squeezes the failure message plus Retry/Dismiss into
+ * it, while the page behind stays interactive.
+ *
+ * jsdom does no layout, so this asserts the STRUCTURE that fix depends on:
+ * the overlay is a child of document.body, not of whatever tree the handler
+ * was mounted in. Rendering it in-tree fails both assertions.
+ */
+
+const walletState = vi.hoisted(() => ({
+  signMessage: vi.fn(async () => new Uint8Array([1, 2, 3])),
+}));
+
+vi.mock("@solana/wallet-adapter-react", () => ({
+  useWallet: () => ({
+    connected: true,
+    publicKey: {
+      toBase58: () => "TestWa11etPubkey1111111111111111111111111111",
+    },
+    signMessage: walletState.signMessage,
+    signIn: undefined,
+  }),
+}));
+
+vi.mock("@/lib/supabase/client", () => ({
+  createClient: () => ({
+    auth: { getUser: async () => ({ data: { user: null } }) },
+  }),
+}));
+
+import { WalletAuthHandler } from "../wallet-auth-handler";
+
+const HOST = "clipping-host";
+
+function renderUnderHeaderLikeHost(ui: ReactElement) {
+  return render(
+    <NextIntlClientProvider locale="en" messages={messages}>
+      {/* Stands in for header.tsx's `relative bg-transparent backdrop-blur-md`
+          wrapper: the element that becomes the containing block. */}
+      <div data-testid={HOST} className="relative backdrop-blur-md">
+        {ui}
+      </div>
+    </NextIntlClientProvider>
+  );
+}
+
+function expectPortalled(overlay: HTMLElement): void {
+  expect(screen.getByTestId(HOST)).not.toContainElement(overlay);
+  expect(overlay.parentElement).toBe(document.body);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("WalletAuthHandler overlay placement", () => {
+  it("portals the signing-in overlay out of its mount tree", async () => {
+    // The nonce request never settles, so the overlay stays on "authenticating".
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => new Promise<Response>(() => {}))
+    );
+
+    renderUnderHeaderLikeHost(<WalletAuthHandler />);
+
+    const overlay = await screen.findByTestId("siws-overlay");
+    expect(overlay).toHaveTextContent(messages.auth.signingIn);
+    expectPortalled(overlay);
+  });
+
+  it("portals the error overlay, so the failure message and Retry are not trapped in the nav", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = typeof input === "string" ? input : String(input);
+        if (url.includes("/api/auth/nonce")) {
+          return {
+            ok: true,
+            json: async () => ({ nonce: "test-nonce", domain: "localhost" }),
+          } as Response;
+        }
+        return {
+          ok: false,
+          json: async () => ({ error: "serverError" }),
+        } as Response;
+      })
+    );
+
+    renderUnderHeaderLikeHost(<WalletAuthHandler />);
+
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent(messages.auth.authFailed);
+    expect(
+      screen.getByRole("button", { name: messages.auth.retry })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: messages.auth.dismiss })
+    ).toBeInTheDocument();
+    expectPortalled(screen.getByTestId("siws-overlay"));
+  });
+});

--- a/apps/web/src/components/auth/auth-modal-body.tsx
+++ b/apps/web/src/components/auth/auth-modal-body.tsx
@@ -1,15 +1,12 @@
 "use client";
 
-import { useCallback, useEffect, useRef } from "react";
+import { useEffect, useRef } from "react";
 import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
 import { SolanaLogo } from "@/components/icons/solana-logo";
 import { trackEvent } from "@/lib/analytics";
 import { isDynamicEnabled } from "@/lib/dynamic/config";
-import {
-  getAmbientWallet,
-  useAmbientWalletLive,
-} from "@/lib/solana/ambient-wallet-store";
+import { useAmbientWalletLive } from "@/lib/solana/ambient-wallet-store";
 import { DynamicSocialSignIn } from "@/components/auth/dynamic-social-sign-in";
 import { OAuthFallbackButton } from "@/components/auth/oauth-fallback-button";
 import type { AuthLoadingMethod } from "@/components/auth/auth-modal-types";
@@ -26,6 +23,12 @@ export interface AuthModalBodyProps {
   walletStackFailed: boolean;
   /** Re-arms that chunk. The Solana button is its own retry affordance. */
   retryWalletStack: () => void;
+  /**
+   * Runs the timed close-then-open-the-wallet-picker sequence. Owned by the
+   * shell, not here: closing the dialog unmounts this body, so timers started
+   * here would be cleared exactly when the picker is due to open.
+   */
+  startWalletHandoff: () => void;
 }
 
 /**
@@ -54,6 +57,7 @@ export default function AuthModalBody({
   onLater,
   walletStackFailed,
   retryWalletStack,
+  startWalletHandoff,
 }: AuthModalBodyProps) {
   const t = useTranslations("auth");
   const dynamicEnabled = isDynamicEnabled();
@@ -62,22 +66,11 @@ export default function AuthModalBody({
   // effect below finishes the handoff as soon as one does.
   const awaitingStack = useRef(false);
 
-  const handOffToWalletModal = useCallback(() => {
-    // Brief loading state, then hand off to the wallet-select modal of
-    // whichever provider stack is live — read at call time from the store,
-    // since this body renders outside the stack's React tree.
-    setTimeout(() => {
-      setOpen(false);
-      setLoading(null);
-      setTimeout(() => getAmbientWallet()?.openWalletModal(), 200);
-    }, 400);
-  }, [setOpen, setLoading]);
-
   useEffect(() => {
     if (!awaitingStack.current) return;
     if (walletStackLive) {
       awaitingStack.current = false;
-      handOffToWalletModal();
+      startWalletHandoff();
     } else if (walletStackFailed) {
       // No stack is coming. Say so instead of spinning forever — the other
       // two methods on this screen still work.
@@ -88,7 +81,7 @@ export default function AuthModalBody({
   }, [
     walletStackLive,
     walletStackFailed,
-    handOffToWalletModal,
+    startWalletHandoff,
     setLoading,
     setErrorMessage,
     t,
@@ -99,7 +92,7 @@ export default function AuthModalBody({
     setErrorMessage(null);
     trackEvent("auth_method_selected", { method: "solana" });
     if (walletStackLive) {
-      handOffToWalletModal();
+      startWalletHandoff();
       return;
     }
     // No stack yet — wait for one. If a previous attempt's chunk died, this

--- a/apps/web/src/components/auth/auth-modal-body.tsx
+++ b/apps/web/src/components/auth/auth-modal-body.tsx
@@ -1,18 +1,20 @@
 "use client";
 
+import { useCallback, useEffect, useRef } from "react";
 import { useTranslations } from "next-intl";
-import { GithubLogo } from "@phosphor-icons/react";
 import { Button } from "@/components/ui/button";
-import { GoogleLogo } from "@/components/icons/google-logo";
 import { SolanaLogo } from "@/components/icons/solana-logo";
-import { createClient } from "@/lib/supabase/client";
-import { buildOAuthRedirect } from "@/lib/auth/oauth-redirect";
 import { trackEvent } from "@/lib/analytics";
 import { isDynamicEnabled } from "@/lib/dynamic/config";
-import { getAmbientWallet } from "@/lib/solana/ambient-wallet-store";
+import {
+  getAmbientWallet,
+  useAmbientWalletLive,
+} from "@/lib/solana/ambient-wallet-store";
 import { DynamicSocialSignIn } from "@/components/auth/dynamic-social-sign-in";
+import { OAuthFallbackButton } from "@/components/auth/oauth-fallback-button";
+import type { AuthLoadingMethod } from "@/components/auth/auth-modal-types";
 
-export type AuthLoadingMethod = "solana" | "google" | "github" | null;
+export type { AuthLoadingMethod };
 
 export interface AuthModalBodyProps {
   loading: AuthLoadingMethod;
@@ -22,6 +24,10 @@ export interface AuthModalBodyProps {
   setOpen: (v: boolean) => void;
   showLater: boolean;
   onLater?: () => void;
+  /** The scoped provider stack's chunk failed to load. */
+  walletStackFailed: boolean;
+  /** Re-arms that chunk. The Solana button is its own retry affordance. */
+  retryWalletStack: () => void;
 }
 
 /**
@@ -34,7 +40,11 @@ export interface AuthModalBodyProps {
  * Needs no provider above it in the React tree: the wallet-select modal is
  * reached through the ambient store (the live stack registers
  * `openWalletModal`), and the Dynamic buttons call the SDK imperatively.
- * AuthModal only renders this once a stack is registered.
+ *
+ * Only the Solana button depends on that stack, so only it waits for one
+ * (#1109 review): gating the whole body on a live registration made Google
+ * and GitHub — which need nothing but Supabase — hostage to a ~300 kB
+ * download, and serialised the two chunks besides.
  */
 export default function AuthModalBody({
   loading,
@@ -44,21 +54,17 @@ export default function AuthModalBody({
   setOpen,
   showLater,
   onLater,
+  walletStackFailed,
+  retryWalletStack,
 }: AuthModalBodyProps) {
   const t = useTranslations("auth");
   const dynamicEnabled = isDynamicEnabled();
+  const walletStackLive = useAmbientWalletLive();
+  // Set when the learner picks Solana before a stack has registered; the
+  // effect below finishes the handoff as soon as one does.
+  const awaitingStack = useRef(false);
 
-  // Return the learner to the page they signed in from (#619 review): the OAuth
-  // callback otherwise always lands on /dashboard, stranding someone mid-lesson
-  // — and, post-LX-A4, away from the replay that finishes their banked work. The
-  // path-shape guard lives in buildOAuthRedirect (unit-tested); the callback
-  // re-sanitizes server-side too.
-  const oauthRedirectTo = () =>
-    buildOAuthRedirect(window.location.origin, window.location.pathname);
-
-  const handleConnectSolana = () => {
-    setLoading("solana");
-    trackEvent("auth_method_selected", { method: "solana" });
+  const handOffToWalletModal = useCallback(() => {
     // Brief loading state, then hand off to the wallet-select modal of
     // whichever provider stack is live — read at call time from the store,
     // since this body renders outside the stack's React tree.
@@ -67,58 +73,43 @@ export default function AuthModalBody({
       setLoading(null);
       setTimeout(() => getAmbientWallet()?.openWalletModal(), 200);
     }, 400);
-  };
+  }, [setOpen, setLoading]);
 
-  const handleConnectGitHub = async () => {
-    setLoading("github");
-    setErrorMessage(null);
-    trackEvent("auth_method_selected", { method: "github" });
-    try {
-      const supabase = createClient();
-      const { error } = await supabase.auth.signInWithOAuth({
-        provider: "github",
-        options: {
-          redirectTo: oauthRedirectTo(),
-        },
-      });
-      if (error) {
-        console.error("[AuthModal] GitHub sign-in error:", error.message);
-        setErrorMessage(t("githubSignInFailed"));
-        setLoading(null);
-      }
-    } catch (err: unknown) {
-      const message =
-        err instanceof Error ? err.message : t("githubSignInFailed");
-      console.error("[AuthModal] GitHub sign-in error:", message);
-      setErrorMessage(t("githubSignInFailed"));
+  useEffect(() => {
+    if (!awaitingStack.current) return;
+    if (walletStackLive) {
+      awaitingStack.current = false;
+      handOffToWalletModal();
+    } else if (walletStackFailed) {
+      // No stack is coming. Say so instead of spinning forever — the other
+      // two methods on this screen still work.
+      awaitingStack.current = false;
       setLoading(null);
+      setErrorMessage(t("authFailed"));
     }
-  };
+  }, [
+    walletStackLive,
+    walletStackFailed,
+    handOffToWalletModal,
+    setLoading,
+    setErrorMessage,
+    t,
+  ]);
 
-  const handleConnectGoogle = async () => {
-    setLoading("google");
+  const handleConnectSolana = () => {
+    setLoading("solana");
     setErrorMessage(null);
-    trackEvent("auth_method_selected", { method: "google" });
-    try {
-      const supabase = createClient();
-      const { error } = await supabase.auth.signInWithOAuth({
-        provider: "google",
-        options: {
-          redirectTo: oauthRedirectTo(),
-        },
-      });
-      if (error) {
-        console.error("[AuthModal] Google sign-in error:", error.message);
-        setErrorMessage(t("googleSignInFailed"));
-        setLoading(null);
-      }
-    } catch (err: unknown) {
-      const message =
-        err instanceof Error ? err.message : t("googleSignInFailed");
-      console.error("[AuthModal] Google sign-in error:", message);
-      setErrorMessage(t("googleSignInFailed"));
-      setLoading(null);
+    trackEvent("auth_method_selected", { method: "solana" });
+    if (walletStackLive) {
+      handOffToWalletModal();
+      return;
     }
+    // No stack yet — wait for one. If a previous attempt's chunk died, this
+    // click re-arms it too, so the button doubles as its own retry: either a
+    // stack registers and the handoff runs, or the effect above reports the
+    // failure and clears the loading state.
+    awaitingStack.current = true;
+    if (walletStackFailed) retryWalletStack();
   };
 
   return (
@@ -146,56 +137,27 @@ export default function AuthModalBody({
         </div>
       </div>
 
-      {/* Google goes through Dynamic when it is configured, so the learner
-          also walks away with an embedded wallet; the Supabase OAuth
-          button below is the fallback AND the kill switch — unsetting the
-          environment id restores it untouched. */}
-      {dynamicEnabled ? (
-        <DynamicSocialSignIn
-          provider="google"
-          disabled={loading !== null}
-          onError={setErrorMessage}
-        />
-      ) : (
-        <Button
-          variant="outline"
-          className="h-12 w-full gap-3 text-sm font-medium"
-          onClick={handleConnectGoogle}
-          disabled={loading !== null}
-        >
-          {loading === "google" ? (
-            <div className="h-5 w-5 animate-spin rounded-full border-2 border-current border-t-transparent" />
-          ) : (
-            <GoogleLogo className="h-5 w-5 shrink-0" />
-          )}
-          {loading === "google" ? t("connecting") : t("signInWithGoogle")}
-        </Button>
-      )}
-
-      {/* GitHub goes through Dynamic when it is configured, so the learner
-          also walks away with an embedded wallet; the Supabase OAuth
-          button below is the fallback AND the kill switch — unsetting the
-          environment id restores it untouched. */}
-      {dynamicEnabled ? (
-        <DynamicSocialSignIn
-          provider="github"
-          disabled={loading !== null}
-          onError={setErrorMessage}
-        />
-      ) : (
-        <Button
-          variant="outline"
-          className="h-12 w-full gap-3 text-sm font-medium"
-          onClick={handleConnectGitHub}
-          disabled={loading !== null}
-        >
-          {loading === "github" ? (
-            <div className="h-5 w-5 animate-spin rounded-full border-2 border-current border-t-transparent" />
-          ) : (
-            <GithubLogo className="h-5 w-5 shrink-0" weight="fill" />
-          )}
-          {loading === "github" ? t("connecting") : t("signInWithGitHub")}
-        </Button>
+      {/* Google and GitHub go through Dynamic when it is configured, so the
+          learner also walks away with an embedded wallet; the Supabase OAuth
+          buttons are the fallback AND the kill switch — unsetting the
+          environment id restores them untouched. */}
+      {(["google", "github"] as const).map((provider) =>
+        dynamicEnabled ? (
+          <DynamicSocialSignIn
+            key={provider}
+            provider={provider}
+            disabled={loading !== null}
+            onError={setErrorMessage}
+          />
+        ) : (
+          <OAuthFallbackButton
+            key={provider}
+            provider={provider}
+            loading={loading}
+            setLoading={setLoading}
+            setErrorMessage={setErrorMessage}
+          />
+        )
       )}
 
       {errorMessage && (

--- a/apps/web/src/components/auth/auth-modal-body.tsx
+++ b/apps/web/src/components/auth/auth-modal-body.tsx
@@ -14,8 +14,6 @@ import { DynamicSocialSignIn } from "@/components/auth/dynamic-social-sign-in";
 import { OAuthFallbackButton } from "@/components/auth/oauth-fallback-button";
 import type { AuthLoadingMethod } from "@/components/auth/auth-modal-types";
 
-export type { AuthLoadingMethod };
-
 export interface AuthModalBodyProps {
   loading: AuthLoadingMethod;
   setLoading: (v: AuthLoadingMethod) => void;

--- a/apps/web/src/components/auth/auth-modal-types.ts
+++ b/apps/web/src/components/auth/auth-modal-types.ts
@@ -1,0 +1,10 @@
+/**
+ * Types shared by the auth modal and the two button modules it composes.
+ * Their own home would be `auth-modal.tsx`, but the body imports them and
+ * `auth-modal.tsx` imports the body — a plain type module breaks the cycle
+ * and stays free of any runtime import.
+ */
+export type AuthLoadingMethod = "solana" | "google" | "github" | null;
+
+/** The two providers offered through both the Dynamic and Supabase rails. */
+export type SocialProvider = "google" | "github";

--- a/apps/web/src/components/auth/auth-modal.tsx
+++ b/apps/web/src/components/auth/auth-modal.tsx
@@ -28,11 +28,10 @@ import {
   useWalletReturnCaptureActive,
 } from "@/lib/solana/ambient-wallet-store";
 import { ChunkErrorBoundary } from "@/components/auth/chunk-error-boundary";
+import { OAuthFallbackButton } from "@/components/auth/oauth-fallback-button";
 import { useSocialReturnPending } from "@/hooks/use-social-return-pending";
-import type {
-  AuthLoadingMethod,
-  AuthModalBodyProps,
-} from "@/components/auth/auth-modal-body";
+import type { AuthLoadingMethod } from "@/components/auth/auth-modal-types";
+import type { AuthModalBodyProps } from "@/components/auth/auth-modal-body";
 
 interface AuthModalProps {
   trigger?: React.ReactNode;
@@ -120,6 +119,11 @@ export function AuthModal({
   //  - captureActive: DynamicReturnCatcher has decided to mount its own stack
   //    for a redirect return but its chunk has not registered yet; arming in
   //    that window would race it (review F4).
+  //
+  // Nothing in the dialog WAITS on that stack any more — the body renders as
+  // soon as its own chunk lands, and the Solana button alone tracks the
+  // registration (#1109 review). Keeping the two downloads gated on each
+  // other also made them serial.
   const ambientLive = useAmbientWalletLive();
   const captureActive = useWalletReturnCaptureActive();
   const [scopedMounted, setScopedMounted] = useState(false);
@@ -156,19 +160,37 @@ export function AuthModal({
     if (scopedMounted && stackCount >= 2) setScopedMounted(false);
   }, [scopedMounted, stackCount]);
 
-  // Chunk-load failure handling (review F3): both lazies are recreated per
-  // attempt because a rejected React.lazy caches its rejection.
-  const [chunkFailed, setChunkFailed] = useState(false);
-  const [attempt, setAttempt] = useState(0);
-  const { LazyBody, LazyStack } = useMemo(() => {
-    void attempt; // cache-buster: a new attempt makes fresh lazy components
-    return {
-      LazyBody: lazy(
-        () => import("@/components/auth/auth-modal-body")
-      ) as ComponentType<AuthModalBodyProps>,
-      LazyStack: lazy(() => import("@/components/auth/scoped-auth-providers")),
-    };
-  }, [attempt]);
+  // Chunk-load failure handling (review F3): a lazy is recreated per attempt
+  // because a rejected React.lazy caches its rejection.
+  //
+  // The two chunks fail separately and cost different things (#1109 review):
+  // a dead STACK chunk only takes the wallet button with it, while a dead
+  // BODY chunk takes the whole button set — and Google/GitHub need neither,
+  // so they are re-rendered here from the static fallback module rather than
+  // left behind a "Try again". Separate attempt counters keep one retry from
+  // remounting the other half, which would drop the body's in-flight state.
+  const [stackFailed, setStackFailed] = useState(false);
+  const [bodyFailed, setBodyFailed] = useState(false);
+  const [stackAttempt, setStackAttempt] = useState(0);
+  const [bodyAttempt, setBodyAttempt] = useState(0);
+  const retryWalletStack = () => {
+    setStackFailed(false);
+    setStackAttempt((a) => a + 1);
+  };
+  const retryBody = () => {
+    setBodyFailed(false);
+    setBodyAttempt((a) => a + 1);
+  };
+  const LazyBody = useMemo(() => {
+    void bodyAttempt; // cache-buster: a new attempt makes a fresh lazy
+    return lazy(
+      () => import("@/components/auth/auth-modal-body")
+    ) as ComponentType<AuthModalBodyProps>;
+  }, [bodyAttempt]);
+  const LazyStack = useMemo(() => {
+    void stackAttempt;
+    return lazy(() => import("@/components/auth/scoped-auth-providers"));
+  }, [stackAttempt]);
 
   const spinner = (
     <div
@@ -184,8 +206,8 @@ export function AuthModal({
     <>
       {scopedMounted ? (
         <ChunkErrorBoundary
-          key={`stack-${attempt}`}
-          onError={() => setChunkFailed(true)}
+          key={`stack-${stackAttempt}`}
+          onError={() => setStackFailed(true)}
         >
           <Suspense fallback={null}>
             <LazyStack />
@@ -220,34 +242,44 @@ export function AuthModal({
               {t(showLater ? "keepProgressSubtitle" : "signInSubtitle")}
             </DialogDescription>
           </DialogHeader>
-          {chunkFailed ? (
-            <div className="mt-6 flex flex-col items-center gap-4">
+          {bodyFailed ? (
+            // The button set is gone with its chunk, but two of the three ways
+            // in never needed it: render them from the static module so a
+            // blocked CDN or a stale deploy costs the wallet path only.
+            <div className="mt-6 space-y-3">
               <p
                 className="max-w-xs text-center text-sm font-medium text-danger"
                 role="alert"
               >
                 {t("authFailed")}
               </p>
-              <Button
-                variant="push"
-                size="sm"
-                onClick={() => {
-                  setChunkFailed(false);
-                  setAttempt((a) => a + 1);
-                }}
-              >
-                {t("retry")}
-              </Button>
+              <OAuthFallbackButton
+                provider="google"
+                loading={loading}
+                setLoading={setLoading}
+                setErrorMessage={setErrorMessage}
+              />
+              <OAuthFallbackButton
+                provider="github"
+                loading={loading}
+                setLoading={setLoading}
+                setErrorMessage={setErrorMessage}
+              />
+              {errorMessage && (
+                <p className="text-center text-sm text-danger" role="alert">
+                  {errorMessage}
+                </p>
+              )}
+              <div className="flex justify-center pt-1">
+                <Button variant="ghost" size="sm" onClick={retryBody}>
+                  {t("retry")}
+                </Button>
+              </div>
             </div>
-          ) : !ambientLive ? (
-            // The provider stack is still standing up (scoped chunk loading,
-            // or the catcher's) — the body needs it registered before the
-            // wallet buttons can do anything.
-            spinner
           ) : (
             <ChunkErrorBoundary
-              key={`body-${attempt}`}
-              onError={() => setChunkFailed(true)}
+              key={`body-${bodyAttempt}`}
+              onError={() => setBodyFailed(true)}
             >
               <Suspense fallback={spinner}>
                 <LazyBody
@@ -258,6 +290,8 @@ export function AuthModal({
                   setOpen={setOpen}
                   showLater={showLater}
                   onLater={onLater}
+                  walletStackFailed={stackFailed}
+                  retryWalletStack={retryWalletStack}
                 />
               </Suspense>
             </ChunkErrorBoundary>

--- a/apps/web/src/components/auth/auth-modal.tsx
+++ b/apps/web/src/components/auth/auth-modal.tsx
@@ -119,6 +119,16 @@ export function AuthModal({
   // the body's `awaitingStack` is a ref inside the lazy chunk, so a body
   // remount mid-load would otherwise orphan a truthy `loading` forever — and
   // `onOpenChange` below refuses to close while it is truthy (#1126).
+  //
+  // This also drops a visible OAuth error when the SIWS auto-close below
+  // fires — deliberate. From the moment the overlay takes the screen it owns
+  // error reporting, and every SIWS terminus surfaces its own outcome:
+  // success hard-redirects, and failure (including a declined signature)
+  // renders the overlay's own message with Retry and Dismiss. Resurfacing a
+  // stale Google error underneath a wallet flow would misattribute the
+  // failure, and nothing is stranded — the learner can reopen and retry.
+  // Keep that invariant if you add a SIWS ending: if one can ever end
+  // silently, this reset starts hiding a real error.
   useEffect(() => {
     if (open) return;
     setLoading(null);

--- a/apps/web/src/components/auth/auth-modal.tsx
+++ b/apps/web/src/components/auth/auth-modal.tsx
@@ -247,11 +247,13 @@ export function AuthModal({
             // in never needed it: render them from the static module so a
             // blocked CDN or a stale deploy costs the wallet path only.
             <div className="mt-6 space-y-3">
+              {/* One error placement (#1077): a later OAuth failure replaces
+                  the chunk message rather than stacking a second alert. */}
               <p
-                className="max-w-xs text-center text-sm font-medium text-danger"
+                className="mx-auto max-w-xs text-center text-sm font-medium text-danger"
                 role="alert"
               >
-                {t("authFailed")}
+                {errorMessage ?? t("authFailed")}
               </p>
               <OAuthFallbackButton
                 provider="google"
@@ -265,11 +267,6 @@ export function AuthModal({
                 setLoading={setLoading}
                 setErrorMessage={setErrorMessage}
               />
-              {errorMessage && (
-                <p className="text-center text-sm text-danger" role="alert">
-                  {errorMessage}
-                </p>
-              )}
               <div className="flex justify-center pt-1">
                 <Button variant="ghost" size="sm" onClick={retryBody}>
                   {t("retry")}

--- a/apps/web/src/components/auth/auth-modal.tsx
+++ b/apps/web/src/components/auth/auth-modal.tsx
@@ -25,6 +25,7 @@ import {
 import { Button } from "@/components/ui/button";
 import {
   getAmbientWallet,
+  getSiwsActive,
   useAmbientStackCount,
   useAmbientWalletLive,
   useSiwsActive,
@@ -242,6 +243,21 @@ export function AuthModal({
       handoffTimers.current.push(setTimeout(fn, ms));
     };
     at(() => {
+      // SIWS beat us to it. autoConnect reconnects a remembered wallet the
+      // moment the stack mounts, so the learner can already be mid-signature
+      // while this timer runs — the picker would land ON TOP of the overlay
+      // and bury the Retry and Dismiss this whole change exists to keep
+      // reachable. Stand down; the overlay owns the screen now.
+      if (getSiwsActive()) {
+        setLoading(null);
+        return;
+      }
+      // Closed behind our back (SIWS, or the learner). Never write an error
+      // into a closed dialog — it would greet them on their next open.
+      if (!openRef.current) {
+        setLoading(null);
+        return;
+      }
       // Read the store BEFORE closing: a stack that unregistered during the
       // wait has no modal to hand off to, and closing first would leave the
       // learner on the page with the spinner gone and no error anywhere.
@@ -253,6 +269,9 @@ export function AuthModal({
       setOpen(false);
       setLoading(null);
       at(() => {
+        // Same two guards, re-read: both windows are live, and this one runs
+        // with the dialog already closed.
+        if (getSiwsActive()) return;
         const live = getAmbientWallet();
         if (live) {
           live.openWalletModal();

--- a/apps/web/src/components/auth/auth-modal.tsx
+++ b/apps/web/src/components/auth/auth-modal.tsx
@@ -4,6 +4,7 @@ import {
   forwardRef,
   lazy,
   Suspense,
+  useCallback,
   useEffect,
   useMemo,
   useRef,
@@ -23,8 +24,10 @@ import {
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import {
+  getAmbientWallet,
   useAmbientStackCount,
   useAmbientWalletLive,
+  useSiwsActive,
   useWalletReturnCaptureActive,
 } from "@/lib/solana/ambient-wallet-store";
 import { ChunkErrorBoundary } from "@/components/auth/chunk-error-boundary";
@@ -99,12 +102,39 @@ export function AuthModal({
   const [internalOpen, setInternalOpen] = useState(false);
   const isControlled = controlledOpen !== undefined;
   const open = isControlled ? controlledOpen : internalOpen;
-  const setOpen = (v: boolean) => {
-    if (!isControlled) setInternalOpen(v);
-    onOpenChange?.(v);
-  };
+  // Stable, so the effects and the lazy body that take it as a dependency
+  // don't re-run on every parent render.
+  const setOpen = useCallback(
+    (v: boolean) => {
+      if (!isControlled) setInternalOpen(v);
+      onOpenChange?.(v);
+    },
+    [isControlled, onOpenChange]
+  );
   const [loading, setLoading] = useState<AuthLoadingMethod>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  // Every close resets, whichever path closed us. `loading` lives here while
+  // the body's `awaitingStack` is a ref inside the lazy chunk, so a body
+  // remount mid-load would otherwise orphan a truthy `loading` forever — and
+  // `onOpenChange` below refuses to close while it is truthy (#1126).
+  useEffect(() => {
+    if (open) return;
+    setLoading(null);
+    setErrorMessage(null);
+  }, [open]);
+
+  // The SIWS overlay has taken the screen (#1109 follow-up): since #1097 the
+  // dialog is what mounts the wallet stack, and `autoConnect` can reconnect a
+  // remembered wallet and fire SIWS while the dialog is still open. Radix
+  // marks the body `pointer-events: none` for a modal dialog, and the overlay
+  // portals into that body — leaving its Retry and Dismiss buttons visible
+  // but unclickable over a dialog the scrim covers. Close, exactly as the
+  // manual wallet path does before handing off to the wallet-select modal.
+  const siwsActive = useSiwsActive();
+  useEffect(() => {
+    if (siwsActive && open) setOpen(false);
+  }, [siwsActive, open, setOpen]);
 
   // Where the wallet/Dynamic providers come from (#1097): on (platform)
   // routes the layout's stack is registered in the ambient store; elsewhere
@@ -180,6 +210,9 @@ export function AuthModal({
   const retryBody = () => {
     setBodyFailed(false);
     setBodyAttempt((a) => a + 1);
+    // Or a retry that lands would show the previous failure under a fresh
+    // button set.
+    setErrorMessage(null);
   };
   const LazyBody = useMemo(() => {
     void bodyAttempt; // cache-buster: a new attempt makes a fresh lazy
@@ -191,6 +224,47 @@ export function AuthModal({
     void stackAttempt;
     return lazy(() => import("@/components/auth/scoped-auth-providers"));
   }, [stackAttempt]);
+
+  // The wallet handoff — brief loading state, close, then open the
+  // wallet-select modal of whichever stack is live. It lives here rather than
+  // in the body because closing the dialog UNMOUNTS the body: timers started
+  // there would be cleared exactly when the picker is due to open. AuthModal
+  // survives the close (it renders in the Header), and clears them if IT
+  // unmounts — the case that would otherwise pop the wallet picker open
+  // unbidden on whatever route the learner moved to.
+  const handoffTimers = useRef<ReturnType<typeof setTimeout>[]>([]);
+  useEffect(() => {
+    const pending = handoffTimers.current;
+    return () => pending.forEach(clearTimeout);
+  }, []);
+  const startWalletHandoff = useCallback(() => {
+    const at = (fn: () => void, ms: number) => {
+      handoffTimers.current.push(setTimeout(fn, ms));
+    };
+    at(() => {
+      // Read the store BEFORE closing: a stack that unregistered during the
+      // wait has no modal to hand off to, and closing first would leave the
+      // learner on the page with the spinner gone and no error anywhere.
+      if (!getAmbientWallet()) {
+        setLoading(null);
+        setErrorMessage(t("authFailed"));
+        return;
+      }
+      setOpen(false);
+      setLoading(null);
+      at(() => {
+        const live = getAmbientWallet();
+        if (live) {
+          live.openWalletModal();
+          return;
+        }
+        // Vanished inside the close window — re-open with the failure rather
+        // than leave the click unanswered.
+        setOpen(true);
+        setErrorMessage(t("authFailed"));
+      }, 200);
+    }, 400);
+  }, [setOpen, t]);
 
   const spinner = (
     <div
@@ -217,10 +291,9 @@ export function AuthModal({
       <Dialog
         open={open}
         onOpenChange={(v) => {
-          if (!loading) {
-            setOpen(v);
-            if (!v) setErrorMessage(null);
-          }
+          // The close reset lives in the `open` effect above, so it covers
+          // every path in (Later, the wallet handoff, a controlled parent).
+          if (!loading) setOpen(v);
         }}
       >
         {(trigger !== undefined || !isControlled) && (
@@ -248,12 +321,15 @@ export function AuthModal({
             // blocked CDN or a stale deploy costs the wallet path only.
             <div className="mt-6 space-y-3">
               {/* One error placement (#1077): a later OAuth failure replaces
-                  the chunk message rather than stacking a second alert. */}
+                  the chunk message rather than stacking a second alert.
+                  Not `authFailed` — no wallet was involved and nothing was
+                  attempted, and this is what a screen reader announces the
+                  moment the modal opens. */}
               <p
                 className="mx-auto max-w-xs text-center text-sm font-medium text-danger"
                 role="alert"
               >
-                {errorMessage ?? t("authFailed")}
+                {errorMessage ?? t("optionsLoadFailed")}
               </p>
               <OAuthFallbackButton
                 provider="google"
@@ -268,7 +344,12 @@ export function AuthModal({
                 setErrorMessage={setErrorMessage}
               />
               <div className="flex justify-center pt-1">
-                <Button variant="ghost" size="sm" onClick={retryBody}>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={retryBody}
+                  disabled={loading !== null}
+                >
                   {t("retry")}
                 </Button>
               </div>
@@ -289,6 +370,7 @@ export function AuthModal({
                   onLater={onLater}
                   walletStackFailed={stackFailed}
                   retryWalletStack={retryWalletStack}
+                  startWalletHandoff={startWalletHandoff}
                 />
               </Suspense>
             </ChunkErrorBoundary>

--- a/apps/web/src/components/auth/oauth-fallback-button.tsx
+++ b/apps/web/src/components/auth/oauth-fallback-button.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { GithubLogo } from "@phosphor-icons/react";
+import { Button } from "@/components/ui/button";
+import { GoogleLogo } from "@/components/icons/google-logo";
+import { createClient } from "@/lib/supabase/client";
+import { buildOAuthRedirect } from "@/lib/auth/oauth-redirect";
+import { trackEvent } from "@/lib/analytics";
+import type {
+  AuthLoadingMethod,
+  SocialProvider,
+} from "@/components/auth/auth-modal-types";
+
+interface ProviderConfig {
+  Icon: React.ComponentType<{ className?: string }>;
+  /** auth.* key for the button label. */
+  labelKey: string;
+  /** auth.* key for the failure message (rendered by the parent). */
+  errorKey: string;
+}
+
+const PROVIDERS: Record<SocialProvider, ProviderConfig> = {
+  google: {
+    Icon: GoogleLogo,
+    labelKey: "signInWithGoogle",
+    errorKey: "googleSignInFailed",
+  },
+  github: {
+    Icon: ({ className }) => <GithubLogo className={className} weight="fill" />,
+    labelKey: "signInWithGitHub",
+    errorKey: "githubSignInFailed",
+  },
+};
+
+/**
+ * Plain `supabase.auth.signInWithOAuth` sign-in — the Google/GitHub path that
+ * runs when Dynamic is unconfigured, and the kill switch that restores the
+ * pre-Dynamic buttons untouched.
+ *
+ * Deliberately its own module, statically importable from anywhere: this is
+ * the ONE way in that needs neither wallet-adapter nor the Dynamic SDK, so it
+ * must not sit behind the lazy chunk that carries them. `auth-modal.tsx`
+ * renders it directly when that chunk fails to load, which is what keeps
+ * Google and GitHub reachable on a blocked CDN or a stale deploy (#1109
+ * review). Imports nothing heavier than the Supabase browser client, which
+ * the header already carries.
+ */
+export function OAuthFallbackButton({
+  provider,
+  loading,
+  setLoading,
+  setErrorMessage,
+}: {
+  provider: SocialProvider;
+  loading: AuthLoadingMethod;
+  setLoading: (v: AuthLoadingMethod) => void;
+  setErrorMessage: (v: string | null) => void;
+}) {
+  const t = useTranslations("auth");
+  const { Icon, labelKey, errorKey } = PROVIDERS[provider];
+
+  const handleClick = async () => {
+    setLoading(provider);
+    setErrorMessage(null);
+    trackEvent("auth_method_selected", { method: provider });
+    try {
+      const supabase = createClient();
+      const { error } = await supabase.auth.signInWithOAuth({
+        provider,
+        options: {
+          // Return the learner to the page they signed in from (#619 review):
+          // the OAuth callback otherwise always lands on /dashboard, stranding
+          // someone mid-lesson — and, post-LX-A4, away from the replay that
+          // finishes their banked work. The path-shape guard lives in
+          // buildOAuthRedirect (unit-tested); the callback re-sanitizes
+          // server-side too.
+          redirectTo: buildOAuthRedirect(
+            window.location.origin,
+            window.location.pathname
+          ),
+        },
+      });
+      if (error) {
+        console.error(`[AuthModal] ${provider} sign-in error:`, error.message);
+        setErrorMessage(t(errorKey));
+        setLoading(null);
+      }
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : t(errorKey);
+      console.error(`[AuthModal] ${provider} sign-in error:`, message);
+      setErrorMessage(t(errorKey));
+      setLoading(null);
+    }
+  };
+
+  return (
+    <Button
+      variant="outline"
+      className="h-12 w-full gap-3 text-sm font-medium"
+      onClick={handleClick}
+      disabled={loading !== null}
+    >
+      {loading === provider ? (
+        <div className="h-5 w-5 animate-spin rounded-full border-2 border-current border-t-transparent" />
+      ) : (
+        <Icon className="h-5 w-5 shrink-0" />
+      )}
+      {loading === provider ? t("connecting") : t(labelKey)}
+    </Button>
+  );
+}

--- a/apps/web/src/components/auth/wallet-auth-handler.tsx
+++ b/apps/web/src/components/auth/wallet-auth-handler.tsx
@@ -1,12 +1,6 @@
 "use client";
 
-import {
-  useEffect,
-  useLayoutEffect,
-  useRef,
-  useState,
-  useCallback,
-} from "react";
+import { useEffect, useRef, useState, useCallback } from "react";
 import { createPortal } from "react-dom";
 import { useWallet } from "@solana/wallet-adapter-react";
 import { useLocale, useTranslations } from "next-intl";
@@ -49,11 +43,13 @@ export function WalletAuthHandler() {
   const [overlayState, setOverlayState] = useState<AuthOverlayState>({
     status: "idle",
   });
-  // Resolved in an effect, never at module scope or during render: the server
-  // has no `document`, and a portal on the first client render would not match
-  // the server's null output.
+  // Resolved in an effect, never at module scope or during render: this
+  // component is server-rendered on (platform) routes, where there is no
+  // `document`. A plain useEffect, not useLayoutEffect — the latter warns
+  // during SSR, and nothing here needs to beat a paint: the overlay only
+  // appears once the async auth flow starts, long after mount.
   const [portalTarget, setPortalTarget] = useState<Element | null>(null);
-  useLayoutEffect(() => setPortalTarget(document.body), []);
+  useEffect(() => setPortalTarget(document.body), []);
 
   const authenticate = useCallback(async () => {
     if (!publicKey || (!signIn && !signMessage) || isAuthenticating.current)

--- a/apps/web/src/components/auth/wallet-auth-handler.tsx
+++ b/apps/web/src/components/auth/wallet-auth-handler.tsx
@@ -244,13 +244,22 @@ export function WalletAuthHandler() {
     }
   }, [connected, publicKey, signIn, signMessage, authenticate]);
 
-  // Reset when wallet disconnects
+  // Reset when wallet disconnects. Mid-signature is the exception: the dialog
+  // has already auto-closed for SIWS, so idling silently empties the screen.
+  // No Retry — authenticate() early-returns without a publicKey.
   useEffect(() => {
-    if (!connected) {
-      hasTriedAuth.current = false;
-      setOverlayState({ status: "idle" });
-    }
-  }, [connected]);
+    if (connected) return;
+    hasTriedAuth.current = false;
+    setOverlayState((prev) =>
+      prev.status === "authenticating"
+        ? {
+            status: "error",
+            message: t("walletDisconnected"),
+            canRetry: false,
+          }
+        : { status: "idle" }
+    );
+  }, [connected, t]);
 
   if (overlayState.status === "idle" || !portalTarget) return null;
 

--- a/apps/web/src/components/auth/wallet-auth-handler.tsx
+++ b/apps/web/src/components/auth/wallet-auth-handler.tsx
@@ -6,6 +6,7 @@ import { useWallet } from "@solana/wallet-adapter-react";
 import { useLocale, useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
 import { createClient } from "@/lib/supabase/client";
+import { setSiwsActive } from "@/lib/solana/ambient-wallet-store";
 import { createSIWSMessage, formatSIWSMessage } from "@/lib/solana/wallet-auth";
 
 type AuthOverlayState =
@@ -29,10 +30,15 @@ type AuthOverlayState =
  *
  * As a body child the overlay leaves the Header's stacking context, so it
  * needs the dialog layer (z-300) rather than the old z-100 — under the
- * Header's z-200 the nav would paint over the scrim and stay clickable. The
- * two never coexist: the sign-in dialog closes before the wallet-select
- * modal opens, and that modal (z-1040, its own stylesheet) closes on connect,
- * which is what triggers this overlay.
+ * Header's z-200 the nav would paint over the scrim and stay clickable.
+ *
+ * It CAN coexist with the sign-in dialog: opening that dialog is what mounts
+ * the scoped stack, and `autoConnect` reconnects a remembered wallet the
+ * instant it mounts, so SIWS can fire with the dialog still up. Radix marks
+ * the body `pointer-events: none` for a modal dialog and this portalled child
+ * inherits it, so the overlay raises `setSiwsActive` and AuthModal closes —
+ * the same handoff the manual path already does. `pointer-events-auto` covers
+ * the exit-animation window, and any other modal that might be open.
  */
 export function WalletAuthHandler() {
   const locale = useLocale();
@@ -50,6 +56,16 @@ export function WalletAuthHandler() {
   // appears once the async auth flow starts, long after mount.
   const [portalTarget, setPortalTarget] = useState<Element | null>(null);
   useEffect(() => setPortalTarget(document.body), []);
+
+  // Tells anything modal above us to get out of the way while the overlay is
+  // up — today that is AuthModal, which would otherwise leave the overlay's
+  // buttons inert under Radix's `pointer-events: none` body.
+  const overlayUp = overlayState.status !== "idle";
+  const siwsOwnerRef = useRef<object>({});
+  useEffect(() => {
+    if (!overlayUp) return;
+    return setSiwsActive(siwsOwnerRef.current);
+  }, [overlayUp]);
 
   const authenticate = useCallback(async () => {
     if (!publicKey || (!signIn && !signMessage) || isAuthenticating.current)
@@ -227,7 +243,7 @@ export function WalletAuthHandler() {
 
   return createPortal(
     <div
-      className="fixed inset-0 z-[300] flex items-center justify-center backdrop-blur-sm [background:color-mix(in_srgb,var(--bg)_80%,transparent)]"
+      className="pointer-events-auto fixed inset-0 z-[300] flex items-center justify-center backdrop-blur-sm [background:color-mix(in_srgb,var(--bg)_80%,transparent)]"
       role="status"
       aria-live="polite"
       data-testid="siws-overlay"

--- a/apps/web/src/components/auth/wallet-auth-handler.tsx
+++ b/apps/web/src/components/auth/wallet-auth-handler.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { useEffect, useRef, useState, useCallback } from "react";
+import {
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  useCallback,
+} from "react";
+import { createPortal } from "react-dom";
 import { useWallet } from "@solana/wallet-adapter-react";
 import { useLocale, useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
@@ -13,9 +20,25 @@ type AuthOverlayState =
   | { status: "error"; message: string; canRetry: boolean };
 
 /**
- * Mounts at the layout level (inside SolanaWalletProvider).
- * Listens for wallet connection and auto-triggers SIWS authentication.
- * Shows a full-screen loading overlay during the auth flow.
+ * Mounts inside SolanaWalletProvider — on (platform) routes via the layout,
+ * elsewhere via the sign-in modal's scoped stack. Listens for wallet
+ * connection and auto-triggers SIWS authentication, showing a full-screen
+ * overlay for the duration.
+ *
+ * The overlay goes through a PORTAL, like the wallet-select modal it follows
+ * (`WalletModal` in @solana/wallet-adapter-react-ui). Since #1097 the scoped
+ * stack mounts under the Header, whose bar carries `backdrop-blur-md` — a
+ * non-`none` backdrop-filter makes that element a containing block for
+ * `position: fixed` descendants, so an in-tree overlay is clipped to the
+ * 57px nav strip. Both the spinner and the error branch (the message a stuck
+ * learner most needs) were rendering inside it.
+ *
+ * As a body child the overlay leaves the Header's stacking context, so it
+ * needs the dialog layer (z-300) rather than the old z-100 — under the
+ * Header's z-200 the nav would paint over the scrim and stay clickable. The
+ * two never coexist: the sign-in dialog closes before the wallet-select
+ * modal opens, and that modal (z-1040, its own stylesheet) closes on connect,
+ * which is what triggers this overlay.
  */
 export function WalletAuthHandler() {
   const locale = useLocale();
@@ -26,6 +49,11 @@ export function WalletAuthHandler() {
   const [overlayState, setOverlayState] = useState<AuthOverlayState>({
     status: "idle",
   });
+  // Resolved in an effect, never at module scope or during render: the server
+  // has no `document`, and a portal on the first client render would not match
+  // the server's null output.
+  const [portalTarget, setPortalTarget] = useState<Element | null>(null);
+  useLayoutEffect(() => setPortalTarget(document.body), []);
 
   const authenticate = useCallback(async () => {
     if (!publicKey || (!signIn && !signMessage) || isAuthenticating.current)
@@ -199,13 +227,14 @@ export function WalletAuthHandler() {
     }
   }, [connected]);
 
-  if (overlayState.status === "idle") return null;
+  if (overlayState.status === "idle" || !portalTarget) return null;
 
-  return (
+  return createPortal(
     <div
-      className="fixed inset-0 z-[100] flex items-center justify-center backdrop-blur-sm [background:color-mix(in_srgb,var(--bg)_80%,transparent)]"
+      className="fixed inset-0 z-[300] flex items-center justify-center backdrop-blur-sm [background:color-mix(in_srgb,var(--bg)_80%,transparent)]"
       role="status"
       aria-live="polite"
+      data-testid="siws-overlay"
     >
       <div className="flex flex-col items-center gap-4">
         {overlayState.status === "authenticating" && (
@@ -238,6 +267,7 @@ export function WalletAuthHandler() {
           </>
         )}
       </div>
-    </div>
+    </div>,
+    portalTarget
   );
 }

--- a/apps/web/src/components/auth/wallet-auth-handler.tsx
+++ b/apps/web/src/components/auth/wallet-auth-handler.tsx
@@ -133,8 +133,21 @@ export function WalletAuthHandler() {
           return;
         }
       } catch {
-        // User intentionally declined signing — dismiss silently
-        setOverlayState({ status: "idle" });
+        // The learner declined the signature. This used to dismiss silently,
+        // which was fine while the sign-in dialog stayed up BEHIND the
+        // overlay — a decline left Google and GitHub in front of them. The
+        // dialog closes now (see the SIWS flag above), so silence would empty
+        // the screen: they clicked Sign in, a signature prompt they never
+        // asked for appeared, they refused it, and everything vanished.
+        //
+        // Retry is the escape hatch that matters here, because `hasTriedAuth`
+        // only resets on DISCONNECT — re-opening the modal and re-picking the
+        // same still-connected wallet would not re-fire SIWS.
+        setOverlayState({
+          status: "error",
+          message: t("signatureDeclined"),
+          canRetry: true,
+        });
         isAuthenticating.current = false;
         return;
       }

--- a/apps/web/src/components/lessons/banked-progress-replay.tsx
+++ b/apps/web/src/components/lessons/banked-progress-replay.tsx
@@ -17,8 +17,13 @@ export const REPLAY_BANKED_EVENT = "superteam:replay-banked";
 
 /**
  * Replays anonymously-banked lesson completions once the learner is signed in
- * (LX-A4c). Mounted globally (GamificationOverlays) so it runs regardless of
- * which page the learner lands on after auth, and re-runs on enrollment.
+ * (LX-A4c), and re-runs on enrollment.
+ *
+ * Mounted by GamificationOverlays, which since #1097 is (platform)-only — so
+ * this does NOT run on marketing routes. Harmless for the banked-work flow:
+ * replaying needs a course to replay INTO, every completion path is a
+ * platform route, and unreplayed work stays banked in localStorage until the
+ * learner gets there.
  *
  * Every outcome is surfaced, never silently dropped:
  *   - completed   → one success toast for the batch.

--- a/apps/web/src/components/onboarding/segment-sync.tsx
+++ b/apps/web/src/components/onboarding/segment-sync.tsx
@@ -17,11 +17,18 @@ import {
  * when the row has no segment yet: a returning learner's stored choice must win
  * over a stale anonymous pick left in this browser.
  *
- * Mounted globally (GamificationOverlays), mirroring BankedProgressReplay so it
- * runs regardless of which page the learner lands on after auth. Best-effort by
- * design: any write failure (including the columns not yet existing in an
- * environment where the migration has not applied) is swallowed — the
- * localStorage copy remains the read fallback, exactly like the progress bank.
+ * Mounted by GamificationOverlays, which since #1097 is (platform)-only — so
+ * this does NOT run on marketing routes, and /start is one of them. A learner
+ * who finishes the intake and signs in through the Supabase-OAuth fallback is
+ * returned to /{locale}/start by `buildOAuthRedirect`, so the copy waits for
+ * their first platform route. The wallet and Dynamic paths land on /dashboard
+ * and sync immediately. Nothing is lost either way — the localStorage copy is
+ * the read fallback until the DB row wins.
+ *
+ * Best-effort by design: any write failure (including the columns not yet
+ * existing in an environment where the migration has not applied) is
+ * swallowed — the localStorage copy remains the read fallback, exactly like
+ * the progress bank.
  *
  * Shared-browser hygiene (F4): once the signed-in user's DB row is the
  * authoritative source — whether we just copied into it OR it already carried a

--- a/apps/web/src/lib/solana/ambient-wallet-store.ts
+++ b/apps/web/src/lib/solana/ambient-wallet-store.ts
@@ -42,6 +42,13 @@ const registrations = new Map<object, AmbientWalletState>();
  */
 let returnCaptureActive = false;
 
+/**
+ * The handlers currently showing the SIWS overlay. A set rather than a
+ * boolean because two stacks can briefly overlap while crossing route groups,
+ * and the departing one's cleanup must not clear the arriving one's flag.
+ */
+const siwsOwners = new Set<object>();
+
 const listeners = new Set<() => void>();
 
 function emit(): void {
@@ -120,6 +127,34 @@ export function getWalletReturnCaptureActive(): boolean {
   return returnCaptureActive;
 }
 
+/**
+ * Raised by `WalletAuthHandler` for as long as its full-screen SIWS overlay is
+ * up, and watched by `AuthModal`, which closes itself when it goes true.
+ *
+ * The two genuinely can coexist since #1097: opening the dialog is what mounts
+ * the scoped stack, and `autoConnect` reconnects a remembered wallet the
+ * instant it mounts — so a returning signed-out learner fires SIWS with the
+ * dialog still open. Radix marks the body `pointer-events: none` for a modal
+ * dialog and the body-portalled overlay inherits it, leaving Retry and Dismiss
+ * rendered but inert behind a full-screen scrim. Closing the dialog is the
+ * same handoff the manual path already does before opening the wallet-select
+ * modal; this makes the automatic path do it too.
+ *
+ * Returns a release for the caller's own claim.
+ */
+export function setSiwsActive(owner: object): () => void {
+  siwsOwners.add(owner);
+  emit();
+  return () => {
+    if (!siwsOwners.delete(owner)) return;
+    emit();
+  };
+}
+
+export function getSiwsActive(): boolean {
+  return siwsOwners.size > 0;
+}
+
 const serverNull = () => null;
 const serverFalse = () => false;
 const serverZero = () => 0;
@@ -146,4 +181,9 @@ export function useWalletReturnCaptureActive(): boolean {
     getWalletReturnCaptureActive,
     serverFalse
   );
+}
+
+/** Whether a SIWS overlay is on screen — see {@link setSiwsActive}. */
+export function useSiwsActive(): boolean {
+  return useSyncExternalStore(subscribe, getSiwsActive, serverFalse);
 }

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -61,6 +61,7 @@
     "accountDeleted": "This account has been deleted and can't sign in.",
     "authFailed": "Wallet authentication failed. Please try again or use a different sign-in method.",
     "optionsLoadFailed": "Some sign-in options couldn't load. Continue with Google or GitHub, or try again.",
+    "signatureDeclined": "Signature declined. Try again, or use another sign-in method.",
     "chooseWallet": "Choose a wallet",
     "connecting": "Connecting...",
     "connectSolanaWallet": "Connect Solana Wallet",

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -62,6 +62,7 @@
     "authFailed": "Wallet authentication failed. Please try again or use a different sign-in method.",
     "optionsLoadFailed": "Some sign-in options couldn't load. Continue with Google or GitHub, or try again.",
     "signatureDeclined": "Signature declined. Try again, or use another sign-in method.",
+    "walletDisconnected": "Sign-in was interrupted — your wallet disconnected. Try again, or use another sign-in method.",
     "chooseWallet": "Choose a wallet",
     "connecting": "Connecting...",
     "connectSolanaWallet": "Connect Solana Wallet",

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -60,6 +60,7 @@
   "auth": {
     "accountDeleted": "This account has been deleted and can't sign in.",
     "authFailed": "Wallet authentication failed. Please try again or use a different sign-in method.",
+    "optionsLoadFailed": "Some sign-in options couldn't load. Continue with Google or GitHub, or try again.",
     "chooseWallet": "Choose a wallet",
     "connecting": "Connecting...",
     "connectSolanaWallet": "Connect Solana Wallet",

--- a/apps/web/src/messages/es.json
+++ b/apps/web/src/messages/es.json
@@ -60,6 +60,7 @@
   "auth": {
     "accountDeleted": "Esta cuenta ha sido eliminada y no puede iniciar sesión.",
     "authFailed": "La autenticación de la billetera falló. Inténtalo de nuevo o usa otro método de inicio de sesión.",
+    "optionsLoadFailed": "Algunas opciones de inicio de sesión no se cargaron. Continúa con Google o GitHub, o inténtalo de nuevo.",
     "chooseWallet": "Elige una billetera",
     "connecting": "Conectando...",
     "connectSolanaWallet": "Conectar Billetera Solana",

--- a/apps/web/src/messages/es.json
+++ b/apps/web/src/messages/es.json
@@ -62,6 +62,7 @@
     "authFailed": "La autenticación de la billetera falló. Inténtalo de nuevo o usa otro método de inicio de sesión.",
     "optionsLoadFailed": "Algunas opciones de inicio de sesión no se cargaron. Continúa con Google o GitHub, o inténtalo de nuevo.",
     "signatureDeclined": "Firma rechazada. Inténtalo de nuevo o usa otro método de inicio de sesión.",
+    "walletDisconnected": "El inicio de sesión se interrumpió: tu billetera se desconectó. Inténtalo de nuevo o usa otro método.",
     "chooseWallet": "Elige una billetera",
     "connecting": "Conectando...",
     "connectSolanaWallet": "Conectar Billetera Solana",

--- a/apps/web/src/messages/es.json
+++ b/apps/web/src/messages/es.json
@@ -61,6 +61,7 @@
     "accountDeleted": "Esta cuenta ha sido eliminada y no puede iniciar sesión.",
     "authFailed": "La autenticación de la billetera falló. Inténtalo de nuevo o usa otro método de inicio de sesión.",
     "optionsLoadFailed": "Algunas opciones de inicio de sesión no se cargaron. Continúa con Google o GitHub, o inténtalo de nuevo.",
+    "signatureDeclined": "Firma rechazada. Inténtalo de nuevo o usa otro método de inicio de sesión.",
     "chooseWallet": "Elige una billetera",
     "connecting": "Conectando...",
     "connectSolanaWallet": "Conectar Billetera Solana",

--- a/apps/web/src/messages/pt-BR.json
+++ b/apps/web/src/messages/pt-BR.json
@@ -61,6 +61,7 @@
     "accountDeleted": "Esta conta foi excluída e não pode mais fazer login.",
     "authFailed": "A autenticação da carteira falhou. Tente novamente ou use outro método de login.",
     "optionsLoadFailed": "Algumas opções de login não carregaram. Continue com Google ou GitHub, ou tente novamente.",
+    "signatureDeclined": "Assinatura recusada. Tente novamente ou use outro método de login.",
     "chooseWallet": "Escolha uma carteira",
     "connecting": "Conectando...",
     "connectSolanaWallet": "Conectar Carteira Solana",

--- a/apps/web/src/messages/pt-BR.json
+++ b/apps/web/src/messages/pt-BR.json
@@ -62,6 +62,7 @@
     "authFailed": "A autenticação da carteira falhou. Tente novamente ou use outro método de login.",
     "optionsLoadFailed": "Algumas opções de login não carregaram. Continue com Google ou GitHub, ou tente novamente.",
     "signatureDeclined": "Assinatura recusada. Tente novamente ou use outro método de login.",
+    "walletDisconnected": "O login foi interrompido — sua carteira desconectou. Tente novamente ou use outro método de acesso.",
     "chooseWallet": "Escolha uma carteira",
     "connecting": "Conectando...",
     "connectSolanaWallet": "Conectar Carteira Solana",

--- a/apps/web/src/messages/pt-BR.json
+++ b/apps/web/src/messages/pt-BR.json
@@ -60,6 +60,7 @@
   "auth": {
     "accountDeleted": "Esta conta foi excluída e não pode mais fazer login.",
     "authFailed": "A autenticação da carteira falhou. Tente novamente ou use outro método de login.",
+    "optionsLoadFailed": "Algumas opções de login não carregaram. Continue com Google ou GitHub, ou tente novamente.",
     "chooseWallet": "Escolha uma carteira",
     "connecting": "Conectando...",
     "connectSolanaWallet": "Conectar Carteira Solana",

--- a/docs/AUTH-FLOWS.md
+++ b/docs/AUTH-FLOWS.md
@@ -45,20 +45,72 @@ nothing; it re-runs the tombstone check per request as a backstop, and that is a
 
 ## 1. Ways in — the auth modal
 
-`src/components/auth/auth-modal.tsx`. Three buttons. The modal deliberately calls no
-Dynamic hook itself: every hook in `@dynamic-labs-sdk/react-hooks` throws
-`MissingProviderError` without a provider, and hooks can't be conditional, so the
+`src/components/auth/auth-modal.tsx` is the dialog shell; the three buttons live in
+`src/components/auth/auth-modal-body.tsx`, which the shell loads through `React.lazy`
+(§1.1). Neither calls a Dynamic hook: every hook in `@dynamic-labs-sdk/react-hooks`
+throws `MissingProviderError` without a provider, and hooks can't be conditional, so the
 feature gate is a component boundary — `DynamicSocialSignIn` (one component, a
-`PROVIDERS` map per provider) owns the hooks and mounts only when
-`isDynamicEnabled()` (`src/lib/dynamic/config.ts`). A fourth entry, email-OTP through
+`PROVIDERS` map per provider) owns the SDK calls and mounts only when
+`isDynamicEnabled()` (`src/lib/dynamic/config.ts`). Since #1097 it renders outside any
+`DynamicProvider`, so it reads the Dynamic session imperatively through the SDK's
+`getCore` escape hatch rather than `useUser`. A fourth entry, email-OTP through
 Dynamic, was removed from the modal in #1032 because it mints a wallet-shaped account
 that forks from a later Google login; the component itself was deleted in #1040.
+
+### 1.1 Where the provider stack comes from (#1097)
+
+Marketing and admin first loads no longer carry wallet-adapter, the Dynamic SDK, or
+TanStack Query. The stack (`SolanaWalletProvider` wrapping `DynamicWalletProvider`)
+mounts in `src/app/[locale]/(platform)/layout.tsx` and nowhere else:
+
+| Route group                                                                                               | Provider stack  | GamificationOverlays | DynamicReturnCatcher    |
+| --------------------------------------------------------------------------------------------------------- | --------------- | -------------------- | ----------------------- |
+| `(platform)` — dashboard, courses, community, leaderboard, certificates, profile, review, settings, teach | at layout level | yes                  | not needed (stack live) |
+| `(marketing)` — landing, `/start`, roadmap                                                                | on demand only  | no                   | yes                     |
+| `admin`                                                                                                   | on demand only  | no                   | yes                     |
+
+The Header lives in `[locale]/layout.tsx`, ABOVE all of it, so its wallet consumers can
+never reach the providers through React context. They read
+`src/lib/solana/ambient-wallet-store.ts` instead: a deliberately SDK-free module-level
+store that the stack's inner registrar publishes into (`connected`, `publicKey`,
+`disconnect`, `openWalletModal`), consumed outside with `useSyncExternalStore`. UserMenu
+disconnects through it (plus a `walletName` localStorage clear, so sign-out sticks with
+no stack mounted); the modal's Solana button opens the wallet-select modal through it.
+
+Two things stand a stack up on a provider-less route:
+
+- **The sign-in modal.** Opening `AuthModal` with no live registration lazily mounts
+  `ScopedAuthProviders` as a SIBLING of the Dialog, and keeps it mounted after close —
+  the Solana path closes the dialog and hands off to the wallet-select modal, which
+  lives in that stack. It never arms beside a live one (a second `WalletProvider`
+  doubles `autoConnect`, listeners, and SIWS) and disarms itself when another stack
+  registers, e.g. navigating into `(platform)` with the dialog open.
+- **`DynamicReturnCatcher`** (`src/components/auth/dynamic-return-catcher.tsx`), mounted
+  by the marketing and admin layouts. A Dynamic social/device redirect returns to the
+  page the learner left, which may be provider-less; the catcher sniffs the SDK's
+  callback params off the URL (no SDK import — the param names are the stable contract)
+  and mounts the same scoped stack, whose `DynamicAuthHandler` then runs the real,
+  SDK-verified detection. On an ordinary page load it renders null and loads nothing. It
+  raises a capture flag in the ambient store synchronously, before its chunk resolves,
+  so the modal cannot arm a competing stack in that window.
+
+Only the Solana button depends on any of this. Google and GitHub through Supabase OAuth
+need nothing but the browser Supabase client, so they render from a statically imported
+module (`src/components/auth/oauth-fallback-button.tsx`) and stay reachable when either
+lazy chunk fails to load — a blocked CDN or a stale deploy costs the wallet path only.
+The Solana button alone waits for a registration, and reports `authFailed` rather than
+spinning forever if the stack chunk dies. `src/__tests__/provider-free-import-graph.test.ts`
+walks the static import graph from the Header, the modal, UserMenu, and the landing
+client and fails if any of the three package families becomes statically reachable
+again.
 
 ### Connect Solana Wallet (wallet-adapter SIWS)
 
 Button hands off to the wallet-adapter modal; the actual auth is
-`src/components/auth/wallet-auth-handler.tsx`, mounted at layout level, which fires on
-wallet connect when no Supabase user exists:
+`src/components/auth/wallet-auth-handler.tsx`, mounted inside
+`SolanaWalletProvider` — so on `(platform)` routes it comes with the layout, and
+elsewhere with the modal's scoped stack. It fires on wallet connect when no Supabase
+user exists:
 
 1. `GET /api/auth/nonce` (`src/app/api/auth/nonce/route.ts`) — random nonce inserted
    into `siws_nonces` with `status='pending'`, 5-min TTL, max 10 pending per IP
@@ -72,6 +124,12 @@ wallet connect when no Supabase user exists:
    fully read; a bound on processing, not on ingress).
 4. On success: **hard redirect** to `/dashboard` — the browser Supabase client only
    reads cookies on boot, so a soft navigation leaves the header logged-out.
+
+Its full-screen overlay (the spinner, and the failure message with Retry/Dismiss) is
+portalled to `document.body`, like the wallet-select modal it follows. On a marketing
+route the handler mounts under the Header, whose bar carries `backdrop-blur-md`, and a
+non-`none` `backdrop-filter` is a containing block for `position: fixed` descendants —
+in-tree, the overlay was clipped to the 57px nav strip.
 
 Server verification (`src/lib/solana/verify-siws.ts`), in order: parse fields → expiry
 
@@ -121,7 +179,9 @@ despite living in this callback.
 page on hydration — the hooks throw outside a provider). No UI. Four jobs:
 
 0. **Social-redirect return.** The button that started sign-in is gone after the
-   full-page round trip, so something mounted on every page must finish it:
+   full-page round trip, so the return has to be finished by whatever the landing page
+   mounts: this handler on `(platform)` routes, and on marketing/admin routes the same
+   handler brought in by `DynamicReturnCatcher`'s scoped stack (§1.1).
    `detectSocialRedirectUrl` → `completeSocialRedirect` → strip callback params →
    if a Supabase session already exists this was a _link_, stop (job 3 will attach the
    wallet) → otherwise `bridgeDynamicSession()` → on success **hard reload**; on
@@ -298,13 +358,17 @@ resolves the account through its `auth.identities` row, synthetic email and all.
   every request carrying a session (covers SIWS sessions that never pass the OAuth
   callback), then next-intl, then auth-gating of `/dashboard`, `/settings`, `/teach`,
   `/review`, and exact `/profile`. `/api/*` is excluded from the matcher — API routes
-  do their own auth. The middleware also gates `/admin` on a separate HMAC-signed
-  `admin_session` cookie; that is a parallel auth system, out of scope for this map.
+  do their own auth. `/admin` is gated the same way — a sessionless request redirects to
+  the localized landing; whether that session is actually an admin is decided
+  server-side by `requireAdmin()` (the service-role-only `admin_users` allowlist) in the
+  admin layout and page, which 404 non-admins. There is no separate admin login.
 - **The Dynamic session is parallel state**, not the session of record. It survives a
-  Supabase sign-out, `DynamicAuthHandler` mounts everywhere, and MPC signing is
-  promptless — so an orphaned Dynamic session silently re-runs the SIWS bridge and
-  signs the learner straight back in on the next page load, making sign-out meaningless
-  on shared devices (#1027). Therefore `handleSignOut` in
+  Supabase sign-out, and MPC signing is promptless — so an orphaned Dynamic session
+  silently re-runs the SIWS bridge and signs the learner straight back in the next time
+  `DynamicAuthHandler` mounts, making sign-out meaningless on shared devices (#1027).
+  Since #1097 that is any `(platform)` route rather than any page at all, which delays
+  the re-sign-in but does not prevent it — the learner's next lesson is a platform
+  route. Therefore `handleSignOut` in
   `src/components/auth/user-menu.tsx` runs `logoutDynamic()` before
   `supabase.auth.signOut()`. `logoutDynamic` (`src/lib/dynamic/client.ts`) races
   Dynamic's `logout()` against a 2.5s deadline — a hung call must not stall sign-out;

--- a/docs/AUTH-FLOWS.md
+++ b/docs/AUTH-FLOWS.md
@@ -94,15 +94,21 @@ Two things stand a stack up on a provider-less route:
   raises a capture flag in the ambient store synchronously, before its chunk resolves,
   so the modal cannot arm a competing stack in that window.
 
-Only the Solana button depends on any of this. Google and GitHub through Supabase OAuth
-need nothing but the browser Supabase client, so they render from a statically imported
-module (`src/components/auth/oauth-fallback-button.tsx`) and stay reachable when either
-lazy chunk fails to load — a blocked CDN or a stale deploy costs the wallet path only.
-The Solana button alone waits for a registration, and reports `authFailed` rather than
-spinning forever if the stack chunk dies. `src/__tests__/provider-free-import-graph.test.ts`
-walks the static import graph from the Header, the modal, UserMenu, and the landing
-client and fails if any of the three package families becomes statically reachable
-again.
+Only the Solana button depends on any of this. On the happy path with Dynamic enabled —
+production — Google and GitHub are `DynamicSocialSignIn` inside the lazy body chunk,
+which still carries the SDK; the win is that the body and the stack now download in
+parallel instead of serially, and that the body no longer waits on a stack registration
+it never needed. With Dynamic unset, and on the failure path, the same two providers
+come from `src/components/auth/oauth-fallback-button.tsx`, a statically imported module
+that needs nothing but the browser Supabase client — so a dead body chunk (blocked CDN,
+stale deploy, offline) still leaves Google and GitHub reachable, and costs the wallet
+path only. The Solana button alone waits for a registration, and reports `authFailed`
+rather than spinning forever if the stack chunk dies.
+`src/__tests__/provider-free-import-graph.test.ts` walks the static import graph from
+`[locale]/layout.tsx`, the marketing layout, the Header, the modal, UserMenu, and the
+landing client, and fails if any of the three package families becomes statically
+reachable again. Bare `import "x"` counts — a side-effect import hides its whole subtree
+otherwise.
 
 ### Connect Solana Wallet (wallet-adapter SIWS)
 
@@ -130,6 +136,15 @@ portalled to `document.body`, like the wallet-select modal it follows. On a mark
 route the handler mounts under the Header, whose bar carries `backdrop-blur-md`, and a
 non-`none` `backdrop-filter` is a containing block for `position: fixed` descendants —
 in-tree, the overlay was clipped to the 57px nav strip.
+
+It can fire with the sign-in dialog still open: opening that dialog is what mounts the
+scoped stack, and `autoConnect` reconnects a remembered wallet the instant it mounts, so
+a returning signed-out learner gets SIWS without touching a button. Radix marks the body
+`pointer-events: none` for a modal dialog and the portalled overlay inherits it, which
+left Retry and Dismiss rendered but inert. So the handler raises `setSiwsActive` in the
+ambient store while the overlay is up and `AuthModal` closes — the same handoff the
+manual wallet path already does before opening the wallet-select modal. The overlay also
+carries `pointer-events-auto`, which covers the dialog's exit-animation window.
 
 Server verification (`src/lib/solana/verify-siws.ts`), in order: parse fields → expiry
 


### PR DESCRIPTION
Post-merge review of #1109 (closes #1097) found four real defects and a set of comments the merge invalidated. Fixed forward here.

**The SIWS overlay was trapped in the header.** On marketing routes the scoped stack mounts inside the header bar, whose `backdrop-blur-md` makes it a containing block for `position: fixed` descendants — verified on production: that div computes `backdrop-filter: blur(12px)`, is 57px tall, and a `fixed; inset:0` probe injected inside it measures 57px. So an anonymous visitor using the header's Sign in got a "Signing in…" band across the nav with the page still interactive, and on the error branch the failure message plus Retry/Dismiss were squeezed into the same strip. The overlay now portals to `document.body` the way the wallet-select modal does, which also moves it to the dialog layer — as a body child, `z-100` would have painted under the header's `z-200`.

**Google and GitHub were hostage to the wallet chunk.** The modal gated its whole body on a live ambient registration, so the two methods that need nothing but Supabase waited on a ~300 kB stack download and then shifted layout — and because `LazyBody` only rendered after the stack registered, the two chunks downloaded serially. The body now renders as soon as its own chunk lands; only the Solana button tracks the registration, and it reports `authFailed` rather than spinning if the stack chunk dies. Stack and body failures are tracked separately with their own retries, and a dead body chunk falls back to `oauth-fallback-button.tsx`, a static module with no wallet or Dynamic import, so the OAuth paths survive a blocked CDN or a stale deploy.

The #1097 goal is intact and now enforced: `provider-free-import-graph.test.ts` walks the static import graph from `header.tsx`, `auth-modal.tsx`, `user-menu.tsx` and `landing-client.tsx` and fails if wallet-adapter, the Dynamic SDK, or TanStack Query becomes statically reachable. It carries its own guard against passing vacuously, and I checked it fails as intended by flipping the modal's `import type` of the body to a value import.

**The two flaky auth tests** raced the lazy chunk behind a 10s `findBy`. Each suite now statically imports `auth-modal-body`, so the module is in the registry at collect time and the lazy import resolves in a microtask; the inflated per-test and per-query timeouts are gone rather than raised.

`docs/AUTH-FLOWS.md` gets a new §1.1 covering the scoped stack, the ambient wallet store, `DynamicReturnCatcher` and which route group mounts what, plus corrections to the three stale claims and to the middleware bullet still describing a retired HMAC `admin_session` cookie.

Twelve full `pnpm --filter web test` runs on this branch: 324 files / 3080 tests, five fully green. Every failure in the other seven was a PGlite `*-execution` test (`Hook timed out in 10000ms` at `PGlite.create()`), and that reproduces on main unchanged — one of two baseline runs failed the same way, in the same files. Flagged separately; no auth test failed in any of the twelve. `tsc --noEmit` and `next lint` clean.

Left alone deliberately: the `LowSolBanner` position change, and `ambient-wallet-store.ts`'s unused `publicKey` field.

Refs #1097, #1109.
