### PR TITLE
refactor(admin): make Program Status say which chain it is on

### DIFF
--- a/apps/web/src/app/[locale]/admin/__tests__/deploy-client.test.tsx
+++ b/apps/web/src/app/[locale]/admin/__tests__/deploy-client.test.tsx
@@ -3,9 +3,9 @@ import type { ReactElement } from "react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { NextIntlClientProvider } from "next-intl";
+import messages from "@/messages/en.json";
 import type { AdminStatus } from "../admin-status-types";
 import { DeployClient } from "../courses/deploy-client";
-import messages from "@/messages/en.json";
 
 function renderWithIntl(ui: ReactElement) {
   return render(
@@ -29,6 +29,7 @@ vi.mock("@/components/admin/course-sync-table", () => ({
 
 const status: AdminStatus = {
   program: {
+    network: "devnet",
     deployed: true,
     programId: "AcademyProgram1111111111111111111111111111",
     configPda: "Config11111111111111111111111111111111111",

--- a/apps/web/src/app/[locale]/admin/__tests__/status-client.test.tsx
+++ b/apps/web/src/app/[locale]/admin/__tests__/status-client.test.tsx
@@ -3,9 +3,9 @@ import type { ReactElement } from "react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { NextIntlClientProvider } from "next-intl";
+import messages from "@/messages/en.json";
 import type { AdminStatus } from "../admin-status-types";
 import { StatusClient } from "../status/status-client";
-import messages from "@/messages/en.json";
 
 // DataResyncPanel carries its own behavior and posts to /api/admin/resync,
 // so it is stubbed out here.
@@ -15,6 +15,7 @@ vi.mock("@/components/admin/data-resync-panel", () => ({
 
 const status: AdminStatus = {
   program: {
+    network: "devnet",
     deployed: true,
     programId: "AcademyProgram1111111111111111111111111111",
     configPda: "Config11111111111111111111111111111111111",
@@ -143,13 +144,65 @@ describe("StatusClient", () => {
     await waitFor(() => {
       expect(screen.getByTestId("data-resync-panel")).toBeInTheDocument();
     });
-    // No test-id on prod markup: locate the counts by their i18n'd labels.
-    const coursesLabel = screen.getByText(`${messages.admin.counts.courses}:`);
+    // No test-id on prod markup: the counts are a `<dl>`, so each label's
+    // `<dd>` sibling carries the number.
+    const coursesLabel = screen.getByText(messages.admin.counts.courses);
     expect(coursesLabel.nextElementSibling).toHaveTextContent("2");
     const achievementsLabel = screen.getByText(
-      `${messages.admin.counts.achievements}:`
+      messages.admin.counts.achievements
     );
     expect(achievementsLabel.nextElementSibling).toHaveTextContent("1");
+  });
+
+  // #1140: the network used to be the literal string "devnet", so this screen
+  // would have kept saying "devnet" while pointed at mainnet.
+  it("renders the network the server reported, not a literal", async () => {
+    mockStatusFetch({
+      ...status,
+      program: { ...status.program, network: "mainnet" },
+    });
+    renderWithIntl(<StatusClient />);
+
+    await waitFor(() => {
+      expect(screen.getByText("mainnet")).toBeInTheDocument();
+    });
+    expect(screen.queryByText("devnet")).not.toBeInTheDocument();
+  });
+
+  it("says 'unknown' when the server could not tell which chain it is on", async () => {
+    mockStatusFetch({
+      ...status,
+      program: { ...status.program, network: "unknown" },
+    });
+    renderWithIntl(<StatusClient />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(messages.admin.programBar.networkUnknown)
+      ).toBeInTheDocument();
+    });
+    expect(screen.queryByText("devnet")).not.toBeInTheDocument();
+    expect(screen.queryByText("mainnet")).not.toBeInTheDocument();
+  });
+
+  it("explains an empty payload instead of rendering nothing", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, json: async () => null } as Response)
+      .mockResolvedValue({ ok: true, json: async () => status } as Response);
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderWithIntl(<StatusClient />);
+    await waitFor(() => {
+      expect(
+        screen.getByText(messages.admin.states.unavailable)
+      ).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    await waitFor(() => {
+      expect(screen.getByText("devnet")).toBeInTheDocument();
+    });
   });
 
   it("refetches on the program-bar Refresh button", async () => {

--- a/apps/web/src/app/[locale]/admin/__tests__/use-admin-status.test.tsx
+++ b/apps/web/src/app/[locale]/admin/__tests__/use-admin-status.test.tsx
@@ -6,6 +6,7 @@ import { useAdminStatus } from "../use-admin-status";
 
 const status: AdminStatus = {
   program: {
+    network: "devnet",
     deployed: true,
     programId: "AcademyProgram1111111111111111111111111111",
     configPda: "Config11111111111111111111111111111111111",

--- a/apps/web/src/app/[locale]/admin/admin-status-types.ts
+++ b/apps/web/src/app/[locale]/admin/admin-status-types.ts
@@ -8,6 +8,7 @@
 import type { AwardT } from "@superteam-lms/content-schema";
 import type { DiffEntry } from "@/lib/admin/sync-diff";
 import type { ChainDriftState, CourseContentDrift } from "@/lib/github/drift";
+import type { RpcNetwork } from "@/lib/solana/network";
 
 // Re-exported so UI components share the diff engine's entry shape instead of
 // carrying duplicate local copies (SP3-C Task 2 consolidation).
@@ -86,6 +87,13 @@ export interface AchievementStatus {
 
 export interface AdminStatus {
   program: {
+    /**
+     * Which chain the server's own `SOLANA_RPC_URL` points at (#1140). Derived
+     * server-side because the client has no honest way to know: the status
+     * screen used to print the literal string "devnet", which would have kept
+     * saying "devnet" on mainnet.
+     */
+    network: RpcNetwork;
     deployed: boolean;
     programId: string;
     configPda: string | null;

--- a/apps/web/src/app/[locale]/admin/content/__tests__/achievements-subview.test.tsx
+++ b/apps/web/src/app/[locale]/admin/content/__tests__/achievements-subview.test.tsx
@@ -3,9 +3,9 @@ import type { ReactElement } from "react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import { NextIntlClientProvider } from "next-intl";
+import messages from "@/messages/en.json";
 import type { AdminStatus } from "../../admin-status-types";
 import { AchievementsSubview } from "../achievements-subview";
-import messages from "@/messages/en.json";
 
 function renderWithIntl(ui: ReactElement) {
   return render(
@@ -17,6 +17,7 @@ function renderWithIntl(ui: ReactElement) {
 
 const status: AdminStatus = {
   program: {
+    network: "devnet",
     deployed: true,
     programId: "AcademyProgram1111111111111111111111111111",
     configPda: "Config11111111111111111111111111111111111",

--- a/apps/web/src/app/[locale]/admin/status/page.tsx
+++ b/apps/web/src/app/[locale]/admin/status/page.tsx
@@ -2,9 +2,9 @@ import { getTranslations } from "next-intl/server";
 import { StatusClient } from "./status-client";
 
 /**
- * `/admin/status` — the console's default screen (the `/admin` root
- * redirects here on a valid session): program-status bar + deploy counts +
- * data resync, relocated from the stacked admin page (SP3-A Task 3).
+ * `/admin/status` — where the console stands: which chain it is pointed at,
+ * whether the program is initialized there, how much content is deployed, and
+ * the per-wallet data resync. The `/admin` root opens on Courses, not here.
  */
 export default async function AdminStatusPage() {
   const t = await getTranslations("admin");

--- a/apps/web/src/app/[locale]/admin/status/status-client.tsx
+++ b/apps/web/src/app/[locale]/admin/status/status-client.tsx
@@ -1,17 +1,50 @@
 "use client";
 
+import type { ReactNode } from "react";
 import { useTranslations } from "next-intl";
-import { useAdminStatus } from "../use-admin-status";
+import type { RpcNetwork } from "@/lib/solana/network";
+import {
+  AdminBadge,
+  type AdminBadgeTone,
+} from "@/components/admin/admin-badge";
+import { AdminButton } from "@/components/admin/admin-button";
+import { AdminCard } from "@/components/admin/admin-card";
 import { DataResyncPanel } from "@/components/admin/data-resync-panel";
+import { useAdminStatus } from "../use-admin-status";
 
 /**
- * `/admin/status` client (SP3-A Task 3): the inline program-status bar
- * relocated from the deleted stacked `admin-client.tsx`, plus the deploy
- * counts and `<DataResyncPanel/>`. The `/api/admin/status` fetch +
- * loading/error/refetch now live in the shared `useAdminStatus` hook (SP3-D);
- * the manual Refresh button restores the affordance the bar lost in the
- * route split, wired to the hook's `refetch`.
+ * `/admin/status` client: which chain the console is pointed at, whether the
+ * program is initialized there, how much content is deployed, and the resync
+ * tool. Data comes from the shared `useAdminStatus` hook (`GET
+ * /api/admin/status`), same as `/admin/courses`.
+ *
+ * The network is a server-derived field, not a literal (#1140) — the screen
+ * whose job is telling an operator which chain they are on cannot be the one
+ * screen that guesses.
  */
+
+/**
+ * `mainnet` reads as attention rather than "fine": it is the chain where a
+ * mistaken deploy is permanent. `unknown` is the same tone because the RPC
+ * host named no cluster, so mainnet has not been ruled out.
+ */
+const NETWORK_TONE: Record<RpcNetwork, AdminBadgeTone> = {
+  devnet: "neutral",
+  mainnet: "warning",
+  unknown: "warning",
+};
+
+function Field({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <div className="space-y-1">
+      <dt className="text-xs font-semibold uppercase tracking-wide text-text-3">
+        {label}
+      </dt>
+      <dd className="text-sm text-text">{children}</dd>
+    </div>
+  );
+}
+
 export function StatusClient() {
   const t = useTranslations("admin");
   const { status, loading, error, refetch } = useAdminStatus();
@@ -24,74 +57,120 @@ export function StatusClient() {
     );
   }
 
+  // A failed status fetch is transient/recoverable — neutral `streak`, not the
+  // blocking `danger` red. Same tone as the sibling deploy screen.
   if (error) {
     return (
-      <div className="rounded-md border border-danger bg-danger-light p-4 text-sm text-danger">
+      <div
+        role="alert"
+        className="flex flex-wrap items-center gap-3 rounded-md border border-streak bg-streak-light p-4 text-sm text-streak"
+      >
         {t(error === "network" ? "states.networkError" : "states.fetchError")}
-        <button onClick={refetch} className="ml-3 underline hover:no-underline">
-          {t("states.retry")}
-        </button>
+        <AdminButton onClick={refetch}>{t("states.retry")}</AdminButton>
       </div>
     );
   }
 
-  if (!status) return null;
+  // Not loading, no error, no payload: rare, but a blank screen used to be the
+  // whole answer here. Say so and offer the same retry.
+  if (!status) {
+    return (
+      <AdminCard className="flex flex-wrap items-center gap-3 text-sm text-text-2">
+        {t("states.unavailable")}
+        <AdminButton onClick={refetch}>{t("states.retry")}</AdminButton>
+      </AdminCard>
+    );
+  }
 
   const { program, courses, achievements } = status;
 
   return (
     <div className="space-y-8">
-      {/* Program status bar */}
-      <div className="rounded-lg border border-border bg-card p-4 text-sm shadow-card">
-        <div className="flex flex-wrap items-center gap-3">
-          <span className="text-text-3">{t("programBar.network")}:</span>
-          <span className="text-text">devnet</span>
-          <span className="text-border">|</span>
-          <span className="text-text-3">{t("programBar.program")}:</span>
-          <span className="font-mono text-xs text-text">
-            {program.programId.slice(0, 8)}...{program.programId.slice(-4)}
-          </span>
-          <span className="text-border">|</span>
-          <span className="text-text-3">{t("programBar.config")}:</span>
-          {program.deployed ? (
-            <span className="text-success">{t("programBar.found")}</span>
-          ) : (
-            <span className="text-danger">
-              {t("programBar.notInitialized")}
-            </span>
-          )}
-          {!program.authorityMatch.matches && (
-            <span className="ml-2 text-xs text-accent">
-              {t("programBar.authorityMismatch")}
-            </span>
-          )}
-          <button
-            onClick={refetch}
-            className="ml-auto rounded-md border border-border bg-card px-3 py-1 text-xs text-text-2 shadow-push-sm transition-all hover:bg-subtle active:translate-y-[2px] active:shadow-push-active"
+      <AdminCard
+        as="section"
+        aria-labelledby="admin-status-program"
+        className="space-y-4"
+      >
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <h3
+            id="admin-status-program"
+            className="font-display text-base font-bold text-text"
           >
-            {t("states.refresh")}
-          </button>
+            {t("statusScreen.programHeading")}
+          </h3>
+          <AdminButton onClick={refetch}>{t("states.refresh")}</AdminButton>
         </div>
-      </div>
 
-      {/* Deploy counts */}
-      <div className="flex flex-wrap items-center gap-3 rounded-lg border border-border bg-card p-4 text-sm shadow-card">
-        <span className="text-text-3">{t("counts.courses")}:</span>
-        <span className="text-text">{courses.length}</span>
-        <span className="text-border">|</span>
-        <span className="text-text-3">{t("counts.achievements")}:</span>
-        <span className="text-text">{achievements.length}</span>
-      </div>
+        <dl className="grid gap-4 sm:grid-cols-3">
+          <Field label={t("programBar.network")}>
+            <AdminBadge tone={NETWORK_TONE[program.network]}>
+              {program.network === "unknown"
+                ? t("programBar.networkUnknown")
+                : program.network}
+            </AdminBadge>
+          </Field>
+          <Field label={t("programBar.program")}>
+            <span className="font-mono text-xs text-text">
+              {program.programId.slice(0, 8)}...{program.programId.slice(-4)}
+            </span>
+          </Field>
+          <Field label={t("programBar.config")}>
+            <AdminBadge tone={program.deployed ? "success" : "danger"}>
+              {program.deployed
+                ? t("programBar.found")
+                : t("programBar.notInitialized")}
+            </AdminBadge>
+          </Field>
+        </dl>
 
-      {/* Data Resync */}
-      <section>
-        <h3 className="mb-4 font-display text-lg font-bold text-text">
+        {!program.authorityMatch.matches && (
+          <p
+            role="alert"
+            className="rounded-md border border-danger bg-danger-light p-3 text-xs text-danger"
+          >
+            {t("programBar.authorityMismatch")}
+          </p>
+        )}
+      </AdminCard>
+
+      <AdminCard
+        as="section"
+        aria-labelledby="admin-status-counts"
+        className="space-y-4"
+      >
+        <h3
+          id="admin-status-counts"
+          className="font-display text-base font-bold text-text"
+        >
+          {t("statusScreen.countsHeading")}
+        </h3>
+        <dl className="grid gap-4 sm:grid-cols-2">
+          <Field label={t("counts.courses")}>
+            <span className="font-display text-2xl font-bold text-text">
+              {courses.length}
+            </span>
+          </Field>
+          <Field label={t("counts.achievements")}>
+            <span className="font-display text-2xl font-bold text-text">
+              {achievements.length}
+            </span>
+          </Field>
+        </dl>
+      </AdminCard>
+
+      <AdminCard
+        as="section"
+        aria-labelledby="admin-status-resync"
+        className="space-y-4"
+      >
+        <h3
+          id="admin-status-resync"
+          className="font-display text-base font-bold text-text"
+        >
           {t("resync.heading")}
         </h3>
-        <div className="rounded-lg border border-border bg-card p-4 shadow-card">
-          <DataResyncPanel />
-        </div>
-      </section>
+        <DataResyncPanel />
+      </AdminCard>
     </div>
   );
 }

--- a/apps/web/src/app/api/admin/status/route.ts
+++ b/apps/web/src/app/api/admin/status/route.ts
@@ -18,6 +18,7 @@ import {
   getProgramId,
 } from "@/lib/solana/pda";
 import { decodeCourse, type DecodedCourse } from "@/lib/solana/academy-reads";
+import { networkFromRpcUrl } from "@/lib/solana/network";
 import {
   verifyAuthorityMatchesConfig,
   isAdminSignerReady,
@@ -316,6 +317,7 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
 
   return NextResponse.json({
     program: {
+      network: networkFromRpcUrl(serverEnv.SOLANA_RPC_URL),
       deployed: authorityCheck.matches,
       programId: getProgramId().toBase58(),
       configPda: authorityCheck.configAuthority ? "found" : null,

--- a/apps/web/src/lib/solana/__tests__/network.test.ts
+++ b/apps/web/src/lib/solana/__tests__/network.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterAll } from "vitest";
-import { resolveSolanaNetwork } from "../network";
+import { resolveSolanaNetwork, networkFromRpcUrl } from "../network";
 
 const ORIGINAL = process.env.NEXT_PUBLIC_SOLANA_NETWORK;
 
@@ -38,5 +38,42 @@ describe("resolveSolanaNetwork", () => {
       cluster: "mainnet-beta",
       label: "Mainnet",
     });
+  });
+});
+
+describe("networkFromRpcUrl", () => {
+  it("reads devnet out of the host", () => {
+    expect(networkFromRpcUrl("https://api.devnet.solana.com")).toBe("devnet");
+    expect(networkFromRpcUrl("https://devnet.helius-rpc.com/?api-key=x")).toBe(
+      "devnet"
+    );
+  });
+
+  it("reads mainnet out of the host, including mainnet-beta", () => {
+    expect(networkFromRpcUrl("https://api.mainnet-beta.solana.com")).toBe(
+      "mainnet"
+    );
+    expect(networkFromRpcUrl("https://mainnet.helius-rpc.com/?api-key=x")).toBe(
+      "mainnet"
+    );
+  });
+
+  it("says unknown for a host that names no cluster", () => {
+    expect(networkFromRpcUrl("https://rpc.internal.example.com")).toBe(
+      "unknown"
+    );
+    expect(networkFromRpcUrl("http://localhost:8899")).toBe("unknown");
+  });
+
+  it("says unknown rather than throwing on an unparseable URL", () => {
+    expect(networkFromRpcUrl("")).toBe("unknown");
+    expect(networkFromRpcUrl("not a url")).toBe("unknown");
+  });
+
+  it("ignores cluster names outside the host", () => {
+    expect(networkFromRpcUrl("https://rpc.example.com/devnet")).toBe("unknown");
+    expect(networkFromRpcUrl("https://rpc.example.com/?net=mainnet")).toBe(
+      "unknown"
+    );
   });
 });

--- a/apps/web/src/lib/solana/network.ts
+++ b/apps/web/src/lib/solana/network.ts
@@ -20,3 +20,35 @@ export function resolveSolanaNetwork(): SolanaNetworkInfo {
     label: network.charAt(0).toUpperCase() + network.slice(1),
   };
 }
+
+/**
+ * The chain an RPC endpoint points at, as far as its host can tell. `unknown`
+ * is an answer, not a fallback: a private or proxied endpoint that names no
+ * cluster must read as unknown rather than be assumed to be devnet.
+ */
+export type RpcNetwork = "devnet" | "mainnet" | "unknown";
+
+/**
+ * Derive the network from the RPC URL instead of `NEXT_PUBLIC_SOLANA_NETWORK`,
+ * which is optional, unvalidated, and free to disagree with the endpoint the
+ * server actually reads through (#1140). The URL is where the reads go, so it
+ * is the one source that cannot quietly lie about which chain an operator is
+ * looking at.
+ *
+ * Matched on the host only — a path or query segment is not evidence of a
+ * cluster, and matching the whole URL would let an api-key param pick the
+ * label. A host naming both resolves to mainnet: over-claiming makes an
+ * operator more careful, under-claiming is the trap this fixes.
+ */
+export function networkFromRpcUrl(rpcUrl: string): RpcNetwork {
+  let host: string;
+  try {
+    host = new URL(rpcUrl).host.toLowerCase();
+  } catch {
+    return "unknown";
+  }
+  // "mainnet" is a substring of "mainnet-beta", so this covers both spellings.
+  if (host.includes("mainnet")) return "mainnet";
+  if (host.includes("devnet")) return "devnet";
+  return "unknown";
+}

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -1261,7 +1261,8 @@
       "fetchError": "Failed to fetch status",
       "networkError": "Network error",
       "retry": "Retry",
-      "refresh": "Refresh"
+      "refresh": "Refresh",
+      "unavailable": "No status was returned."
     },
     "programBar": {
       "network": "Network",
@@ -1269,7 +1270,12 @@
       "config": "Config",
       "found": "Found",
       "notInitialized": "Not initialized",
+      "networkUnknown": "unknown",
       "authorityMismatch": "Authority mismatch — check PROGRAM_AUTHORITY_SECRET"
+    },
+    "statusScreen": {
+      "programHeading": "Program",
+      "countsHeading": "Deployed content"
     },
     "deployScreen": {
       "coursesHeading": "Courses",

--- a/apps/web/src/messages/es.json
+++ b/apps/web/src/messages/es.json
@@ -1261,7 +1261,8 @@
       "fetchError": "Error al obtener el estado",
       "networkError": "Error de red",
       "retry": "Reintentar",
-      "refresh": "Actualizar"
+      "refresh": "Actualizar",
+      "unavailable": "No se devolvió ningún estado."
     },
     "programBar": {
       "network": "Red",
@@ -1269,7 +1270,12 @@
       "config": "Config",
       "found": "Encontrada",
       "notInitialized": "No inicializada",
+      "networkUnknown": "desconocida",
       "authorityMismatch": "Discrepancia de autoridad — verifica PROGRAM_AUTHORITY_SECRET"
+    },
+    "statusScreen": {
+      "programHeading": "Programa",
+      "countsHeading": "Contenido desplegado on-chain"
     },
     "deployScreen": {
       "coursesHeading": "Cursos",

--- a/apps/web/src/messages/pt-BR.json
+++ b/apps/web/src/messages/pt-BR.json
@@ -1261,7 +1261,8 @@
       "fetchError": "Falha ao buscar o status",
       "networkError": "Erro de rede",
       "retry": "Tentar novamente",
-      "refresh": "Atualizar"
+      "refresh": "Atualizar",
+      "unavailable": "Nenhum status foi retornado."
     },
     "programBar": {
       "network": "Rede",
@@ -1269,7 +1270,12 @@
       "config": "Config",
       "found": "Encontrada",
       "notInitialized": "Não inicializada",
+      "networkUnknown": "desconhecida",
       "authorityMismatch": "Divergência de autoridade — verifique PROGRAM_AUTHORITY_SECRET"
+    },
+    "statusScreen": {
+      "programHeading": "Programa",
+      "countsHeading": "Conteúdo publicado on-chain"
     },
     "deployScreen": {
       "coursesHeading": "Cursos",


### PR DESCRIPTION
The network label on `/admin/status` was the literal string `devnet`. The screen whose whole job is telling an operator which chain they are looking at would have said "devnet" on mainnet.

It now comes from the server: `GET /api/admin/status` returns `program.network`, derived from `SOLANA_RPC_URL`'s host by `networkFromRpcUrl()`. A host that names no cluster reads `unknown` rather than falling back to devnet. `NEXT_PUBLIC_SOLANA_NETWORK` is deliberately not wired in — it is optional, unvalidated, and free to disagree with the endpoint the reads actually go through.

The rest is the renovation the issue asks for: the three hand-rolled `rounded-lg border border-border bg-card` shells become `AdminCard`, the pipe-separated text runs become labelled `<dl>` fields with `AdminBadge`, Refresh/Retry become `AdminButton`, the error tone drops to `streak` to match `deploy-client.tsx`, and `if (!status) return null` now says what happened and offers a retry. The stale `status/page.tsx` docblock claiming this is the console's default screen is fixed — `/admin` opens on Courses.

Red-proof: with the fix reverted to the literal, the two new network tests fail (2 failed | 7 passed); restored, 9 pass.

88 tests pass across the admin, `lib/solana/network` and messages suites; `tsc --noEmit` clean; eslint + prettier clean on the changed files.

Closes #1140