### PR TITLE
fix(admin): collapse the courses intro behind a disclosure

### DIFF
--- a/apps/web/src/app/[locale]/admin/courses/page.tsx
+++ b/apps/web/src/app/[locale]/admin/courses/page.tsx
@@ -33,23 +33,35 @@ export default async function AdminCoursesPage() {
           {t("screens.courses")}
         </h2>
 
-        <AdminCard className="space-y-4">
-          <p className="text-sm text-text-2">{t("coursesScreen.intro.lede")}</p>
-          <ol className="space-y-3">
-            {(["step1", "step2"] as const).map((step) => (
-              <li key={step} className="space-y-1">
-                <p className="text-sm font-semibold text-text">
-                  {t(`coursesScreen.intro.${step}Title`)}
-                </p>
-                <p className="text-sm text-text-3">
-                  {t(`coursesScreen.intro.${step}Body`)}
-                </p>
-              </li>
-            ))}
-          </ol>
-          <p className="rounded-md border border-primary bg-primary-bg p-3 text-sm text-text-2">
-            {t("coursesScreen.intro.contentOnlyNote")}
-          </p>
+        {/* Collapsed by default. This explains the publish-then-deploy model,
+            which is worth reading once and never again — as permanent chrome it
+            just pushed the actual controls down the page. */}
+        <AdminCard className="p-0">
+          <details className="group">
+            <summary className="cursor-pointer list-none rounded-md p-4 text-sm font-semibold text-text-2 outline-none transition-colors hover:text-text focus-visible:ring-2 focus-visible:ring-primary">
+              {t("coursesScreen.intro.summary")}
+            </summary>
+            <div className="space-y-4 px-4 pb-4">
+              <p className="text-sm text-text-2">
+                {t("coursesScreen.intro.lede")}
+              </p>
+              <ol className="space-y-3">
+                {(["step1", "step2"] as const).map((step) => (
+                  <li key={step} className="space-y-1">
+                    <p className="text-sm font-semibold text-text">
+                      {t(`coursesScreen.intro.${step}Title`)}
+                    </p>
+                    <p className="text-sm text-text-3">
+                      {t(`coursesScreen.intro.${step}Body`)}
+                    </p>
+                  </li>
+                ))}
+              </ol>
+              <p className="rounded-md border border-primary bg-primary-bg p-3 text-sm text-text-2">
+                {t("coursesScreen.intro.contentOnlyNote")}
+              </p>
+            </div>
+          </details>
         </AdminCard>
       </section>
 

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -1191,6 +1191,7 @@
     },
     "coursesScreen": {
       "intro": {
+        "summary": "How publishing and deploying work",
         "lede": "Getting a course to learners takes two separate steps, in order. This screen holds both: publish on top, deploy below.",
         "step1Title": "1. Publish — does the app have this course?",
         "step1Body": "Course content lives in the academy-courses repo. The app ships a compiled copy of it, pinned to one commit in content.lock. Publishing is a human pull request that bumps that pin and rebuilds the bundle; once it merges, Vercel redeploys and the content is in the app. This screen writes nothing — it shows the drift and hands you a prefilled PR.",

--- a/apps/web/src/messages/es.json
+++ b/apps/web/src/messages/es.json
@@ -1191,6 +1191,7 @@
     },
     "coursesScreen": {
       "intro": {
+        "summary": "Cómo funcionan la publicación y el deploy",
         "lede": "Llevar un curso hasta los estudiantes requiere dos pasos separados, en este orden. Esta pantalla reúne los dos: publicación arriba, despliegue abajo.",
         "step1Title": "1. Publicar — ¿la app ya tiene este curso?",
         "step1Body": "El contenido de los cursos vive en el repositorio academy-courses. La app distribuye una copia compilada de él, fijada a un único commit en content.lock. Publicar es un pull request humano que actualiza esa fijación y reconstruye el paquete; en cuanto se fusiona, Vercel vuelve a desplegar y el contenido queda en la app. Esta pantalla no escribe nada: muestra la divergencia y te entrega un PR ya rellenado.",

--- a/apps/web/src/messages/pt-BR.json
+++ b/apps/web/src/messages/pt-BR.json
@@ -1191,6 +1191,7 @@
     },
     "coursesScreen": {
       "intro": {
+        "summary": "Como funcionam a publicação e o deploy",
         "lede": "Levar um curso até os alunos exige duas etapas separadas, nesta ordem. Esta tela reúne as duas: publicação em cima, implantação embaixo.",
         "step1Title": "1. Publicar — o app já tem este curso?",
         "step1Body": "O conteúdo dos cursos vive no repositório academy-courses. O app distribui uma cópia compilada dele, fixada em um único commit no content.lock. Publicar é um pull request humano que atualiza esse pin e reconstrói o pacote; assim que ele é mesclado, a Vercel faz o redeploy e o conteúdo passa a estar no app. Esta tela não escreve nada — ela mostra a divergência e entrega um PR pré-preenchido.",


### PR DESCRIPTION
Six paragraphs explaining the publish-then-deploy model occupied the top of the Courses screen on every visit, pushing the actual controls down the page. It is read once and known forever after.

Collapsed behind a disclosure rather than deleted: the note that a course still reading Synced after you rewrote a lesson is not a bug prevents a real support question, and the two-step model is genuinely worth explaining the first time. New auth.coursesScreen.intro.summary key in all three locales; the existing strings are untouched, so the pinning test still passes (7/7).