### PR TITLE
fix(admin): give the console its own loading and error boundaries

### DIFF
--- a/apps/web/src/app/[locale]/admin/content/loading.tsx
+++ b/apps/web/src/app/[locale]/admin/content/loading.tsx
@@ -1,0 +1,2 @@
+// Segment marker for Next instant loading + prefetch (#1092); UI lives in route-loading.
+export { default } from "@/components/ui/route-loading";

--- a/apps/web/src/app/[locale]/admin/courses/loading.tsx
+++ b/apps/web/src/app/[locale]/admin/courses/loading.tsx
@@ -1,0 +1,2 @@
+// Segment marker for Next instant loading + prefetch (#1092); UI lives in route-loading.
+export { default } from "@/components/ui/route-loading";

--- a/apps/web/src/app/[locale]/admin/error.tsx
+++ b/apps/web/src/app/[locale]/admin/error.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { useEffect } from "react";
+import { useTranslations } from "next-intl";
+import * as Sentry from "@sentry/nextjs";
+
+/**
+ * Admin-console error boundary (#1133). `/admin` sits outside `(platform)` and
+ * `(marketing)`, so before this file a server throw in the panel escalated to
+ * the root `app/error.tsx` — a full-screen, hardcoded-English page that took
+ * the console shell and nav rail with it. Living in the `admin` segment, this
+ * boundary renders in the layout's children slot, so the rail stays usable and
+ * the reader can retry or click to another screen.
+ *
+ * It cannot catch a throw from `admin/layout.tsx` itself (Next boundaries do
+ * not wrap their own layout) — a failing `requireAdmin()` still escalates.
+ */
+export default function AdminError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  const t = useTranslations("error");
+
+  useEffect(() => {
+    Sentry.captureException(error);
+  }, [error]);
+
+  return (
+    <div className="flex min-h-[50vh] flex-col items-center justify-center gap-4 p-8 text-center">
+      <h2 className="font-display text-xl font-semibold text-text">
+        {t("title")}
+      </h2>
+      <p className="text-text-3">{t("description")}</p>
+      <button
+        onClick={reset}
+        className="inline-flex items-center rounded-lg bg-primary px-6 py-3 text-sm font-medium text-white transition-opacity hover:opacity-90"
+      >
+        {t("tryAgain")}
+      </button>
+    </div>
+  );
+}

--- a/apps/web/src/app/[locale]/admin/insights/loading.tsx
+++ b/apps/web/src/app/[locale]/admin/insights/loading.tsx
@@ -1,0 +1,2 @@
+// Segment marker for Next instant loading + prefetch (#1092); UI lives in route-loading.
+export { default } from "@/components/ui/route-loading";

--- a/apps/web/src/app/[locale]/admin/loading.tsx
+++ b/apps/web/src/app/[locale]/admin/loading.tsx
@@ -1,0 +1,2 @@
+// Segment marker for Next instant loading + prefetch (#1092); UI lives in route-loading.
+export { default } from "@/components/ui/route-loading";

--- a/apps/web/src/app/[locale]/admin/moderation/loading.tsx
+++ b/apps/web/src/app/[locale]/admin/moderation/loading.tsx
@@ -1,0 +1,2 @@
+// Segment marker for Next instant loading + prefetch (#1092); UI lives in route-loading.
+export { default } from "@/components/ui/route-loading";

--- a/apps/web/src/app/[locale]/admin/status/loading.tsx
+++ b/apps/web/src/app/[locale]/admin/status/loading.tsx
@@ -1,0 +1,2 @@
+// Segment marker for Next instant loading + prefetch (#1092); UI lives in route-loading.
+export { default } from "@/components/ui/route-loading";


### PR DESCRIPTION
`/admin` sits outside `(platform)`, so it picked up neither the shared route loading markers from #1106 nor a group error boundary. Every nav click sat on the previous screen while `requireAdmin()` did its `getUser()` plus `admin_users` read, and a server throw in the panel escalated to the root `app/error.tsx` — the full-screen, hardcoded-English page — taking the console shell and nav rail with it.

Six loading markers (the `/admin` root plus courses, moderation, insights, status, content), each the same two-line re-export as the ten `(platform)` ones. The error boundary lives in the `admin` segment so it renders in the layout's children slot: the rail stays usable and the reader can retry. It reuses the existing `error` namespace, so no new message keys.

The `deploy` and `publish` stubs deliberately get no marker. They only `redirect()` — a spinner there would flash and vanish — and the `admin` root boundary already covers the transition.

Locally: `tsc --noEmit` clean, lint clean (only the pre-existing import/order warnings), `next build` compiles with all eight admin routes intact, and `vitest run` is 3113 passing across 326 files with no failures. No test for the boundaries themselves — the ten sibling markers and both sibling `error.tsx` files are untested, and I did not want to invent a convention here.

Closes #1133
