### PR TITLE
feat(content): make course listing visibility a content flag

### DIFF
--- a/apps/web/src/app/[locale]/(marketing)/page.tsx
+++ b/apps/web/src/app/[locale]/(marketing)/page.tsx
@@ -1,6 +1,6 @@
 import { ERROR_IDS } from "@/constants/errorIds";
 import { getAllCourses, getDeployedAchievements } from "@/lib/content/queries";
-import { resolveHeroHref } from "@/lib/courses/entry-lesson";
+import { resolveFlagshipLessonHref } from "@/lib/courses/entry-lesson";
 import { logError } from "@/lib/logging";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { LandingPageClient } from "./landing-client";
@@ -74,9 +74,7 @@ export default async function LandingPage({
   const [courses, achievements, flagshipLessonHref, stats] = await Promise.all([
     getAllCourses(),
     getDeployedAchievements(),
-    // The event booth course page once it's synced; the LX-A1 flagship lesson
-    // deep-link (or catalog) until then — resolveHeroHref owns that gate.
-    resolveHeroHref(locale),
+    resolveFlagshipLessonHref(locale),
     fetchPlatformStats(),
   ]);
 

--- a/apps/web/src/lib/content/__tests__/unlisted-courses.test.ts
+++ b/apps/web/src/lib/content/__tests__/unlisted-courses.test.ts
@@ -6,20 +6,26 @@ import type { DeploymentStatus } from "../deployments";
 import { UNLISTED_COURSE_IDS, isUnlistedCourse } from "@/lib/courses/unlisted";
 import {
   getAllCourses,
+  getAllCourseTags,
   getAllCoursesIncludingUnlisted,
+  getAllLearningPaths,
   getCourseBySlug,
   getRecommendedCourses,
 } from "../queries";
-import { resolveHeroHref } from "@/lib/courses/entry-lesson";
 
 /**
- * Unlisted = hidden from listings, reachable by direct link — asserted against
- * the REAL committed bundle (the entry-course-live pattern), mocking only the
- * on-chain sync gate so every course reads as synced+active. A course that is
- * both in UNLISTED_COURSE_IDS and absent from getAllCourses here is proven
- * hidden on every surface that lists through it (catalog, landing count,
- * sitemap); getCourseBySlug still resolving is what keeps the direct link —
- * and the landing hero that uses it — alive.
+ * Course visibility is a CONTENT decision, not a code one (#1137).
+ *
+ * The predicate under test is `isCourseUnlisted` in ../queries.ts:
+ * `c.unlisted === true || isUnlistedCourse(c._id)`. The first clause is the
+ * new content flag (packages/content-schema/src/course.ts, carried through the
+ * projector); the second is the outgoing hardcoded id set, kept only until the
+ * content repo sets the flag and `content.lock` bumps (Part 2).
+ *
+ * Asserted against the REAL committed bundle (the entry-course-live pattern),
+ * mocking only the on-chain sync gate so every course reads as synced+active.
+ * Today's bundle carries no `unlisted: true` course, so the bundle exercises
+ * the fallback half; the flag half is proven on doc shapes.
  */
 
 vi.mock("@/lib/content/deployments", async (importActual) => {
@@ -50,19 +56,38 @@ vi.mock("@/lib/content/deployments", async (importActual) => {
 const PILULA_ID = "course-pilula-solana-superteam";
 const PILULA_SLUG = "pilula-solana-superteam";
 
-describe("unlisted courses — hidden from listings, live by direct link", () => {
-  it("the Pílula course is registered as unlisted", () => {
-    expect(isUnlistedCourse(PILULA_ID)).toBe(true);
+/** Mirrors `isCourseUnlisted` (lib/content/queries.ts), which is not exported. */
+const hidden = (c: { _id: string; unlisted?: unknown }) =>
+  c.unlisted === true || isUnlistedCourse(c._id);
+
+describe("the unlisted predicate — content flag OR the outgoing fallback", () => {
+  it("hides a course the CONTENT flags, with no entry in the id set", () => {
+    expect(hidden({ _id: "course-anything", unlisted: true })).toBe(true);
+    expect(isUnlistedCourse("course-anything")).toBe(false);
   });
 
-  it("every unlisted id exists in the bundle — a stale entry is dead config", async () => {
+  it("still hides the one course the outgoing constant covers", () => {
+    // The flag cannot be set until the content PR lands and content.lock
+    // bumps; without this clause the Pílula would pop back into the catalog
+    // the moment this PR deployed.
+    expect(hidden({ _id: PILULA_ID })).toBe(true);
+  });
+
+  it("leaves a listed course alone, flag absent or explicitly false", () => {
+    expect(hidden({ _id: "course-x" })).toBe(false);
+    expect(hidden({ _id: "course-x", unlisted: false })).toBe(false);
+  });
+
+  it("every fallback id exists in the bundle — a stale entry is dead config", async () => {
     const all = await getAllCoursesIncludingUnlisted();
     const ids = new Set(all.map((c) => c._id));
     for (const id of UNLISTED_COURSE_IDS) {
       expect(ids.has(id), `unlisted id "${id}" not in the bundle`).toBe(true);
     }
   });
+});
 
+describe("unlisted courses — hidden from every listing surface", () => {
   it("the catalog listing excludes it; the admin listing keeps it", async () => {
     const listed = await getAllCourses();
     expect(listed.some((c) => c._id === PILULA_ID)).toBe(false);
@@ -76,18 +101,32 @@ describe("unlisted courses — hidden from listings, live by direct link", () =>
     expect(recommended.some((c) => c._id === PILULA_ID)).toBe(false);
   });
 
+  it("the catalog filter chips never carry its tags", async () => {
+    // The #1137 leak: getAllCourseTags had no listing filter, so an unlisted
+    // course's skills became catalog filter chips — chips that then matched
+    // nothing, because the course behind them is filtered out of the results.
+    const tagged = await getAllCourseTags();
+    expect(tagged.some((c) => c._id === PILULA_ID)).toBe(false);
+  });
+
+  it("no learning path surfaces it as a member", async () => {
+    // A path is a listing surface too: hiding that held only on the catalog
+    // tab would not be hiding. Green either way today — the Pílula belongs to
+    // no path — so this is a guard for the day one joins, not a red-proof.
+    const paths = await getAllLearningPaths();
+    const members = paths.flatMap((p) => p.courses ?? []);
+    expect(members.some((c) => c._id === PILULA_ID)).toBe(false);
+  });
+});
+
+describe("unlisted is a listing property, not an access gate", () => {
   it("the direct link stays live — getCourseBySlug still resolves it", async () => {
     const course = await getCourseBySlug(PILULA_SLUG);
     expect(course?._id).toBe(PILULA_ID);
   });
 
-  it("the landing hero does NOT promote it — it falls back to the flagship deep-link", async () => {
-    // The homepage CTA is the biggest discovery surface of all; promoting a
-    // course there while hiding it from the catalog would be the two halves
-    // of the site contradicting each other. The QR/direct link keeps working
-    // (previous test); only the hero PROMOTION falls back.
-    const href = await resolveHeroHref("en");
-    expect(href).not.toContain(PILULA_SLUG);
-    expect(href).toMatch(/^\/en\/courses\/[^/]+\/lessons\/[^/]+$/);
+  it("admin surfaces see it — an unlisted course must stay repairable", async () => {
+    const admin = await getAllCoursesIncludingUnlisted();
+    expect(admin.some((c) => c._id === PILULA_ID)).toBe(true);
   });
 });

--- a/apps/web/src/lib/content/compile/projector.ts
+++ b/apps/web/src/lib/content/compile/projector.ts
@@ -137,6 +137,10 @@ export function projectContent(
       prerequisiteCourse: c.prerequisiteCourse
         ? weakRef(c.prerequisiteCourse)
         : undefined,
+      // `|| undefined` so the default-false case emits no key at all: every
+      // course in today's bundle is listed, so the generated JSON stays
+      // byte-identical and the CI content-freshness gate stays green.
+      unlisted: c.unlisted || undefined,
       modules: c.modules.map((m) => ({
         _type: "courseModule",
         _key: m.key,

--- a/apps/web/src/lib/content/queries.ts
+++ b/apps/web/src/lib/content/queries.ts
@@ -200,15 +200,27 @@ async function gatedCourses(): Promise<CourseDoc[]> {
 // --- Public / catalog queries (gated: synced + active) ---
 
 /**
- * Catalog listing: synced+active AND listed. Unlisted courses
- * (lib/courses/unlisted.ts) stay reachable by direct URL — getCourseBySlug /
- * getLessonBySlug carry no listing filter — but never appear in the catalog,
- * the landing count, the sitemap, or recommendations.
+ * Listing visibility (#1137): hidden from discovery because the CONTENT says
+ * so — `unlisted: true` on the course doc, carried through the projector into
+ * the bundle. Unlisted is a LISTING property, not an access gate: the course
+ * page, its lessons, enrolment and completion keep working for anyone holding
+ * the URL. What goes away is the catalog, the landing count, the sitemap,
+ * recommendations, the filter chips, and path membership.
+ *
+ * The second clause is the app-code constant this replaces
+ * (lib/courses/unlisted.ts), kept as a temporary fallback: the flag lives in
+ * the content repo, so today's one unlisted course can only set it once that
+ * content PR lands and `content.lock` bumps (Part 2 of #1137). Drop the
+ * clause — and unlisted.ts with it — at that bump.
  */
+function isCourseUnlisted(c: CourseDoc): boolean {
+  return c.unlisted === true || isUnlistedCourse(c._id);
+}
+
 export async function getAllCourses(): Promise<Course[]> {
   const courses = await gatedCourses();
   return courses
-    .filter((c) => !isUnlistedCourse(c._id))
+    .filter((c) => !isCourseUnlisted(c))
     .map((c) => projectCourse(c, projectionDeps))
     .sort(byTrackLevel);
 }
@@ -333,8 +345,11 @@ export async function getAllLearningPaths(): Promise<LearningPath[]> {
     const memberIds = new Set(pathCourseRefIds(p));
     // Iterate the store (doc order) so member ordering matches GROQ's
     // `*[_type=="course" && _id in ^.courses[]._ref && …]` document order.
+    // A path is a listing surface: an unlisted course must not surface through
+    // one, or the hiding would only hold on the catalog tab.
     const members = [...coursesById.values()].filter(
-      (c) => memberIds.has(c._id) && isSynced(map.get(c._id))
+      (c) =>
+        memberIds.has(c._id) && isSynced(map.get(c._id)) && !isCourseUnlisted(c)
     );
     return projectLearningPath(p, members, projectionDeps);
   });
@@ -501,7 +516,7 @@ export async function getRecommendedCourses(
         isSynced(map.get(c._id)) &&
         // Recommendations are a listing surface — never surface an unlisted
         // course, even to a learner who found it by direct link.
-        !isUnlistedCourse(c._id)
+        !isCourseUnlisted(c)
     )
     .map((c) => projectRecommended(c, learningPathTitleFor(c._id)))
     .sort(byTrackLevel);
@@ -511,14 +526,18 @@ export async function getAllCourseTags(): Promise<
   { _id: string; title: string; tags: string[]; totalLessons: number }[]
 > {
   const courses = await gatedCourses();
-  return courses
-    .filter((c) => Array.isArray(c.tags))
-    .map((c) => ({
-      _id: c._id,
-      title: str(c.title) as string,
-      tags: c.tags as string[],
-      totalLessons: countCourseLessons(c),
-    }));
+  return (
+    courses
+      // Filter chips are a listing surface too — an unlisted course's tags used
+      // to leak into the catalog filters, offering a chip that matched nothing.
+      .filter((c) => !isCourseUnlisted(c) && Array.isArray(c.tags))
+      .map((c) => ({
+        _id: c._id,
+        title: str(c.title) as string,
+        tags: c.tags as string[],
+        totalLessons: countCourseLessons(c),
+      }))
+  );
 }
 
 /**

--- a/apps/web/src/lib/courses/entry-lesson.ts
+++ b/apps/web/src/lib/courses/entry-lesson.ts
@@ -1,13 +1,8 @@
-import {
-  getCourseIdBySlug,
-  getCourseLessons,
-  getCourseSlugById,
-} from "@/lib/content/queries";
+import { getCourseLessons, getCourseSlugById } from "@/lib/content/queries";
 import {
   DEFAULT_SEGMENT,
   SEGMENT_ENTRY_COURSE,
 } from "@/lib/courses/learner-segment";
-import { isUnlistedCourse } from "@/lib/courses/unlisted";
 
 /**
  * Resolves a content course id into its first-lesson deep-link for `locale`.
@@ -46,29 +41,4 @@ export async function resolveFlagshipLessonHref(
   locale: string
 ): Promise<string> {
   return resolveEntryLessonHref(locale, SEGMENT_ENTRY_COURSE[DEFAULT_SEGMENT]);
-}
-
-/** The event booth micro-course (academy-courses#37). */
-const HERO_COURSE_SLUG = "pilula-solana-superteam";
-
-/**
- * The landing hero target: the Pílula COURSE page — the booth audience picks
- * a course, they don't get dropped mid-lesson — but only once that course is
- * deployed+synced (`getCourseIdBySlug` is the sync-gated read; the ungated
- * `getCourseById` would happily link a course whose page 404s). Until the
- * admin sync runs, the hero keeps the flagship lesson deep-link.
- *
- * UNLISTED demotes the hero too: unlisting removes a course from every
- * discovery surface, and the homepage's primary CTA is the biggest discovery
- * surface there is — promoting a course there while hiding it from the
- * catalog would be the two halves of the site contradicting each other. The
- * course page itself stays reachable (that is what unlisted means), so the
- * booth QR/direct links keep working; only the hero's PROMOTION falls back
- * to the flagship deep-link.
- */
-export async function resolveHeroHref(locale: string): Promise<string> {
-  const synced = await getCourseIdBySlug(HERO_COURSE_SLUG);
-  return synced && !isUnlistedCourse(synced._id)
-    ? `/${locale}/courses/${HERO_COURSE_SLUG}`
-    : resolveFlagshipLessonHref(locale);
 }

--- a/apps/web/src/lib/courses/unlisted.ts
+++ b/apps/web/src/lib/courses/unlisted.ts
@@ -1,18 +1,26 @@
 /**
+ * TEMPORARY FALLBACK — dies in Part 2 of #1137.
+ *
+ * Listing visibility now lives on the course document (`unlisted: true`,
+ * packages/content-schema/src/course.ts) and is read from the bundle by
+ * `isCourseUnlisted` in lib/content/queries.ts. That field lives in the
+ * content repo, so the one course hidden this way can only set it once the
+ * content PR lands and `content.lock` bumps. Until then this set is the
+ * second half of an OR, keeping the course hidden across the gap. At the
+ * bump, delete this file and the fallback clause.
+ *
+ * Do NOT add ids here — hiding a course is a content change.
+ *
+ * ---
  * Unlisted courses: reachable by direct link, absent from every listing.
  *
  * "Unlisted" is a LISTING property, not an access gate — the course page,
  * its lessons, enrolment, and completion all keep working for anyone who has
  * the URL. What goes away is discovery: the catalog, the landing course
- * count, the sitemap, and recommendations. That is the distribution model
- * for event/QR-code courses (the Pílula: handed out at the booth, not
- * browsed to), and it is why the landing hero may still deep-link an
- * unlisted course — a deliberate direct link is exactly the channel
- * unlisting preserves.
- *
- * App-side constant on purpose, same reasoning as SEGMENT_ENTRY_COURSE
- * (lib/courses/learner-segment.ts): listing changes ship with a code deploy,
- * not a content.lock bump through the two-repo staging cycle.
+ * count, the sitemap, recommendations, the catalogue filter chips, and path
+ * membership. That is the distribution model for event/QR-code courses (the
+ * Pílula: handed out at the booth, not browsed to) — a deliberate direct
+ * link is exactly the channel unlisting preserves.
  *
  * Admin surfaces must NOT consume this — sync/resync need to see every
  * course (`getAllCoursesIncludingUnlisted` in lib/content/queries.ts), or an

--- a/packages/content-lint/src/checks/gate4b-path-lifecycle.ts
+++ b/packages/content-lint/src/checks/gate4b-path-lifecycle.ts
@@ -6,10 +6,10 @@ import { diag, type Diagnostic } from "../diagnostics";
  * Gate 4b — path lifecycle flags must say what an empty shelf means (#627,
  * owner ruling 2026-07-28).
  *
- * The app hides a path with zero courses and reads neither `draft` nor
- * `retired` (the bundle's LearningPath type carries neither field). So an
- * emptied path is invisible either way, and the flags exist purely to record
- * intent. Before this gate, "retired" was spelled `draft: true` + `courses: []`
+ * The app hides a path with zero courses, and since #1141 it also hides one
+ * flagged `draft` or `retired` — so an emptied path is invisible either way,
+ * and the flags additionally record WHICH kind of emptiness it is. Before this
+ * gate, "retired" was spelled `draft: true` + `courses: []`
  * — indistinguishable from "coming soon", which is how #559 nearly shipped a
  * permanently unearnable `path-completed` achievement: the path looked merely
  * unfinished, so nothing flagged that its last course had been removed for good.

--- a/packages/content-schema/schema/course.schema.json
+++ b/packages/content-schema/schema/course.schema.json
@@ -75,6 +75,10 @@
       "type": "string",
       "pattern": "^course-[a-z0-9]+(?:-[a-z0-9]+)*$"
     },
+    "unlisted": {
+      "default": false,
+      "type": "boolean"
+    },
     "modules": {
       "minItems": 1,
       "type": "array",

--- a/packages/content-schema/src/course.ts
+++ b/packages/content-schema/src/course.ts
@@ -53,6 +53,21 @@ export const Course = z
      */
     thumbnail: z.string().min(1).optional(),
     prerequisiteCourse: CourseId.optional(),
+    /**
+     * Listed nowhere, live by direct link (#1137). The course page, its
+     * lessons, enrolment and completion all keep working for anyone holding
+     * the URL; what goes away is discovery — the catalogue, the landing
+     * count, the sitemap, recommendations, the catalogue filter chips, and
+     * path membership. That is the distribution model for event/QR-booth
+     * courses.
+     *
+     * This is the ONLY listing-visibility control: it is read at runtime by
+     * lib/content/queries.ts, so hiding a course is a content decision, not
+     * an app-code constant. "Gone" is a different state and already modelled
+     * twice over — `_draft/` parking keeps a course out of the bundle, and
+     * the admin deactivate toggle takes a deployed one off-chain-active.
+     */
+    unlisted: z.boolean().default(false),
     modules: z.array(CourseModule).min(1),
     // No authored `tags` field (#466 C3): a course's catalogue tags are
     // DERIVED — the compiler's projector computes them as the sorted,

--- a/packages/content-schema/src/path.ts
+++ b/packages/content-schema/src/path.ts
@@ -12,9 +12,10 @@ import { DIFFICULTIES } from "./constants";
  *   - `retired: true` — permanently emptied; the id is preserved because path
  *                       ids are permanent once live.
  *
- * Neither flag is read at runtime — hiding is empty-`courses`-only, and the
- * bundle's `LearningPath` type carries neither. They exist for the content
- * gates and for authors reading the file.
+ * Both flags ARE read at runtime: `getAllLearningPaths`
+ * (apps/web/src/lib/content/queries.ts) filters a draft or retired path out of
+ * the Paths tab (#1141) — visibility is a content decision, which is what
+ * replaced the hardcoded Coming-soon constant. The content gates read them too.
  *
  * content-lint gate 4b enforces the rest: a `retired` path MUST be empty, a
  * draft+empty path MUST also be retired (the implicit-retirement pattern that


### PR DESCRIPTION
Part 1 of #1137. Course visibility becomes a content flag: `unlisted: boolean` on the course schema, carried through the projector, read by `lib/content/queries.ts`. Part 2 is the content-repo PR that sets the flag on the Pílula plus the `content.lock` bump; Part 3 deletes the fallback.

**The fallback.** `lib/courses/unlisted.ts` stays as the second half of `c.unlisted === true || isUnlistedCourse(c._id)`. The flag lives in the content repo, so it can't be set until the lock bumps — without the OR, the Pílula would pop back into the catalog the moment this deployed. The file is marked for deletion at that bump.

**Two surfaces the id set never covered, now filtered.** `getAllCourseTags` had no listing filter at all, so an unlisted course's skills showed up as catalog filter chips — chips that matched nothing, because the course behind them was filtered out of the results. Fixed, with a red-proof. Path membership is filtered too (behaviour-neutral today: the Pílula belongs to no path).

**The dead hero override is gone.** `HERO_COURSE_SLUG` + the unlisted branch in `resolveHeroHref` could never fire: #1031 added the override, #1062 unlisted that same course, #1071 made the override refuse unlisted courses. The condition has been permanently false since. The landing now calls `resolveFlagshipLessonHref` directly — the branch it was already taking.

Untouched by design: `getCourseBySlug`, `getLessonBySlug`, `getCoursesByIds`, grading reads, and every admin query. Unlisted is a listing property, not an access gate — the QR/direct link keeps working, and admin surfaces must keep seeing the course or it could never be repaired.

Also corrects two comments in `path.ts` and `gate4b-path-lifecycle.ts` that still say `draft`/`retired` are never read at runtime — false once #1141 lands. **Ordering note:** those two lines are only accurate after #1141 merges. If this merges first, they're briefly ahead of the code.

Bundle recompile is byte-identical (`unlisted: c.unlisted || undefined` emits no key when false), so the CI freshness gate stays green.

Tests: 3117 pass across 326 web files, 177 content-schema, 132 content-lint. Red-proof: reverting the `getAllCourseTags` filter fails the chips test.

Skipped the optional admin `unlisted` badge — every course reads false until Part 2, so it would ship three locale strings for a badge nothing can display.
