### PR TITLE
fix(admin): three real states for the moderation queue and its nav badge

### DIFF
--- a/apps/web/src/app/[locale]/admin/__tests__/admin-nav.test.tsx
+++ b/apps/web/src/app/[locale]/admin/__tests__/admin-nav.test.tsx
@@ -139,21 +139,74 @@ describe("AdminNav", () => {
     renderWithIntl(<AdminNav />);
 
     // Give the async fetch a chance to resolve, then assert nothing appeared.
-    await waitFor(() => expect(global.fetch).toHaveBeenCalled());
+    const link = await screen.findByRole("link", { name: nav.moderation });
+    await waitFor(() =>
+      expect(link.querySelector(".animate-pulse")).toBeNull()
+    );
+    expect(link).not.toHaveTextContent(/\d/);
     expect(
-      screen.getByRole("link", { name: nav.moderation })
-    ).toBeInTheDocument();
+      screen.queryByLabelText(nav.pendingFlagsUnknown)
+    ).not.toBeInTheDocument();
   });
 
-  it("hides the badge (and never throws) when the count fetch fails", async () => {
+  // #1132: a failed count used to collapse into a hidden badge, which is the
+  // same thing the nav shows for "queue is clear" — the nav then corroborated
+  // the panel's wrong all-clear.
+  it("marks the count unknown (not zero, not hidden) when the count fetch throws", async () => {
     vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("offline")));
     renderWithIntl(<AdminNav />);
 
-    await waitFor(() => expect(global.fetch).toHaveBeenCalled());
-    // Nav still renders its five links; the badge simply never shows.
+    await waitFor(() =>
+      expect(screen.getByLabelText(nav.pendingFlagsUnknown)).toBeInTheDocument()
+    );
+    // Nav still renders its five links and never throws into the tree.
     expect(screen.getAllByRole("link")).toHaveLength(5);
+    // The marker is scoped to Moderation and carries no count.
     expect(
-      screen.getByRole("link", { name: nav.moderation })
-    ).toBeInTheDocument();
+      screen.getByRole("link", { name: /Moderation/ })
+    ).not.toHaveTextContent(/\d/);
+    // Ambient nav chrome, deliberately not a live region.
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("marks the count unknown when the count fetch returns non-ok", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValue({ ok: false, status: 401, json: async () => ({}) })
+    );
+    renderWithIntl(<AdminNav />);
+
+    await waitFor(() =>
+      expect(screen.getByLabelText(nav.pendingFlagsUnknown)).toBeInTheDocument()
+    );
+  });
+
+  it("keeps the three badge states distinct: loading, resolved, failed", async () => {
+    // Loading: a placeholder pill, and neither a count nor the unknown marker.
+    vi.stubGlobal("fetch", vi.fn().mockReturnValue(new Promise(() => {})));
+    const { unmount } = renderWithIntl(<AdminNav />);
+    const moderationLink = screen.getByRole("link", { name: nav.moderation });
+    expect(moderationLink.querySelector(".animate-pulse")).not.toBeNull();
+    expect(
+      screen.queryByLabelText(nav.pendingFlagsUnknown)
+    ).not.toBeInTheDocument();
+    unmount();
+
+    // Resolved with a count: the red count pill, no placeholder.
+    mockFlags(2);
+    renderWithIntl(<AdminNav />);
+    await waitFor(() =>
+      expect(screen.getByLabelText("2 pending flags")).toBeInTheDocument()
+    );
+    expect(
+      screen
+        .getByRole("link", { name: /Moderation/ })
+        .querySelector(".animate-pulse")
+    ).toBeNull();
+    expect(
+      screen.queryByLabelText(nav.pendingFlagsUnknown)
+    ).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/app/[locale]/admin/admin-nav.tsx
+++ b/apps/web/src/app/[locale]/admin/admin-nav.tsx
@@ -19,25 +19,40 @@ const SECTIONS = [
 ] as const;
 
 /**
- * Best-effort pending-flags count for the "Moderation" nav badge. Reuses the
- * existing `GET /api/admin/flags` list route (no count-only sibling exists);
- * `.length` of the returned rows is the pending count. Purely additive to nav
- * render — it never throws into the tree, and a failed/zero fetch leaves the
- * badge hidden.
+ * Three states for the "Moderation" nav badge. `failed` exists because a
+ * hidden badge means "queue is clear", and before #1132 a dead endpoint got
+ * that same silent treatment — the nav then corroborated the panel's wrong
+ * all-clear.
  */
-function usePendingFlagCount(): number {
-  const [count, setCount] = useState(0);
+type PendingFlagState =
+  | { status: "loading" }
+  | { status: "ready"; count: number }
+  | { status: "failed" };
+
+/**
+ * Pending-flags count for the "Moderation" nav badge. Reuses the existing
+ * `GET /api/admin/flags` list route (no count-only sibling exists); `.length`
+ * of the returned rows is the pending count. Still purely additive to nav
+ * render — it never throws into the tree — but a failure is now reported as
+ * `failed` rather than collapsing into zero.
+ */
+function usePendingFlagCount(): PendingFlagState {
+  const [state, setState] = useState<PendingFlagState>({ status: "loading" });
 
   useEffect(() => {
     let active = true;
     void (async () => {
       try {
         const res = await fetch("/api/admin/flags");
-        if (!res.ok) return;
+        if (!res.ok) {
+          if (active) setState({ status: "failed" });
+          return;
+        }
         const body = (await res.json()) as { flags?: unknown[] };
-        if (active) setCount(body.flags?.length ?? 0);
+        if (active)
+          setState({ status: "ready", count: body.flags?.length ?? 0 });
       } catch {
-        // Non-critical at-a-glance count; leave the badge hidden on error.
+        if (active) setState({ status: "failed" });
       }
     })();
     return () => {
@@ -45,7 +60,7 @@ function usePendingFlagCount(): number {
     };
   }, []);
 
-  return count;
+  return state;
 }
 
 /**
@@ -67,7 +82,7 @@ export function AdminNav() {
         {SECTIONS.map((section) => {
           const href = `/${locale}/admin/${section}`;
           const isActive = pathname === href || pathname.startsWith(`${href}/`);
-          const showBadge = section === "moderation" && pendingFlags > 0;
+          const badge = section === "moderation" ? pendingFlags : null;
 
           return (
             <li key={section}>
@@ -83,12 +98,37 @@ export function AdminNav() {
                 )}
               >
                 <span>{t(`nav.${section}`)}</span>
-                {showBadge && (
+                {/* Muted placeholder while the count is in flight, so
+                    "not known yet" does not look like "queue is clear".
+                    Decorative: the moderation screen carries the accessible
+                    loading text, and a live region firing on every admin page
+                    load would be pure noise. */}
+                {badge?.status === "loading" && (
                   <span
-                    aria-label={t("nav.pendingFlags", { count: pendingFlags })}
+                    aria-hidden="true"
+                    className="inline-flex h-[1.125rem] w-5 animate-pulse rounded-full bg-subtle"
+                  />
+                )}
+                {/* Unknown, not zero. Neutral `streak` rather than `danger`,
+                    and deliberately not a live region — this nav renders on
+                    every admin screen, so an assertive announcement per
+                    transient blip costs more than it buys. Clicking it lands
+                    on Moderation, where the panel offers the real retry. */}
+                {badge?.status === "failed" && (
+                  <span
+                    aria-label={t("nav.pendingFlagsUnknown")}
+                    title={t("nav.pendingFlagsUnknown")}
+                    className="inline-flex min-w-[1.25rem] items-center justify-center rounded-full border border-streak bg-streak-light px-1.5 py-0.5 text-xs font-bold leading-none text-streak"
+                  >
+                    ?
+                  </span>
+                )}
+                {badge?.status === "ready" && badge.count > 0 && (
+                  <span
+                    aria-label={t("nav.pendingFlags", { count: badge.count })}
                     className="inline-flex min-w-[1.25rem] items-center justify-center rounded-full bg-danger px-1.5 py-0.5 text-xs font-bold leading-none text-white"
                   >
-                    {pendingFlags}
+                    {badge.count}
                   </span>
                 )}
               </Link>

--- a/apps/web/src/components/admin/__tests__/flags-panel.test.tsx
+++ b/apps/web/src/components/admin/__tests__/flags-panel.test.tsx
@@ -2,8 +2,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import { NextIntlClientProvider } from "next-intl";
-import { FlagsPanel } from "../flags-panel";
 import messages from "@/messages/en.json";
+import { FlagsPanel } from "../flags-panel";
 
 const flag = {
   id: "flag-1",
@@ -32,6 +32,139 @@ beforeEach(() => {
 afterEach(() => {
   vi.unstubAllGlobals();
   vi.restoreAllMocks();
+});
+
+const flagsMsgs = messages.admin.flags;
+
+/** A `fetch` that never settles, so the panel stays in its loading state. */
+function pendingFetch() {
+  const fetchMock = vi.fn().mockReturnValue(new Promise(() => {}));
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+// #1132: the queue used to initialise to `[]` with no loading state and
+// swallow every load failure, so "No pending flags." was what a moderator saw
+// whether the queue was clear, still loading, or unreachable.
+describe("FlagsPanel load states", () => {
+  it("shows the loading state — not the empty state — before the fetch settles", () => {
+    pendingFetch();
+    renderPanel();
+
+    expect(screen.getByText(flagsMsgs.loading)).toBeInTheDocument();
+    expect(screen.queryByText(flagsMsgs.noPending)).not.toBeInTheDocument();
+    // Loading is a polite status, never an alert.
+    expect(screen.getByRole("status")).toHaveTextContent(flagsMsgs.loading);
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("shows the empty state only once a successful fetch returns no flags", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ ok: true, json: async () => ({ flags: [] }) })
+    );
+    renderPanel();
+
+    await waitFor(() =>
+      expect(screen.getByText(flagsMsgs.noPending)).toBeInTheDocument()
+    );
+    expect(screen.queryByText(flagsMsgs.loading)).not.toBeInTheDocument();
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("does NOT render the empty state when the load fails with a 500", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValue({ ok: false, status: 500, json: async () => ({}) })
+    );
+    renderPanel();
+
+    await waitFor(() =>
+      expect(screen.getByText(flagsMsgs.loadErrorFetch)).toBeInTheDocument()
+    );
+    expect(screen.queryByText(flagsMsgs.noPending)).not.toBeInTheDocument();
+    expect(screen.queryByText(flagsMsgs.loading)).not.toBeInTheDocument();
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      flagsMsgs.loadErrorFetch
+    );
+  });
+
+  it("does NOT render the empty state when the load fetch throws", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("offline")));
+    renderPanel();
+
+    await waitFor(() =>
+      expect(screen.getByText(flagsMsgs.loadErrorNetwork)).toBeInTheDocument()
+    );
+    expect(screen.queryByText(flagsMsgs.noPending)).not.toBeInTheDocument();
+  });
+
+  it("tells the moderator the session expired when the load 401s", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValue({ ok: false, status: 401, json: async () => ({}) })
+    );
+    renderPanel();
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(flagsMsgs.loadErrorUnauthorized)
+      ).toBeInTheDocument()
+    );
+    // A 401 is not the generic fetch failure — different cause, different fix.
+    expect(
+      screen.queryByText(flagsMsgs.loadErrorFetch)
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText(flagsMsgs.noPending)).not.toBeInTheDocument();
+  });
+
+  it("retries the load from the failed state and renders the recovered queue", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: false, status: 500, json: async () => ({}) })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ flags: [flag] }),
+      });
+    vi.stubGlobal("fetch", fetchMock);
+    renderPanel();
+
+    await waitFor(() =>
+      expect(screen.getByText(flagsMsgs.loadErrorFetch)).toBeInTheDocument()
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: messages.admin.states.retry })
+    );
+
+    await waitFor(() =>
+      expect(screen.getByText(flag.preview)).toBeInTheDocument()
+    );
+    expect(
+      screen.queryByText(flagsMsgs.loadErrorFetch)
+    ).not.toBeInTheDocument();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("reports the loaded count to the parent badge", async () => {
+    const onCountChange = vi.fn();
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValue({ ok: true, json: async () => ({ flags: [flag] }) })
+    );
+    render(
+      <NextIntlClientProvider locale="en" messages={messages}>
+        <FlagsPanel onCountChange={onCountChange} />
+      </NextIntlClientProvider>
+    );
+
+    await waitFor(() => expect(onCountChange).toHaveBeenLastCalledWith(1));
+  });
 });
 
 describe("FlagsPanel action-error paths", () => {

--- a/apps/web/src/components/admin/flags-panel.tsx
+++ b/apps/web/src/components/admin/flags-panel.tsx
@@ -17,29 +17,58 @@ interface ModerationFlag {
 /** Which failure the last action hit — mapped to a translated string by the UI. */
 type ActionError = "fetch" | "network";
 
+/**
+ * Which failure the last queue load hit. `unauthorized` is split out from
+ * `fetch` because the route 401s on an expired admin session, and that needs a
+ * different instruction than a 500 — retrying a dead session just fails again.
+ */
+type LoadError = "fetch" | "network" | "unauthorized";
+
+const LOAD_ERROR_KEY: Record<LoadError, string> = {
+  fetch: "loadErrorFetch",
+  network: "loadErrorNetwork",
+  unauthorized: "loadErrorUnauthorized",
+};
+
 export function FlagsPanel({
   onCountChange,
 }: {
   onCountChange?: (count: number) => void;
 }) {
   const t = useTranslations("admin.flags");
+  const tAdmin = useTranslations("admin");
   const [flags, setFlags] = useState<ModerationFlag[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<LoadError | null>(null);
   const [busyId, setBusyId] = useState<string | null>(null);
   const [error, setError] = useState<ActionError | null>(null);
 
-  const load = useCallback(async () => {
-    try {
-      const res = await fetch("/api/admin/flags");
-      if (!res.ok) return;
-      const body = (await res.json()) as { flags?: ModerationFlag[] };
-      setFlags(body.flags ?? []);
-    } catch {
-      // Non-critical convenience view.
-    }
+  // A failed load must never read as "queue is clear" (#1132), so it drops
+  // whatever was on screen and renders the failed branch instead of the list.
+  const load = useCallback((): void => {
+    setLoading(true);
+    setLoadError(null);
+    void (async () => {
+      try {
+        const res = await fetch("/api/admin/flags");
+        if (!res.ok) {
+          setFlags([]);
+          setLoadError(res.status === 401 ? "unauthorized" : "fetch");
+          return;
+        }
+        const body = (await res.json()) as { flags?: ModerationFlag[] };
+        setFlags(body.flags ?? []);
+      } catch {
+        setFlags([]);
+        setLoadError("network");
+      } finally {
+        setLoading(false);
+      }
+    })();
   }, []);
 
   useEffect(() => {
-    void load();
+    load();
   }, [load]);
 
   // Keep the parent's badge count in sync with the list (incl. optimistic drops).
@@ -79,13 +108,39 @@ export function FlagsPanel({
     <div className="space-y-4">
       <p className="text-sm text-text-3">{t("description")}</p>
 
+      {/* Transient errors get the neutral `streak` treatment, not `danger` —
+          the convention course-sync-table.tsx documents, where `danger` is
+          reserved for blocking and destructive states. */}
       {error && (
-        <div className="rounded-md border border-danger bg-danger-light p-3 text-sm text-danger">
+        <div
+          role="alert"
+          className="rounded-md border border-streak bg-streak-light p-3 text-sm text-streak"
+        >
           {t(error === "network" ? "errorNetwork" : "errorFetch")}
         </div>
       )}
 
-      {flags.length === 0 ? (
+      {loading ? (
+        <div className="flex items-center justify-center py-10">
+          <p role="status" className="text-sm text-text-3">
+            {t("loading")}
+          </p>
+        </div>
+      ) : loadError ? (
+        <div
+          role="alert"
+          className="rounded-md border border-streak bg-streak-light p-3 text-sm text-streak"
+        >
+          {t(LOAD_ERROR_KEY[loadError])}
+          <button
+            type="button"
+            onClick={load}
+            className="ml-3 underline hover:no-underline"
+          >
+            {tAdmin("states.retry")}
+          </button>
+        </div>
+      ) : flags.length === 0 ? (
         <p className="text-sm text-text-3">{t("noPending")}</p>
       ) : (
         <ul className="space-y-2">

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -1175,6 +1175,7 @@
       "courses": "Courses",
       "moderation": "Moderation",
       "pendingFlags": "{count, plural, one {# pending flag} other {# pending flags}}",
+      "pendingFlagsUnknown": "Pending flag count unavailable",
       "status": "Status",
       "content": "Content",
       "insights": "Insights"
@@ -1486,7 +1487,11 @@
     },
     "flags": {
       "description": "Community posts reported by users. Resolve once you've actioned the content, or dismiss if the report isn't valid.",
+      "loading": "Loading the moderation queue...",
       "noPending": "No pending flags.",
+      "loadErrorFetch": "Couldn't load the moderation queue. Its state is unknown — reports may be waiting.",
+      "loadErrorNetwork": "Network error loading the moderation queue. Its state is unknown — reports may be waiting.",
+      "loadErrorUnauthorized": "Your admin session has expired, so the moderation queue could not be loaded. Sign in again.",
       "reportedBy": "reported by @{reporter}",
       "unknownReporter": "unknown",
       "targetThread": "thread",

--- a/apps/web/src/messages/es.json
+++ b/apps/web/src/messages/es.json
@@ -1175,6 +1175,7 @@
       "courses": "Cursos",
       "moderation": "Moderación",
       "pendingFlags": "{count, plural, one {# reporte pendiente} other {# reportes pendientes}}",
+      "pendingFlagsUnknown": "Recuento de reportes pendientes no disponible",
       "status": "Estado",
       "content": "Contenido",
       "insights": "Métricas"
@@ -1486,7 +1487,11 @@
     },
     "flags": {
       "description": "Publicaciones de la comunidad reportadas por usuarios. Resuelve una vez que hayas actuado sobre el contenido, o descarta si el reporte no es válido.",
+      "loading": "Cargando la cola de moderación...",
       "noPending": "No hay reportes pendientes.",
+      "loadErrorFetch": "No se pudo cargar la cola de moderación. Su estado es desconocido: puede haber reportes esperando.",
+      "loadErrorNetwork": "Error de red al cargar la cola de moderación. Su estado es desconocido: puede haber reportes esperando.",
+      "loadErrorUnauthorized": "Tu sesión de administrador expiró, por lo que no se pudo cargar la cola de moderación. Inicia sesión de nuevo.",
       "reportedBy": "reportado por @{reporter}",
       "unknownReporter": "desconocido",
       "targetThread": "hilo",

--- a/apps/web/src/messages/pt-BR.json
+++ b/apps/web/src/messages/pt-BR.json
@@ -1175,6 +1175,7 @@
       "courses": "Cursos",
       "moderation": "Moderação",
       "pendingFlags": "{count, plural, one {# denúncia pendente} other {# denúncias pendentes}}",
+      "pendingFlagsUnknown": "Contagem de denúncias pendentes indisponível",
       "status": "Status",
       "content": "Conteúdo",
       "insights": "Métricas"
@@ -1486,7 +1487,11 @@
     },
     "flags": {
       "description": "Publicações da comunidade denunciadas por usuários. Resolva depois de tratar o conteúdo ou descarte se a denúncia não for válida.",
+      "loading": "Carregando a fila de moderação...",
       "noPending": "Nenhuma denúncia pendente.",
+      "loadErrorFetch": "Não foi possível carregar a fila de moderação. O estado dela é desconhecido — pode haver denúncias aguardando.",
+      "loadErrorNetwork": "Erro de rede ao carregar a fila de moderação. O estado dela é desconhecido — pode haver denúncias aguardando.",
+      "loadErrorUnauthorized": "Sua sessão de administrador expirou, então a fila de moderação não pôde ser carregada. Entre novamente.",
       "reportedBy": "denunciado por @{reporter}",
       "unknownReporter": "desconhecido",
       "targetThread": "tópico",


### PR DESCRIPTION
The moderation queue initialised to an empty list with no loading state and swallowed every load failure, so "No pending flags." was what a moderator saw whether the queue was genuinely clear, still loading, or unreachable. The nav badge failed identically and corroborated the wrong all-clear. Both surfaces now separate loading, loaded, and failed.

The panel's failed state is a `role="alert"` with a Retry button; loading is a `role="status"` line. A 401 gets its own copy — an expired admin session is a plausible cause and retrying a dead session just fails again, so the message says to sign in rather than blaming the fetch. Failed loads clear the list so the empty branch cannot render underneath.

The nav badge shows a muted placeholder pill while the count is in flight and a neutral `?` marker when it cannot be fetched, so "unknown" is distinct from both "clear" (no badge) and a red count. It is deliberately not a live region: the nav renders on every admin screen, and an assertive announcement per transient blip would cost more than it buys. Clicking it lands on Moderation, where the panel offers the real retry. I also moved the panel's existing action-error banner from `danger` to `streak`, the tone `course-sync-table.tsx` documents for transient recoverable errors, so the two banners in one panel do not disagree.

No shared loading/error wrapper here — #1134 owns that and will absorb both call sites.

Test results on this branch: `src/components/admin/__tests__`, `src/app/[locale]/admin/__tests__` and `src/messages/__tests__` are 19 files / 115 tests passing, plus a clean `tsc --noEmit`. Red-proof: reverting the two components while keeping the new tests fails 8 of the 11 new cases, including `does NOT render the empty state when the load fails with a 500`, which reverts to rendering "No pending flags."

Closes #1132
