### PR TITLE
feat(admin): let the moderation queue actually moderate

### DIFF
--- a/apps/web/src/app/api/CLAUDE.md
+++ b/apps/web/src/app/api/CLAUDE.md
@@ -98,7 +98,7 @@ ADMIN_SECRET/HMAC-cookie system and its `/api/admin/auth` login route are gone.
 | `/api/admin/courses/recreate/preflight` | GET      | Admin session (admin_users) | Read-only preflight validation for the recreate execute route        |
 | `/api/admin/achievements/sync`          | POST     | Admin session (admin_users) | Deploy achievement type + collection on-chain                        |
 | `/api/admin/resync`                     | POST     | Admin session (admin_users) | Resync on-chain state to Supabase                                    |
-| `/api/admin/flags`                      | GET      | Admin session (admin_users) | Pending community flags for the moderation queue                     |
+| `/api/admin/flags`                      | GET/POST | Admin session (admin_users) | Moderation queue; POST actions a flag (resolve/dismiss/remove/lock)  |
 | `/api/admin/freeze`                     | GET/POST | Admin session (admin_users) | Read/set the global deploy-window freeze (reset wave B2)             |
 | `/api/admin/publish/pin`                | GET      | Admin session (admin_users) | Content pin: pinned bundle SHA + counts vs academy-courses HEAD      |
 | `/api/admin/capstone-funnel`            | GET      | Admin session (admin_users) | Capstone credential funnel counters (#725)                           |

--- a/apps/web/src/app/api/admin/flags/__tests__/route.test.ts
+++ b/apps/web/src/app/api/admin/flags/__tests__/route.test.ts
@@ -5,6 +5,8 @@ import type { NextRequest } from "next/server";
 
 vi.mock("server-only", () => ({}));
 
+const ADMIN_ID = "admin-user-1";
+
 const h = vi.hoisted(() => ({
   AdminAuthError: class AdminAuthError extends Error {},
   state: { authThrows: false, rateLimited: false },
@@ -28,7 +30,6 @@ vi.mock("@/lib/rate-limit", () => ({
     ),
 }));
 
-const ADMIN_ID = "admin-user-1";
 const THREAD_FLAG = {
   id: "flag-thread",
   thread_id: "thread-1",
@@ -44,17 +45,14 @@ type Err = { message: string } | null;
 
 interface Recorded {
   rpc: { name: string; args: Record<string, unknown> }[];
-  updates: { table: string; values: Record<string, unknown>; id: string }[];
-  inserts: { table: string; values: Record<string, unknown> }[];
 }
+let rec: Recorded;
 
 const db = {
+  // POST flag lookup
   flag: null as Record<string, unknown> | null,
   flagLookupError: null as Err,
   rpcError: null as Err,
-  lockError: null as Err,
-  flagUpdateError: null as Err,
-  auditError: null as Err,
   // GET fixtures
   pendingFlags: [] as Record<string, unknown>[],
   answers: [] as Record<string, unknown>[],
@@ -63,16 +61,23 @@ const db = {
   profiles: [] as Record<string, unknown>[],
 };
 
-let rec: Recorded;
+const TABLE_ROWS: Record<string, () => Record<string, unknown>[]> = {
+  flags: () => db.pendingFlags,
+  answers: () => db.answers,
+  threads: () => db.threads,
+  forum_categories: () => db.categories,
+  profiles: () => db.profiles,
+};
 
-/** Thenable query builder: every chained filter returns itself. */
+/**
+ * Chainable, thenable query builder. `.maybeSingle()` serves the POST single-row
+ * flag lookup; awaiting the chain (`.then`) serves the GET list reads. Every
+ * filter returns `this`, so `.eq().eq().maybeSingle()` and `.eq().order().limit()`
+ * both work.
+ */
 class Q implements PromiseLike<{ data: unknown; error: Err }> {
-  constructor(
-    private readonly resolveTo: () => { data: unknown; error: Err },
-    private readonly onEq?: (id: string) => void
-  ) {}
-  eq(_col: string, value: string): this {
-    this.onEq?.(value);
+  constructor(private readonly table: string) {}
+  eq(): this {
     return this;
   }
   in(): this {
@@ -85,7 +90,7 @@ class Q implements PromiseLike<{ data: unknown; error: Err }> {
     return this;
   }
   maybeSingle(): Promise<{ data: unknown; error: Err }> {
-    return Promise.resolve(this.resolveTo());
+    return Promise.resolve({ data: db.flag, error: db.flagLookupError });
   }
   then<R1, R2 = never>(
     onfulfilled?:
@@ -93,75 +98,22 @@ class Q implements PromiseLike<{ data: unknown; error: Err }> {
       | null,
     onrejected?: ((r: unknown) => R2 | PromiseLike<R2>) | null
   ): PromiseLike<R1 | R2> {
-    return Promise.resolve(this.resolveTo()).then(onfulfilled, onrejected);
+    return Promise.resolve({
+      data: TABLE_ROWS[this.table]?.() ?? [],
+      error: null,
+    }).then(onfulfilled, onrejected);
   }
 }
 
-const TABLE_ROWS: Record<string, () => Record<string, unknown>[]> = {
-  flags: () => db.pendingFlags,
-  answers: () => db.answers,
-  threads: () => db.threads,
-  forum_categories: () => db.categories,
-  profiles: () => db.profiles,
-};
-
-const adminClient = {
-  from(table: string) {
-    return {
-      select: () =>
-        new Q(() =>
-          table === "flags" && db.flag !== undefined && db.flagLookupError
-            ? { data: null, error: db.flagLookupError }
-            : { data: TABLE_ROWS[table]?.() ?? [], error: null }
-        ),
-      update: (values: Record<string, unknown>) =>
-        new Q(
-          () => ({
-            data: null,
-            error: table === "threads" ? db.lockError : db.flagUpdateError,
-          }),
-          (id) => rec.updates.push({ table, values, id })
-        ),
-      insert: (values: Record<string, unknown>) => {
-        rec.inserts.push({ table, values });
-        return new Q(() => ({ data: null, error: db.auditError }));
-      },
-    };
-  },
-  rpc(name: string, args: Record<string, unknown>) {
-    rec.rpc.push({ name, args });
-    return Promise.resolve({ data: null, error: db.rpcError });
-  },
-};
-
-// The POST flag lookup uses `.maybeSingle()`, which the shared builder above
-// resolves from TABLE_ROWS — override it for the single-row read.
-const flagLookup = {
-  select: () =>
-    ({
-      eq: () => ({
-        maybeSingle: () =>
-          Promise.resolve({ data: db.flag, error: db.flagLookupError }),
-      }),
-    }) as unknown as Q,
-};
-
 vi.mock("@/lib/supabase/admin", () => ({
   createAdminClient: () => ({
-    from: (table: string) => {
-      const base = adminClient.from(table);
-      if (table === "flags") {
-        return { ...base, select: flagLookupSelect ?? base.select };
-      }
-      return base;
+    from: (table: string) => ({ select: () => new Q(table) }),
+    rpc: (name: string, args: Record<string, unknown>) => {
+      rec.rpc.push({ name, args });
+      return Promise.resolve({ data: null, error: db.rpcError });
     },
-    rpc: adminClient.rpc,
   }),
 }));
-
-// GET reads `flags` with `.select().eq().order().limit()`; POST reads it with
-// `.select().eq().maybeSingle()`. One handle switches which shape is served.
-let flagLookupSelect: (() => unknown) | null = null;
 
 const post = async (body: unknown, referer?: string): Promise<Response> => {
   const { POST } = await import("../route");
@@ -190,19 +142,15 @@ beforeEach(() => {
   h.state.authThrows = false;
   h.state.rateLimited = false;
   isRateLimited.mockClear();
-  rec = { rpc: [], updates: [], inserts: [] };
+  rec = { rpc: [] };
   db.flag = THREAD_FLAG;
   db.flagLookupError = null;
   db.rpcError = null;
-  db.lockError = null;
-  db.flagUpdateError = null;
-  db.auditError = null;
   db.pendingFlags = [];
   db.answers = [];
   db.threads = [];
   db.categories = [];
   db.profiles = [];
-  flagLookupSelect = flagLookup.select as unknown as () => unknown;
 });
 
 describe("POST /api/admin/flags — auth and validation", () => {
@@ -213,8 +161,6 @@ describe("POST /api/admin/flags — auth and validation", () => {
 
     expect(res.status).toBe(401);
     expect(rec.rpc).toEqual([]);
-    expect(rec.updates).toEqual([]);
-    expect(rec.inserts).toEqual([]);
     expect(isRateLimited).not.toHaveBeenCalled();
   });
 
@@ -223,7 +169,6 @@ describe("POST /api/admin/flags — auth and validation", () => {
 
     expect(res.status).toBe(400);
     expect(rec.rpc).toEqual([]);
-    expect(rec.updates).toEqual([]);
   });
 
   it("400s when flagId is missing", async () => {
@@ -231,7 +176,7 @@ describe("POST /api/admin/flags — auth and validation", () => {
     expect(res.status).toBe(400);
   });
 
-  it("404s on a flag that does not exist", async () => {
+  it("404s on a flag that is missing or no longer pending", async () => {
     db.flag = null;
 
     const res = await post({ flagId: "nope", action: "remove" });
@@ -247,8 +192,6 @@ describe("POST /api/admin/flags — auth and validation", () => {
 
     expect(res.status).toBe(429);
     expect(rec.rpc).toEqual([]);
-    expect(rec.updates).toEqual([]);
-    expect(rec.inserts).toEqual([]);
     expect(isRateLimited).toHaveBeenCalledWith(
       "admin-moderate",
       ADMIN_ID,
@@ -257,39 +200,24 @@ describe("POST /api/admin/flags — auth and validation", () => {
   });
 });
 
-describe("POST /api/admin/flags — remove", () => {
-  it("soft-deletes a reported thread, resolves the flag, audits it", async () => {
+describe("POST /api/admin/flags — remove (one atomic RPC)", () => {
+  it("removes a reported thread through the thread RPC, passing flag + actor", async () => {
     const res = await post({ flagId: "flag-thread", action: "remove" });
 
     expect(res.status).toBe(200);
     expect(rec.rpc).toEqual([
       {
         name: "moderate_soft_delete_thread",
-        args: { p_thread_id: "thread-1" },
+        args: {
+          p_thread_id: "thread-1",
+          p_flag_id: "flag-thread",
+          p_actor_id: ADMIN_ID,
+        },
       },
     ]);
-    expect(rec.updates).toEqual([
-      {
-        table: "flags",
-        id: "flag-thread",
-        values: expect.objectContaining({
-          status: "resolved",
-          resolved_by: ADMIN_ID,
-        }) as unknown as Record<string, unknown>,
-      },
-    ]);
-    expect(rec.inserts[0]).toEqual({
-      table: "moderation_actions",
-      values: expect.objectContaining({
-        action: "removed_thread",
-        thread_id: "thread-1",
-        flag_id: "flag-thread",
-        actor_id: ADMIN_ID,
-      }) as unknown as Record<string, unknown>,
-    });
   });
 
-  it("soft-deletes a reported answer via the answer RPC", async () => {
+  it("removes a reported answer through the answer RPC", async () => {
     db.flag = ANSWER_FLAG;
 
     const res = await post({ flagId: "flag-answer", action: "remove" });
@@ -298,43 +226,47 @@ describe("POST /api/admin/flags — remove", () => {
     expect(rec.rpc).toEqual([
       {
         name: "moderate_soft_delete_answer",
-        args: { p_answer_id: "answer-1" },
+        args: {
+          p_answer_id: "answer-1",
+          p_flag_id: "flag-answer",
+          p_actor_id: ADMIN_ID,
+        },
       },
     ]);
-    expect(rec.inserts[0]?.values.action).toBe("removed_answer");
   });
 
-  it("409s (not 500) when the target is already removed, and writes nothing else", async () => {
+  it("409s when the RPC reports the content already actioned", async () => {
     db.rpcError = { message: "Thread not found or already removed" };
 
     const res = await post({ flagId: "flag-thread", action: "remove" });
 
     expect(res.status).toBe(409);
-    expect(rec.updates).toEqual([]);
-    expect(rec.inserts).toEqual([]);
   });
 
-  it("500s on an unexpected RPC failure without resolving the flag", async () => {
+  it("500s on an unexpected RPC failure", async () => {
     db.rpcError = { message: "connection reset" };
 
     const res = await post({ flagId: "flag-thread", action: "remove" });
 
     expect(res.status).toBe(500);
-    expect(rec.updates).toEqual([]);
-    expect(rec.inserts).toEqual([]);
   });
 });
 
 describe("POST /api/admin/flags — lock", () => {
-  it("locks the reported thread and LEAVES the flag pending", async () => {
+  it("locks the reported thread through the lock RPC", async () => {
     const res = await post({ flagId: "flag-thread", action: "lock" });
 
     expect(res.status).toBe(200);
-    expect(rec.updates).toEqual([
-      { table: "threads", id: "thread-1", values: { is_locked: true } },
+    expect(rec.rpc).toEqual([
+      {
+        name: "moderate_lock_thread",
+        args: {
+          p_thread_id: "thread-1",
+          p_flag_id: "flag-thread",
+          p_actor_id: ADMIN_ID,
+        },
+      },
     ]);
-    expect(rec.updates.some((u) => u.table === "flags")).toBe(false);
-    expect(rec.inserts[0]?.values.action).toBe("locked_thread");
   });
 
   it("400s on an answer report — there is no thread of its own to lock", async () => {
@@ -343,68 +275,45 @@ describe("POST /api/admin/flags — lock", () => {
     const res = await post({ flagId: "flag-answer", action: "lock" });
 
     expect(res.status).toBe(400);
-    expect(rec.updates).toEqual([]);
-    expect(rec.inserts).toEqual([]);
-  });
-
-  it("500s when the lock write fails, and does not audit a lock that never landed", async () => {
-    db.lockError = { message: "boom" };
-
-    const res = await post({ flagId: "flag-thread", action: "lock" });
-
-    expect(res.status).toBe(500);
-    expect(rec.inserts).toEqual([]);
+    expect(rec.rpc).toEqual([]);
   });
 });
 
 describe("POST /api/admin/flags — resolve / dismiss", () => {
-  it("resolve marks the flag resolved, attributes it, and touches no content", async () => {
+  it("resolve calls moderate_resolve_flag with p_dismiss=false", async () => {
     const res = await post({ flagId: "flag-thread", action: "resolve" });
 
     expect(res.status).toBe(200);
-    expect(rec.rpc).toEqual([]);
-    expect(rec.updates[0]?.values).toMatchObject({
-      status: "resolved",
-      resolved_by: ADMIN_ID,
-    });
-    expect(rec.inserts[0]?.values.action).toBe("resolved");
+    expect(rec.rpc).toEqual([
+      {
+        name: "moderate_resolve_flag",
+        args: {
+          p_flag_id: "flag-thread",
+          p_dismiss: false,
+          p_actor_id: ADMIN_ID,
+        },
+      },
+    ]);
   });
 
-  it("dismiss marks the flag dismissed", async () => {
+  it("dismiss calls moderate_resolve_flag with p_dismiss=true", async () => {
     const res = await post({ flagId: "flag-thread", action: "dismiss" });
 
     expect(res.status).toBe(200);
-    expect(rec.updates[0]?.values).toMatchObject({ status: "dismissed" });
-    expect(rec.inserts[0]?.values.action).toBe("dismissed");
+    expect(rec.rpc[0]?.args.p_dismiss).toBe(true);
   });
 
-  it("500s when the flag update fails", async () => {
-    db.flagUpdateError = { message: "nope" };
+  it("409s if the flag was resolved out from under us (race)", async () => {
+    db.rpcError = { message: "Flag not found or already resolved" };
 
-    const res = await post({ flagId: "flag-thread", action: "dismiss" });
+    const res = await post({ flagId: "flag-thread", action: "resolve" });
 
-    expect(res.status).toBe(500);
-    expect(rec.inserts).toEqual([]);
-  });
-});
-
-describe("POST /api/admin/flags — audit failure is reported, not swallowed", () => {
-  it("returns audited:false when the audit insert fails after the action landed", async () => {
-    db.auditError = { message: "audit table unreachable" };
-    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-
-    const res = await post({ flagId: "flag-thread", action: "remove" });
-
-    expect(res.status).toBe(200);
-    expect(await res.json()).toEqual({ success: true, audited: false });
-    expect(errorSpy).toHaveBeenCalled();
-    errorSpy.mockRestore();
+    expect(res.status).toBe(409);
   });
 });
 
 describe("GET /api/admin/flags — links and bodies", () => {
   beforeEach(() => {
-    flagLookupSelect = null; // GET uses the list-shaped flags read
     db.pendingFlags = [
       {
         id: "flag-thread",

--- a/apps/web/src/app/api/admin/flags/__tests__/route.test.ts
+++ b/apps/web/src/app/api/admin/flags/__tests__/route.test.ts
@@ -1,0 +1,463 @@
+/* eslint-disable import/order -- vi.mock("server-only") must be hoisted above
+   the route import so the `server-only` graph loads under vitest. */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { NextRequest } from "next/server";
+
+vi.mock("server-only", () => ({}));
+
+const h = vi.hoisted(() => ({
+  AdminAuthError: class AdminAuthError extends Error {},
+  state: { authThrows: false, rateLimited: false },
+}));
+
+vi.mock("@/lib/admin/auth", () => ({
+  AdminAuthError: h.AdminAuthError,
+  adminUnauthorizedResponse: () =>
+    new Response(JSON.stringify({ error: "Unauthorized" }), { status: 401 }),
+  requireAdminAuth: vi.fn(() => {
+    if (h.state.authThrows) throw new h.AdminAuthError();
+    return { userId: ADMIN_ID };
+  }),
+}));
+
+const isRateLimited = vi.fn(async () => h.state.rateLimited);
+vi.mock("@/lib/rate-limit", () => ({
+  isRateLimited: (...args: unknown[]) =>
+    (isRateLimited as unknown as (...a: unknown[]) => Promise<boolean>)(
+      ...args
+    ),
+}));
+
+const ADMIN_ID = "admin-user-1";
+const THREAD_FLAG = {
+  id: "flag-thread",
+  thread_id: "thread-1",
+  answer_id: null,
+};
+const ANSWER_FLAG = {
+  id: "flag-answer",
+  thread_id: null,
+  answer_id: "answer-1",
+};
+
+type Err = { message: string } | null;
+
+interface Recorded {
+  rpc: { name: string; args: Record<string, unknown> }[];
+  updates: { table: string; values: Record<string, unknown>; id: string }[];
+  inserts: { table: string; values: Record<string, unknown> }[];
+}
+
+const db = {
+  flag: null as Record<string, unknown> | null,
+  flagLookupError: null as Err,
+  rpcError: null as Err,
+  lockError: null as Err,
+  flagUpdateError: null as Err,
+  auditError: null as Err,
+  // GET fixtures
+  pendingFlags: [] as Record<string, unknown>[],
+  answers: [] as Record<string, unknown>[],
+  threads: [] as Record<string, unknown>[],
+  categories: [] as Record<string, unknown>[],
+  profiles: [] as Record<string, unknown>[],
+};
+
+let rec: Recorded;
+
+/** Thenable query builder: every chained filter returns itself. */
+class Q implements PromiseLike<{ data: unknown; error: Err }> {
+  constructor(
+    private readonly resolveTo: () => { data: unknown; error: Err },
+    private readonly onEq?: (id: string) => void
+  ) {}
+  eq(_col: string, value: string): this {
+    this.onEq?.(value);
+    return this;
+  }
+  in(): this {
+    return this;
+  }
+  order(): this {
+    return this;
+  }
+  limit(): this {
+    return this;
+  }
+  maybeSingle(): Promise<{ data: unknown; error: Err }> {
+    return Promise.resolve(this.resolveTo());
+  }
+  then<R1, R2 = never>(
+    onfulfilled?:
+      | ((v: { data: unknown; error: Err }) => R1 | PromiseLike<R1>)
+      | null,
+    onrejected?: ((r: unknown) => R2 | PromiseLike<R2>) | null
+  ): PromiseLike<R1 | R2> {
+    return Promise.resolve(this.resolveTo()).then(onfulfilled, onrejected);
+  }
+}
+
+const TABLE_ROWS: Record<string, () => Record<string, unknown>[]> = {
+  flags: () => db.pendingFlags,
+  answers: () => db.answers,
+  threads: () => db.threads,
+  forum_categories: () => db.categories,
+  profiles: () => db.profiles,
+};
+
+const adminClient = {
+  from(table: string) {
+    return {
+      select: () =>
+        new Q(() =>
+          table === "flags" && db.flag !== undefined && db.flagLookupError
+            ? { data: null, error: db.flagLookupError }
+            : { data: TABLE_ROWS[table]?.() ?? [], error: null }
+        ),
+      update: (values: Record<string, unknown>) =>
+        new Q(
+          () => ({
+            data: null,
+            error: table === "threads" ? db.lockError : db.flagUpdateError,
+          }),
+          (id) => rec.updates.push({ table, values, id })
+        ),
+      insert: (values: Record<string, unknown>) => {
+        rec.inserts.push({ table, values });
+        return new Q(() => ({ data: null, error: db.auditError }));
+      },
+    };
+  },
+  rpc(name: string, args: Record<string, unknown>) {
+    rec.rpc.push({ name, args });
+    return Promise.resolve({ data: null, error: db.rpcError });
+  },
+};
+
+// The POST flag lookup uses `.maybeSingle()`, which the shared builder above
+// resolves from TABLE_ROWS — override it for the single-row read.
+const flagLookup = {
+  select: () =>
+    ({
+      eq: () => ({
+        maybeSingle: () =>
+          Promise.resolve({ data: db.flag, error: db.flagLookupError }),
+      }),
+    }) as unknown as Q,
+};
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: () => ({
+    from: (table: string) => {
+      const base = adminClient.from(table);
+      if (table === "flags") {
+        return { ...base, select: flagLookupSelect ?? base.select };
+      }
+      return base;
+    },
+    rpc: adminClient.rpc,
+  }),
+}));
+
+// GET reads `flags` with `.select().eq().order().limit()`; POST reads it with
+// `.select().eq().maybeSingle()`. One handle switches which shape is served.
+let flagLookupSelect: (() => unknown) | null = null;
+
+const post = async (body: unknown, referer?: string): Promise<Response> => {
+  const { POST } = await import("../route");
+  return POST(
+    new Request("https://app.test/api/admin/flags", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        ...(referer ? { referer } : {}),
+      },
+      body: JSON.stringify(body),
+    }) as unknown as NextRequest
+  );
+};
+
+const get = async (referer?: string): Promise<Response> => {
+  const { GET } = await import("../route");
+  return GET(
+    new Request("https://app.test/api/admin/flags", {
+      headers: referer ? { referer } : {},
+    }) as unknown as NextRequest
+  );
+};
+
+beforeEach(() => {
+  h.state.authThrows = false;
+  h.state.rateLimited = false;
+  isRateLimited.mockClear();
+  rec = { rpc: [], updates: [], inserts: [] };
+  db.flag = THREAD_FLAG;
+  db.flagLookupError = null;
+  db.rpcError = null;
+  db.lockError = null;
+  db.flagUpdateError = null;
+  db.auditError = null;
+  db.pendingFlags = [];
+  db.answers = [];
+  db.threads = [];
+  db.categories = [];
+  db.profiles = [];
+  flagLookupSelect = flagLookup.select as unknown as () => unknown;
+});
+
+describe("POST /api/admin/flags — auth and validation", () => {
+  it("401s without an admin session and touches nothing", async () => {
+    h.state.authThrows = true;
+
+    const res = await post({ flagId: "flag-thread", action: "remove" });
+
+    expect(res.status).toBe(401);
+    expect(rec.rpc).toEqual([]);
+    expect(rec.updates).toEqual([]);
+    expect(rec.inserts).toEqual([]);
+    expect(isRateLimited).not.toHaveBeenCalled();
+  });
+
+  it("400s on an unknown action without touching content", async () => {
+    const res = await post({ flagId: "flag-thread", action: "ban" });
+
+    expect(res.status).toBe(400);
+    expect(rec.rpc).toEqual([]);
+    expect(rec.updates).toEqual([]);
+  });
+
+  it("400s when flagId is missing", async () => {
+    const res = await post({ action: "remove" });
+    expect(res.status).toBe(400);
+  });
+
+  it("404s on a flag that does not exist", async () => {
+    db.flag = null;
+
+    const res = await post({ flagId: "nope", action: "remove" });
+
+    expect(res.status).toBe(404);
+    expect(rec.rpc).toEqual([]);
+  });
+
+  it("429s when the moderation limiter trips, before any write", async () => {
+    h.state.rateLimited = true;
+
+    const res = await post({ flagId: "flag-thread", action: "remove" });
+
+    expect(res.status).toBe(429);
+    expect(rec.rpc).toEqual([]);
+    expect(rec.updates).toEqual([]);
+    expect(rec.inserts).toEqual([]);
+    expect(isRateLimited).toHaveBeenCalledWith(
+      "admin-moderate",
+      ADMIN_ID,
+      expect.objectContaining({ maxTokens: expect.any(Number) })
+    );
+  });
+});
+
+describe("POST /api/admin/flags — remove", () => {
+  it("soft-deletes a reported thread, resolves the flag, audits it", async () => {
+    const res = await post({ flagId: "flag-thread", action: "remove" });
+
+    expect(res.status).toBe(200);
+    expect(rec.rpc).toEqual([
+      {
+        name: "moderate_soft_delete_thread",
+        args: { p_thread_id: "thread-1" },
+      },
+    ]);
+    expect(rec.updates).toEqual([
+      {
+        table: "flags",
+        id: "flag-thread",
+        values: expect.objectContaining({
+          status: "resolved",
+          resolved_by: ADMIN_ID,
+        }) as unknown as Record<string, unknown>,
+      },
+    ]);
+    expect(rec.inserts[0]).toEqual({
+      table: "moderation_actions",
+      values: expect.objectContaining({
+        action: "removed_thread",
+        thread_id: "thread-1",
+        flag_id: "flag-thread",
+        actor_id: ADMIN_ID,
+      }) as unknown as Record<string, unknown>,
+    });
+  });
+
+  it("soft-deletes a reported answer via the answer RPC", async () => {
+    db.flag = ANSWER_FLAG;
+
+    const res = await post({ flagId: "flag-answer", action: "remove" });
+
+    expect(res.status).toBe(200);
+    expect(rec.rpc).toEqual([
+      {
+        name: "moderate_soft_delete_answer",
+        args: { p_answer_id: "answer-1" },
+      },
+    ]);
+    expect(rec.inserts[0]?.values.action).toBe("removed_answer");
+  });
+
+  it("409s (not 500) when the target is already removed, and writes nothing else", async () => {
+    db.rpcError = { message: "Thread not found or already removed" };
+
+    const res = await post({ flagId: "flag-thread", action: "remove" });
+
+    expect(res.status).toBe(409);
+    expect(rec.updates).toEqual([]);
+    expect(rec.inserts).toEqual([]);
+  });
+
+  it("500s on an unexpected RPC failure without resolving the flag", async () => {
+    db.rpcError = { message: "connection reset" };
+
+    const res = await post({ flagId: "flag-thread", action: "remove" });
+
+    expect(res.status).toBe(500);
+    expect(rec.updates).toEqual([]);
+    expect(rec.inserts).toEqual([]);
+  });
+});
+
+describe("POST /api/admin/flags — lock", () => {
+  it("locks the reported thread and LEAVES the flag pending", async () => {
+    const res = await post({ flagId: "flag-thread", action: "lock" });
+
+    expect(res.status).toBe(200);
+    expect(rec.updates).toEqual([
+      { table: "threads", id: "thread-1", values: { is_locked: true } },
+    ]);
+    expect(rec.updates.some((u) => u.table === "flags")).toBe(false);
+    expect(rec.inserts[0]?.values.action).toBe("locked_thread");
+  });
+
+  it("400s on an answer report — there is no thread of its own to lock", async () => {
+    db.flag = ANSWER_FLAG;
+
+    const res = await post({ flagId: "flag-answer", action: "lock" });
+
+    expect(res.status).toBe(400);
+    expect(rec.updates).toEqual([]);
+    expect(rec.inserts).toEqual([]);
+  });
+
+  it("500s when the lock write fails, and does not audit a lock that never landed", async () => {
+    db.lockError = { message: "boom" };
+
+    const res = await post({ flagId: "flag-thread", action: "lock" });
+
+    expect(res.status).toBe(500);
+    expect(rec.inserts).toEqual([]);
+  });
+});
+
+describe("POST /api/admin/flags — resolve / dismiss", () => {
+  it("resolve marks the flag resolved, attributes it, and touches no content", async () => {
+    const res = await post({ flagId: "flag-thread", action: "resolve" });
+
+    expect(res.status).toBe(200);
+    expect(rec.rpc).toEqual([]);
+    expect(rec.updates[0]?.values).toMatchObject({
+      status: "resolved",
+      resolved_by: ADMIN_ID,
+    });
+    expect(rec.inserts[0]?.values.action).toBe("resolved");
+  });
+
+  it("dismiss marks the flag dismissed", async () => {
+    const res = await post({ flagId: "flag-thread", action: "dismiss" });
+
+    expect(res.status).toBe(200);
+    expect(rec.updates[0]?.values).toMatchObject({ status: "dismissed" });
+    expect(rec.inserts[0]?.values.action).toBe("dismissed");
+  });
+
+  it("500s when the flag update fails", async () => {
+    db.flagUpdateError = { message: "nope" };
+
+    const res = await post({ flagId: "flag-thread", action: "dismiss" });
+
+    expect(res.status).toBe(500);
+    expect(rec.inserts).toEqual([]);
+  });
+});
+
+describe("POST /api/admin/flags — audit failure is reported, not swallowed", () => {
+  it("returns audited:false when the audit insert fails after the action landed", async () => {
+    db.auditError = { message: "audit table unreachable" };
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const res = await post({ flagId: "flag-thread", action: "remove" });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ success: true, audited: false });
+    expect(errorSpy).toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+});
+
+describe("GET /api/admin/flags — links and bodies", () => {
+  beforeEach(() => {
+    flagLookupSelect = null; // GET uses the list-shaped flags read
+    db.pendingFlags = [
+      {
+        id: "flag-thread",
+        reason: "spam",
+        details: null,
+        created_at: "2026-08-01T00:00:00Z",
+        reporter_id: "reporter-1",
+        thread_id: "thread-1",
+        answer_id: null,
+      },
+    ];
+    db.threads = [
+      {
+        id: "thread-1",
+        title: "reported title",
+        slug: "reported-title-ab12",
+        category_id: "cat-1",
+        body: "the full reported body",
+      },
+    ];
+    db.categories = [{ id: "cat-1", slug: "general" }];
+    db.profiles = [{ id: "reporter-1", username: "alice" }];
+  });
+
+  it("prefixes the target link with the moderator's locale", async () => {
+    const res = await get("https://app.test/pt-BR/admin");
+    const body = (await res.json()) as { flags: { url: string }[] };
+
+    expect(body.flags[0]?.url).toBe(
+      "/pt-BR/community/general/reported-title-ab12"
+    );
+  });
+
+  it("falls back to the default locale rather than an unprefixed path", async () => {
+    const res = await get();
+    const body = (await res.json()) as { flags: { url: string }[] };
+
+    expect(body.flags[0]?.url).toBe(
+      "/en/community/general/reported-title-ab12"
+    );
+  });
+
+  it("ignores an unknown locale segment in the referer", async () => {
+    const res = await get("https://app.test/fr/admin");
+    const body = (await res.json()) as { flags: { url: string }[] };
+
+    expect(body.flags[0]?.url?.startsWith("/en/")).toBe(true);
+  });
+
+  it("carries the full target body so a link-less card is still judgeable", async () => {
+    const res = await get();
+    const body = (await res.json()) as { flags: { body: string }[] };
+
+    expect(body.flags[0]?.body).toBe("the full reported body");
+  });
+});

--- a/apps/web/src/app/api/admin/flags/route.ts
+++ b/apps/web/src/app/api/admin/flags/route.ts
@@ -188,14 +188,6 @@ const ACTIONS: readonly ModerationAction[] = [
   "lock",
 ];
 
-/** The audit `action` value each request writes, once the target is known. */
-type AuditAction =
-  | "removed_thread"
-  | "removed_answer"
-  | "locked_thread"
-  | "resolved"
-  | "dismissed";
-
 /**
  * POST { flagId, action: "resolve" | "dismiss" | "remove" | "lock" }
  *
@@ -245,36 +237,47 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
 
   const admin = createAdminClient();
 
-  // The target comes from the flag row, never from the request body — a client
-  // can name a flag, not a thread to delete.
+  // Only pending flags are actionable, and the target comes from the flag row,
+  // never from the request body — a client can name a flag, not a thread to
+  // delete. A non-pending or missing flag is a 404 (already handled, or gone).
   const { data: flag, error: flagError } = await admin
     .from("flags")
     .select("id, thread_id, answer_id")
     .eq("id", flagId)
+    .eq("status", "pending")
     .maybeSingle();
 
   if (flagError) {
     return NextResponse.json({ error: "Lookup failed" }, { status: 500 });
   }
   if (!flag) {
-    return NextResponse.json({ error: "Flag not found" }, { status: 404 });
+    return NextResponse.json(
+      { error: "Flag not found or already resolved" },
+      { status: 404 }
+    );
   }
 
   const threadId = flag.thread_id;
   const answerId = flag.answer_id;
 
-  let auditAction: AuditAction;
+  // Every branch is ONE RPC that commits the content change, the flag write, and
+  // the audit row in a single transaction — so a failure can never leave content
+  // removed with no audit trail, or a flag resolved with no record of who did it.
+  let rpcError: { message: string } | null;
 
   if (action === "remove") {
-    let rpc;
     if (threadId !== null) {
-      rpc = await admin.rpc("moderate_soft_delete_thread", {
+      ({ error: rpcError } = await admin.rpc("moderate_soft_delete_thread", {
         p_thread_id: threadId,
-      });
+        p_flag_id: flagId,
+        p_actor_id: auth.userId,
+      }));
     } else if (answerId !== null) {
-      rpc = await admin.rpc("moderate_soft_delete_answer", {
+      ({ error: rpcError } = await admin.rpc("moderate_soft_delete_answer", {
         p_answer_id: answerId,
-      });
+        p_flag_id: flagId,
+        p_actor_id: auth.userId,
+      }));
     } else {
       // chk_flag_target_exclusive makes this unreachable; a flag with no target
       // is corrupt data, not a request to remove nothing.
@@ -283,66 +286,38 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
         { status: 500 }
       );
     }
-    if (rpc.error) {
-      // The RPCs raise on a target that is missing or already tombstoned. That
-      // is a conflict, not a server fault, and must not read as "try again".
-      const gone = /already removed/i.test(rpc.error.message ?? "");
-      console.error("Admin moderation remove failed:", rpc.error.message);
-      return NextResponse.json(
-        { error: gone ? "Content already removed" : "Remove failed" },
-        { status: gone ? 409 : 500 }
-      );
-    }
-    auditAction = threadId ? "removed_thread" : "removed_answer";
   } else if (action === "lock") {
-    if (!threadId) {
+    if (threadId === null) {
       return NextResponse.json(
         { error: "lock applies to thread reports only" },
         { status: 400 }
       );
     }
-    const { error: lockError } = await admin
-      .from("threads")
-      .update({ is_locked: true })
-      .eq("id", threadId);
-    if (lockError) {
-      console.error("Admin moderation lock failed:", lockError.message);
-      return NextResponse.json({ error: "Lock failed" }, { status: 500 });
-    }
-    auditAction = "locked_thread";
+    ({ error: rpcError } = await admin.rpc("moderate_lock_thread", {
+      p_thread_id: threadId,
+      p_flag_id: flagId,
+      p_actor_id: auth.userId,
+    }));
   } else {
-    auditAction = action === "resolve" ? "resolved" : "dismissed";
+    ({ error: rpcError } = await admin.rpc("moderate_resolve_flag", {
+      p_flag_id: flagId,
+      p_dismiss: action === "dismiss",
+      p_actor_id: auth.userId,
+    }));
   }
 
-  // `remove` settles the report as well as the content; `lock` does not.
-  if (action !== "lock") {
-    const { error } = await admin
-      .from("flags")
-      .update({
-        status: action === "dismiss" ? "dismissed" : "resolved",
-        resolved_at: new Date().toISOString(),
-        resolved_by: auth.userId,
-      })
-      .eq("id", flagId);
-
-    if (error) {
-      return NextResponse.json({ error: "Update failed" }, { status: 500 });
-    }
+  if (rpcError) {
+    // The RPCs raise on a target that is missing or already tombstoned/handled.
+    // That is a conflict, not a server fault, and must not read as "try again".
+    const gone = /already removed|already resolved|not found/i.test(
+      rpcError.message ?? ""
+    );
+    console.error(`Admin moderation ${action} failed:`, rpcError.message);
+    return NextResponse.json(
+      { error: gone ? "Content already actioned" : "Action failed" },
+      { status: gone ? 409 : 500 }
+    );
   }
 
-  // Audit last, so it only ever records what actually happened. A failure here
-  // is reported (`audited: false`) rather than turned into a 500: the content
-  // action already landed, and a 500 would invite a destructive retry.
-  const { error: auditError } = await admin.from("moderation_actions").insert({
-    action: auditAction,
-    thread_id: threadId,
-    answer_id: answerId,
-    flag_id: flagId,
-    actor_id: auth.userId,
-  });
-  if (auditError) {
-    console.error("Moderation audit write failed:", auditError.message);
-  }
-
-  return NextResponse.json({ success: true, audited: !auditError });
+  return NextResponse.json({ success: true });
 }

--- a/apps/web/src/app/api/admin/flags/route.ts
+++ b/apps/web/src/app/api/admin/flags/route.ts
@@ -7,17 +7,50 @@ import {
   AdminAuthError,
 } from "@/lib/admin/auth";
 import { createAdminClient } from "@/lib/supabase/admin";
+import { isRateLimited } from "@/lib/rate-limit";
+import { locales, defaultLocale } from "@/lib/i18n/config";
 
 // Reads the admin cookie + service-role DB — never statically prerender.
 export const dynamic = "force-dynamic";
 
-async function guard(req: NextRequest): Promise<NextResponse | null> {
+/**
+ * Admin gate. Returns the 401 response to send, or the acting admin's user id
+ * so the caller can attribute what it writes.
+ */
+async function guard(
+  req: NextRequest
+): Promise<{ denied: NextResponse } | { userId: string }> {
   try {
-    await requireAdminAuth(req);
-    return null;
+    const { userId } = await requireAdminAuth(req);
+    return { userId };
   } catch (e) {
-    if (e instanceof AdminAuthError) return adminUnauthorizedResponse();
+    if (e instanceof AdminAuthError)
+      return { denied: adminUnauthorizedResponse() };
     throw e;
+  }
+}
+
+/**
+ * Locale for the links this route hands the panel. `localePrefix: "always"`
+ * means an unprefixed `/community/...` href is not a valid app path — it gets
+ * redirected by the intl middleware at best, and 404s inside the app router at
+ * worst — so the queue's "View" link was effectively broken.
+ *
+ * The locale comes from the Referer, because the only caller is the admin panel
+ * at `/{locale}/admin` and that is the locale the moderator is actually reading
+ * in. Anything unrecognised falls back to the default locale rather than
+ * emitting a prefix-less path.
+ */
+function localeFromReferer(req: NextRequest): string {
+  const referer = req.headers.get("referer");
+  if (!referer) return defaultLocale;
+  try {
+    const first = new URL(referer).pathname.split("/")[1] ?? "";
+    return (locales as readonly string[]).includes(first)
+      ? first
+      : defaultLocale;
+  } catch {
+    return defaultLocale;
   }
 }
 
@@ -29,6 +62,12 @@ export interface ModerationFlag {
   reporter: string | null;
   targetType: "thread" | "answer";
   preview: string;
+  /**
+   * The reported content in full (thread body or answer body). The card falls
+   * back to showing this when `url` is null — a moderator must never be asked to
+   * decide from a truncated preview with no way to read the post.
+   */
+  body: string;
   url: string | null;
 }
 
@@ -39,8 +78,8 @@ export interface ModerationFlag {
  * rather than PostgREST embedding to keep the FK-hint surface simple.
  */
 export async function GET(req: NextRequest): Promise<NextResponse> {
-  const denied = await guard(req);
-  if (denied) return denied;
+  const auth = await guard(req);
+  if ("denied" in auth) return auth.denied;
 
   const admin = createAdminClient();
   const { data: flags, error } = await admin
@@ -80,7 +119,7 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
     ? ((
         await admin
           .from("threads")
-          .select("id, title, slug, category_id")
+          .select("id, title, slug, category_id, body")
           .in("id", threadIds)
       ).data ?? [])
     : [];
@@ -112,6 +151,7 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
     : [];
   const reporterName = new Map(reporters.map((r) => [r.id, r.username]));
 
+  const locale = localeFromReferer(req);
   const result: ModerationFlag[] = rows.map((f) => {
     const isThread = !!f.thread_id;
     const answer = f.answer_id ? answerMap.get(f.answer_id) : undefined;
@@ -121,7 +161,8 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
     const slug = thread?.category_id
       ? categorySlug.get(thread.category_id)
       : undefined;
-    const url = thread && slug ? `/community/${slug}/${thread.slug}` : null;
+    const url =
+      thread && slug ? `/${locale}/community/${slug}/${thread.slug}` : null;
     return {
       id: f.id,
       reason: f.reason,
@@ -130,6 +171,7 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
       reporter: reporterName.get(f.reporter_id) ?? null,
       targetType: isThread ? "thread" : "answer",
       preview: preview.slice(0, 200),
+      body: isThread ? (thread?.body ?? "") : (answer?.body ?? ""),
       url,
     };
   });
@@ -137,13 +179,41 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
   return NextResponse.json({ flags: result });
 }
 
-/** POST { flagId, action: "resolve" | "dismiss" } — action a pending flag. */
+type ModerationAction = "resolve" | "dismiss" | "remove" | "lock";
+
+const ACTIONS: readonly ModerationAction[] = [
+  "resolve",
+  "dismiss",
+  "remove",
+  "lock",
+];
+
+/** The audit `action` value each request writes, once the target is known. */
+type AuditAction =
+  | "removed_thread"
+  | "removed_answer"
+  | "locked_thread"
+  | "resolved"
+  | "dismissed";
+
+/**
+ * POST { flagId, action: "resolve" | "dismiss" | "remove" | "lock" }
+ *
+ * `remove` soft-deletes the reported content (and auto-resolves the flag);
+ * `lock` locks the reported thread and LEAVES the flag pending, because a lock
+ * stops the argument without settling the report — the moderator still resolves
+ * or dismisses it. `resolve` / `dismiss` are unchanged: they record a decision
+ * about the report only.
+ *
+ * Rate-limited per admin: these actions now destroy content, so a stuck client
+ * (or a stolen session) cannot loop them.
+ */
 export async function POST(req: NextRequest): Promise<NextResponse> {
-  const denied = await guard(req);
-  if (denied) return denied;
+  const auth = await guard(req);
+  if ("denied" in auth) return auth.denied;
 
   let flagId: string;
-  let action: "resolve" | "dismiss";
+  let action: ModerationAction;
   try {
     const body = (await req.json()) as { flagId?: unknown; action?: unknown };
     if (typeof body.flagId !== "string" || body.flagId.length === 0) {
@@ -152,31 +222,127 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
         { status: 400 }
       );
     }
-    if (body.action !== "resolve" && body.action !== "dismiss") {
+    if (!ACTIONS.includes(body.action as ModerationAction)) {
       return NextResponse.json(
-        { error: "action must be 'resolve' or 'dismiss'" },
+        { error: `action must be one of ${ACTIONS.join(", ")}` },
         { status: 400 }
       );
     }
     flagId = body.flagId;
-    action = body.action;
+    action = body.action as ModerationAction;
   } catch {
     return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
   }
 
-  const admin = createAdminClient();
-  // resolved_by is left null to keep the moderation write byte-identical to
-  // the pre-allowlist behavior. status + resolved_at are enough.
-  const { error } = await admin
-    .from("flags")
-    .update({
-      status: action === "resolve" ? "resolved" : "dismissed",
-      resolved_at: new Date().toISOString(),
+  if (
+    await isRateLimited("admin-moderate", auth.userId, {
+      maxTokens: 60,
+      refillIntervalMs: 60_000,
     })
-    .eq("id", flagId);
-
-  if (error) {
-    return NextResponse.json({ error: "Update failed" }, { status: 500 });
+  ) {
+    return NextResponse.json({ error: "Too many requests" }, { status: 429 });
   }
-  return NextResponse.json({ success: true });
+
+  const admin = createAdminClient();
+
+  // The target comes from the flag row, never from the request body — a client
+  // can name a flag, not a thread to delete.
+  const { data: flag, error: flagError } = await admin
+    .from("flags")
+    .select("id, thread_id, answer_id")
+    .eq("id", flagId)
+    .maybeSingle();
+
+  if (flagError) {
+    return NextResponse.json({ error: "Lookup failed" }, { status: 500 });
+  }
+  if (!flag) {
+    return NextResponse.json({ error: "Flag not found" }, { status: 404 });
+  }
+
+  const threadId = flag.thread_id;
+  const answerId = flag.answer_id;
+
+  let auditAction: AuditAction;
+
+  if (action === "remove") {
+    let rpc;
+    if (threadId !== null) {
+      rpc = await admin.rpc("moderate_soft_delete_thread", {
+        p_thread_id: threadId,
+      });
+    } else if (answerId !== null) {
+      rpc = await admin.rpc("moderate_soft_delete_answer", {
+        p_answer_id: answerId,
+      });
+    } else {
+      // chk_flag_target_exclusive makes this unreachable; a flag with no target
+      // is corrupt data, not a request to remove nothing.
+      return NextResponse.json(
+        { error: "Flag has no target" },
+        { status: 500 }
+      );
+    }
+    if (rpc.error) {
+      // The RPCs raise on a target that is missing or already tombstoned. That
+      // is a conflict, not a server fault, and must not read as "try again".
+      const gone = /already removed/i.test(rpc.error.message ?? "");
+      console.error("Admin moderation remove failed:", rpc.error.message);
+      return NextResponse.json(
+        { error: gone ? "Content already removed" : "Remove failed" },
+        { status: gone ? 409 : 500 }
+      );
+    }
+    auditAction = threadId ? "removed_thread" : "removed_answer";
+  } else if (action === "lock") {
+    if (!threadId) {
+      return NextResponse.json(
+        { error: "lock applies to thread reports only" },
+        { status: 400 }
+      );
+    }
+    const { error: lockError } = await admin
+      .from("threads")
+      .update({ is_locked: true })
+      .eq("id", threadId);
+    if (lockError) {
+      console.error("Admin moderation lock failed:", lockError.message);
+      return NextResponse.json({ error: "Lock failed" }, { status: 500 });
+    }
+    auditAction = "locked_thread";
+  } else {
+    auditAction = action === "resolve" ? "resolved" : "dismissed";
+  }
+
+  // `remove` settles the report as well as the content; `lock` does not.
+  if (action !== "lock") {
+    const { error } = await admin
+      .from("flags")
+      .update({
+        status: action === "dismiss" ? "dismissed" : "resolved",
+        resolved_at: new Date().toISOString(),
+        resolved_by: auth.userId,
+      })
+      .eq("id", flagId);
+
+    if (error) {
+      return NextResponse.json({ error: "Update failed" }, { status: 500 });
+    }
+  }
+
+  // Audit last, so it only ever records what actually happened. A failure here
+  // is reported (`audited: false`) rather than turned into a 500: the content
+  // action already landed, and a 500 would invite a destructive retry.
+  const { error: auditError } = await admin.from("moderation_actions").insert({
+    action: auditAction,
+    thread_id: threadId,
+    answer_id: answerId,
+    flag_id: flagId,
+    actor_id: auth.userId,
+  });
+  if (auditError) {
+    console.error("Moderation audit write failed:", auditError.message);
+  }
+
+  return NextResponse.json({ success: true, audited: !auditError });
 }

--- a/apps/web/src/components/admin/__tests__/flags-panel.test.tsx
+++ b/apps/web/src/components/admin/__tests__/flags-panel.test.tsx
@@ -13,6 +13,7 @@ const flag = {
   reporter: "alice",
   targetType: "thread" as const,
   preview: "reported post",
+  body: "the whole reported post, in full",
   url: null,
 };
 
@@ -226,5 +227,228 @@ describe("FlagsPanel action-error paths", () => {
       ).toBeInTheDocument()
     );
     expect(screen.queryByText(/offline/)).not.toBeInTheDocument();
+  });
+});
+
+// #1131: the card can now action the reported CONTENT, not just the report.
+const answerFlag = {
+  ...flag,
+  id: "flag-2",
+  targetType: "answer" as const,
+  preview: "reported answer",
+  body: "the whole reported answer",
+};
+
+/** GET returns `flags`; every later POST gets `actionResponse`. */
+function panelWith(
+  flags: unknown[],
+  actionResponse: Record<string, unknown> = {}
+) {
+  const fetchMock = vi.fn().mockImplementation((_url, init?: RequestInit) =>
+    init?.method === "POST"
+      ? Promise.resolve({
+          ok: true,
+          status: 200,
+          json: async () => ({ success: true, audited: true }),
+          ...actionResponse,
+        })
+      : Promise.resolve({ ok: true, json: async () => ({ flags }) })
+  );
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+function postBodies(fetchMock: ReturnType<typeof vi.fn>): unknown[] {
+  return fetchMock.mock.calls
+    .filter(([, init]) => (init as RequestInit | undefined)?.method === "POST")
+    .map(
+      ([, init]) => JSON.parse(String((init as RequestInit).body)) as unknown
+    );
+}
+
+describe("FlagsPanel remove — destructive, so it takes two clicks", () => {
+  it("does NOT post on the first Remove click", async () => {
+    const fetchMock = panelWith([flag]);
+    renderPanel();
+    await waitFor(() =>
+      expect(screen.getByText(flagsMsgs.remove)).toBeInTheDocument()
+    );
+
+    fireEvent.click(screen.getByText(flagsMsgs.remove));
+
+    expect(postBodies(fetchMock)).toEqual([]);
+    expect(
+      screen.getByText(messages.community.confirmDelete)
+    ).toBeInTheDocument();
+  });
+
+  it("posts action:remove once confirmed", async () => {
+    const fetchMock = panelWith([flag]);
+    renderPanel();
+    await waitFor(() =>
+      expect(screen.getByText(flagsMsgs.remove)).toBeInTheDocument()
+    );
+
+    fireEvent.click(screen.getByText(flagsMsgs.remove));
+    fireEvent.click(screen.getByText(messages.community.delete));
+
+    await waitFor(() =>
+      expect(postBodies(fetchMock)).toEqual([
+        { flagId: "flag-1", action: "remove" },
+      ])
+    );
+    // The actioned flag leaves the queue.
+    await waitFor(() =>
+      expect(screen.queryByText(flag.preview)).not.toBeInTheDocument()
+    );
+  });
+
+  it("cancel disarms the confirm without posting", async () => {
+    const fetchMock = panelWith([flag]);
+    renderPanel();
+    await waitFor(() =>
+      expect(screen.getByText(flagsMsgs.remove)).toBeInTheDocument()
+    );
+
+    fireEvent.click(screen.getByText(flagsMsgs.remove));
+    fireEvent.click(screen.getByText(messages.community.cancel));
+
+    expect(postBodies(fetchMock)).toEqual([]);
+    expect(screen.getByText(flagsMsgs.remove)).toBeInTheDocument();
+    expect(screen.getByText(flag.preview)).toBeInTheDocument();
+  });
+
+  it("tells the moderator to reload when the content is already gone (409)", async () => {
+    panelWith([flag], {
+      ok: false,
+      status: 409,
+      json: async () => ({ error: "Content already removed" }),
+    });
+    renderPanel();
+    await waitFor(() =>
+      expect(screen.getByText(flagsMsgs.remove)).toBeInTheDocument()
+    );
+
+    fireEvent.click(screen.getByText(flagsMsgs.remove));
+    fireEvent.click(screen.getByText(messages.community.delete));
+
+    await waitFor(() =>
+      expect(screen.getByText(flagsMsgs.errorConflict)).toBeInTheDocument()
+    );
+    // A conflict is not the generic retry-me failure.
+    expect(screen.queryByText(flagsMsgs.errorFetch)).not.toBeInTheDocument();
+    // …and the flag stays in the queue, since nothing was decided.
+    expect(screen.getByText(flag.preview)).toBeInTheDocument();
+  });
+
+  it("surfaces a rate-limit refusal as its own message", async () => {
+    panelWith([flag], {
+      ok: false,
+      status: 429,
+      json: async () => ({ error: "Too many requests" }),
+    });
+    renderPanel();
+    await waitFor(() =>
+      expect(screen.getByText(flagsMsgs.remove)).toBeInTheDocument()
+    );
+
+    fireEvent.click(screen.getByText(flagsMsgs.remove));
+    fireEvent.click(screen.getByText(messages.community.delete));
+
+    await waitFor(() =>
+      expect(screen.getByText(flagsMsgs.errorRateLimited)).toBeInTheDocument()
+    );
+  });
+
+  it("warns when the action landed but was not audited", async () => {
+    panelWith([flag], {
+      json: async () => ({ success: true, audited: false }),
+    });
+    renderPanel();
+    await waitFor(() =>
+      expect(screen.getByText(flagsMsgs.remove)).toBeInTheDocument()
+    );
+
+    fireEvent.click(screen.getByText(flagsMsgs.remove));
+    fireEvent.click(screen.getByText(messages.community.delete));
+
+    await waitFor(() =>
+      expect(screen.getByText(flagsMsgs.auditWarning)).toBeInTheDocument()
+    );
+  });
+});
+
+describe("FlagsPanel lock — thread-only, non-terminal", () => {
+  it("offers Lock on a thread report and keeps the card after locking", async () => {
+    const fetchMock = panelWith([flag]);
+    renderPanel();
+    await waitFor(() =>
+      expect(screen.getByText(flagsMsgs.lock)).toBeInTheDocument()
+    );
+
+    fireEvent.click(screen.getByText(flagsMsgs.lock));
+
+    await waitFor(() =>
+      expect(postBodies(fetchMock)).toEqual([
+        { flagId: "flag-1", action: "lock" },
+      ])
+    );
+    // A lock does not settle the report, so the card stays…
+    expect(screen.getByText(flag.preview)).toBeInTheDocument();
+    // …and the button stops offering a no-op.
+    await waitFor(() =>
+      expect(screen.getByText(flagsMsgs.locked)).toBeInTheDocument()
+    );
+    expect(
+      screen.getByRole("button", { name: flagsMsgs.locked })
+    ).toBeDisabled();
+  });
+
+  it("offers no Lock on an answer report — there is no thread of its own", async () => {
+    panelWith([answerFlag]);
+    renderPanel();
+    await waitFor(() =>
+      expect(screen.getByText(answerFlag.preview)).toBeInTheDocument()
+    );
+
+    expect(screen.queryByText(flagsMsgs.lock)).not.toBeInTheDocument();
+    // Remove is still available on an answer.
+    expect(screen.getByText(flagsMsgs.remove)).toBeInTheDocument();
+  });
+});
+
+describe("FlagsPanel link-less cards expose the content", () => {
+  it("renders the full body in an expandable block when there is no link", async () => {
+    panelWith([flag]);
+    renderPanel();
+
+    await waitFor(() =>
+      expect(screen.getByText(flagsMsgs.showContent)).toBeInTheDocument()
+    );
+    expect(screen.getByText(flag.body)).toBeInTheDocument();
+    expect(screen.queryByText(flagsMsgs.view)).not.toBeInTheDocument();
+  });
+
+  it("links out instead when the target URL resolved", async () => {
+    panelWith([{ ...flag, url: "/en/community/general/reported-title-ab12" }]);
+    renderPanel();
+
+    await waitFor(() =>
+      expect(screen.getByText(flagsMsgs.view)).toBeInTheDocument()
+    );
+    expect(screen.getByText(flagsMsgs.view)).toHaveAttribute(
+      "href",
+      "/en/community/general/reported-title-ab12"
+    );
+    expect(screen.queryByText(flagsMsgs.showContent)).not.toBeInTheDocument();
+  });
+
+  it("says so rather than rendering an empty block when the body is missing too", async () => {
+    panelWith([{ ...flag, body: "" }]);
+    renderPanel();
+
+    await waitFor(() =>
+      expect(screen.getByText(flagsMsgs.contentUnavailable)).toBeInTheDocument()
+    );
   });
 });

--- a/apps/web/src/components/admin/__tests__/flags-panel.test.tsx
+++ b/apps/web/src/components/admin/__tests__/flags-panel.test.tsx
@@ -359,23 +359,6 @@ describe("FlagsPanel remove — destructive, so it takes two clicks", () => {
       expect(screen.getByText(flagsMsgs.errorRateLimited)).toBeInTheDocument()
     );
   });
-
-  it("warns when the action landed but was not audited", async () => {
-    panelWith([flag], {
-      json: async () => ({ success: true, audited: false }),
-    });
-    renderPanel();
-    await waitFor(() =>
-      expect(screen.getByText(flagsMsgs.remove)).toBeInTheDocument()
-    );
-
-    fireEvent.click(screen.getByText(flagsMsgs.remove));
-    fireEvent.click(screen.getByText(messages.community.delete));
-
-    await waitFor(() =>
-      expect(screen.getByText(flagsMsgs.auditWarning)).toBeInTheDocument()
-    );
-  });
 });
 
 describe("FlagsPanel lock — thread-only, non-terminal", () => {

--- a/apps/web/src/components/admin/flags-panel.tsx
+++ b/apps/web/src/components/admin/flags-panel.tsx
@@ -11,11 +11,26 @@ interface ModerationFlag {
   reporter: string | null;
   targetType: "thread" | "answer";
   preview: string;
+  body: string;
   url: string | null;
 }
 
-/** Which failure the last action hit — mapped to a translated string by the UI. */
-type ActionError = "fetch" | "network";
+/**
+ * Which failure the last action hit — mapped to a translated string by the UI.
+ * `conflict` is the 409 the route returns when the content is already gone, and
+ * `rateLimited` its 429: both mean "don't just retry", unlike a plain 500.
+ */
+type ActionError = "fetch" | "network" | "conflict" | "rateLimited";
+
+const ACTION_ERROR_KEY: Record<ActionError, string> = {
+  fetch: "errorFetch",
+  network: "errorNetwork",
+  conflict: "errorConflict",
+  rateLimited: "errorRateLimited",
+};
+
+/** What the moderator can do to a flag from the card. */
+type FlagAction = "resolve" | "dismiss" | "remove" | "lock";
 
 /**
  * Which failure the last queue load hit. `unauthorized` is split out from
@@ -37,11 +52,22 @@ export function FlagsPanel({
 }) {
   const t = useTranslations("admin.flags");
   const tAdmin = useTranslations("admin");
+  const tCommunity = useTranslations("community");
   const [flags, setFlags] = useState<ModerationFlag[]>([]);
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState<LoadError | null>(null);
   const [busyId, setBusyId] = useState<string | null>(null);
   const [error, setError] = useState<ActionError | null>(null);
+  // Removal is destructive and irreversible from this panel, so it takes a
+  // second, deliberate click. Only one card can be armed at a time.
+  const [confirmingId, setConfirmingId] = useState<string | null>(null);
+  // Threads locked in this session — `lock` leaves the flag pending, so the
+  // card stays and its Lock button must stop offering a no-op.
+  const [lockedIds, setLockedIds] = useState<string[]>([]);
+  // Expanded "read the reported content here" blocks.
+  const [expandedIds, setExpandedIds] = useState<string[]>([]);
+  // The action landed but its audit row did not — reported, never swallowed.
+  const [auditWarning, setAuditWarning] = useState(false);
 
   // A failed load must never read as "queue is clear" (#1132), so it drops
   // whatever was on screen and renders the failed branch instead of the list.
@@ -76,9 +102,10 @@ export function FlagsPanel({
     onCountChange?.(flags.length);
   }, [flags, onCountChange]);
 
-  async function act(flagId: string, action: "resolve" | "dismiss") {
+  async function act(flagId: string, action: FlagAction) {
     setBusyId(flagId);
     setError(null);
+    setAuditWarning(false);
     try {
       const res = await fetch("/api/admin/flags", {
         method: "POST",
@@ -91,7 +118,23 @@ export function FlagsPanel({
           "Admin flag action failed:",
           body.error ?? `Request failed (${res.status})`
         );
-        setError("fetch");
+        setError(
+          res.status === 409
+            ? "conflict"
+            : res.status === 429
+              ? "rateLimited"
+              : "fetch"
+        );
+        return;
+      }
+      const body = (await res.json().catch(() => ({}))) as {
+        audited?: boolean;
+      };
+      if (body.audited === false) setAuditWarning(true);
+
+      if (action === "lock") {
+        // A lock does not settle the report: the card stays, the button stops.
+        setLockedIds((prev) => [...prev, flagId]);
         return;
       }
       // Optimistically drop the actioned flag.
@@ -101,6 +144,7 @@ export function FlagsPanel({
       setError("network");
     } finally {
       setBusyId(null);
+      setConfirmingId(null);
     }
   }
 
@@ -116,7 +160,16 @@ export function FlagsPanel({
           role="alert"
           className="rounded-md border border-streak bg-streak-light p-3 text-sm text-streak"
         >
-          {t(error === "network" ? "errorNetwork" : "errorFetch")}
+          {t(ACTION_ERROR_KEY[error])}
+        </div>
+      )}
+
+      {auditWarning && (
+        <div
+          role="alert"
+          className="rounded-md border border-streak bg-streak-light p-3 text-sm text-streak"
+        >
+          {t("auditWarning")}
         </div>
       )}
 
@@ -170,7 +223,37 @@ export function FlagsPanel({
               {flag.details && (
                 <p className="mt-1 text-xs text-text-2">“{flag.details}”</p>
               )}
-              <div className="mt-2 flex items-center gap-3">
+
+              {/* No link means the thread or category lookup failed. The
+                  moderator still has to decide, so the reported content itself
+                  is offered here rather than a 200-char preview and nothing. */}
+              {!flag.url && (
+                <details
+                  open={expandedIds.includes(flag.id)}
+                  onToggle={(e) => {
+                    const open = (e.currentTarget as HTMLDetailsElement).open;
+                    setExpandedIds((prev) =>
+                      open
+                        ? [...new Set([...prev, flag.id])]
+                        : prev.filter((id) => id !== flag.id)
+                    );
+                  }}
+                  className="bg-bg-2 mt-2 rounded-md border border-border p-2"
+                >
+                  <summary className="cursor-pointer text-xs text-text-2">
+                    {t("showContent")}
+                  </summary>
+                  <p className="mt-2 whitespace-pre-wrap break-words text-xs text-text">
+                    {flag.body || (
+                      <span className="italic text-text-3">
+                        {t("contentUnavailable")}
+                      </span>
+                    )}
+                  </p>
+                </details>
+              )}
+
+              <div className="mt-2 flex flex-wrap items-center gap-3">
                 {flag.url && (
                   <a
                     href={flag.url}
@@ -181,6 +264,53 @@ export function FlagsPanel({
                     {t("view")}
                   </a>
                 )}
+
+                {confirmingId === flag.id ? (
+                  <>
+                    <span className="text-xs text-danger">
+                      {tCommunity("confirmDelete")}
+                    </span>
+                    <button
+                      type="button"
+                      onClick={() => void act(flag.id, "remove")}
+                      disabled={busyId === flag.id}
+                      className="rounded-md border border-danger bg-danger-light px-2.5 py-1 text-xs font-medium text-danger disabled:opacity-50"
+                    >
+                      {tCommunity("delete")}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => setConfirmingId(null)}
+                      disabled={busyId === flag.id}
+                      className="rounded-md border border-border px-2.5 py-1 text-xs font-medium text-text-2 disabled:opacity-50"
+                    >
+                      {tCommunity("cancel")}
+                    </button>
+                  </>
+                ) : (
+                  <button
+                    type="button"
+                    onClick={() => setConfirmingId(flag.id)}
+                    disabled={busyId === flag.id}
+                    className="rounded-md border border-danger bg-danger-light px-2.5 py-1 text-xs font-medium text-danger disabled:opacity-50"
+                  >
+                    {t("remove")}
+                  </button>
+                )}
+
+                {/* Locking is a thread-level control; an answer report has no
+                    thread of its own to lock. */}
+                {flag.targetType === "thread" && (
+                  <button
+                    type="button"
+                    onClick={() => void act(flag.id, "lock")}
+                    disabled={busyId === flag.id || lockedIds.includes(flag.id)}
+                    className="rounded-md border border-border px-2.5 py-1 text-xs font-medium text-text-2 disabled:opacity-50"
+                  >
+                    {lockedIds.includes(flag.id) ? t("locked") : t("lock")}
+                  </button>
+                )}
+
                 <button
                   type="button"
                   onClick={() => void act(flag.id, "resolve")}

--- a/apps/web/src/components/admin/flags-panel.tsx
+++ b/apps/web/src/components/admin/flags-panel.tsx
@@ -66,8 +66,6 @@ export function FlagsPanel({
   const [lockedIds, setLockedIds] = useState<string[]>([]);
   // Expanded "read the reported content here" blocks.
   const [expandedIds, setExpandedIds] = useState<string[]>([]);
-  // The action landed but its audit row did not — reported, never swallowed.
-  const [auditWarning, setAuditWarning] = useState(false);
 
   // A failed load must never read as "queue is clear" (#1132), so it drops
   // whatever was on screen and renders the failed branch instead of the list.
@@ -105,7 +103,6 @@ export function FlagsPanel({
   async function act(flagId: string, action: FlagAction) {
     setBusyId(flagId);
     setError(null);
-    setAuditWarning(false);
     try {
       const res = await fetch("/api/admin/flags", {
         method: "POST",
@@ -127,11 +124,6 @@ export function FlagsPanel({
         );
         return;
       }
-      const body = (await res.json().catch(() => ({}))) as {
-        audited?: boolean;
-      };
-      if (body.audited === false) setAuditWarning(true);
-
       if (action === "lock") {
         // A lock does not settle the report: the card stays, the button stops.
         setLockedIds((prev) => [...prev, flagId]);
@@ -161,15 +153,6 @@ export function FlagsPanel({
           className="rounded-md border border-streak bg-streak-light p-3 text-sm text-streak"
         >
           {t(ACTION_ERROR_KEY[error])}
-        </div>
-      )}
-
-      {auditWarning && (
-        <div
-          role="alert"
-          className="rounded-md border border-streak bg-streak-light p-3 text-sm text-streak"
-        >
-          {t("auditWarning")}
         </div>
       )}
 

--- a/apps/web/src/lib/supabase/__tests__/moderation-actions-execution.test.ts
+++ b/apps/web/src/lib/supabase/__tests__/moderation-actions-execution.test.ts
@@ -1,0 +1,435 @@
+// REAL SQL-execution proof of the moderator soft-delete RPCs (#1131), run in
+// in-process Postgres (pglite) against BOTH copies of the DDL: the migration
+// that gets applied, and the supabase/schema.sql mirror fresh environments are
+// built from.
+//
+// What has to hold, and why:
+//   1. These functions delete content with NO ownership check — that is the
+//      whole point of a moderator action — so the only thing standing between
+//      "admin removes spam" and "any logged-in user removes anything" is the
+//      REVOKE/GRANT. anon and authenticated must not be able to execute them.
+//      That case is red-proofed in-suite: grant EXECUTE back and the call
+//      succeeds, so the denial is provably the REVOKE and not an accident of
+//      the stub.
+//   2. The cascade semantics must match the author-gated originals (thread →
+//      its answers; answer → answer_count decrement + un-accept), because
+//      moderation removing content differently from an author deleting it is
+//      how denormalized counters drift.
+//   3. The removed target's creation XP is clawed back. Also red-proofed
+//      in-suite: the same cascade WITHOUT the revoke leaves the XP behind.
+//
+// @vitest-environment node
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { PGlite } from "@electric-sql/pglite";
+import { describe, it, expect, beforeAll, beforeEach } from "vitest";
+
+function findRepoRoot(): string {
+  let dir = dirname(fileURLToPath(import.meta.url));
+  while (!existsSync(resolve(dir, "supabase/schema.sql"))) {
+    const parent = dirname(dir);
+    if (parent === dir)
+      throw new Error("repo root (supabase/schema.sql) not found");
+    dir = parent;
+  }
+  return dir;
+}
+
+const repoRoot = findRepoRoot();
+const migration = readFileSync(
+  resolve(
+    repoRoot,
+    "supabase/migrations/20260820160000_moderation_actions.sql"
+  ),
+  "utf8"
+);
+const schema = readFileSync(resolve(repoRoot, "supabase/schema.sql"), "utf8");
+
+// Definitions name their parameter; grants use the bare argument type.
+const THREAD_FN = "public.moderate_soft_delete_thread(p_thread_id UUID)";
+const ANSWER_FN = "public.moderate_soft_delete_answer(p_answer_id UUID)";
+const THREAD_SIG = "public.moderate_soft_delete_thread(UUID)";
+const ANSWER_SIG = "public.moderate_soft_delete_answer(UUID)";
+
+/** Pull one `CREATE OR REPLACE FUNCTION <sig> … $$;` block out of a SQL file. */
+function extractFunction(sql: string, signature: string): string {
+  const start = sql.indexOf(`CREATE OR REPLACE FUNCTION ${signature}`);
+  if (start < 0) throw new Error(`function ${signature} not found`);
+  const end = sql.indexOf("$$;", start);
+  if (end < 0) throw new Error(`unterminated body for ${signature}`);
+  return sql.slice(start, end + 3);
+}
+
+/** Pull one single-statement `<needle>…;` out of a SQL file. */
+function extractStatement(sql: string, needle: string): string {
+  const start = sql.indexOf(needle);
+  if (start < 0) throw new Error(`statement not found: ${needle}`);
+  const end = sql.indexOf(";", start);
+  if (end < 0) throw new Error(`unterminated statement: ${needle}`);
+  return sql.slice(start, end + 1);
+}
+
+// Both copies are assembled from their OWN file's statements, never from
+// literals written here — a schema.sql that lost a REVOKE fails at extraction
+// instead of quietly testing this file's idea of it.
+function grants(sql: string, fn: string): string {
+  return [
+    extractStatement(sql, `REVOKE EXECUTE ON FUNCTION ${fn} FROM`),
+    extractStatement(sql, `GRANT EXECUTE ON FUNCTION ${fn} TO`),
+  ].join("\n");
+}
+
+/** Pull one `CREATE TABLE [IF NOT EXISTS] <name> ( … \n);` block out of a file. */
+function extractTable(sql: string, name: string): string {
+  const start = sql.search(
+    new RegExp(`CREATE TABLE (IF NOT EXISTS )?${name} \\(`)
+  );
+  if (start < 0) throw new Error(`table ${name} not found`);
+  const end = sql.indexOf("\n);", start);
+  if (end < 0) throw new Error(`unterminated table ${name}`);
+  return sql.slice(start, end + 3);
+}
+
+// The migration copy runs the file WHOLE — not a hand-picked set of statements
+// — so a stray `GRANT … TO authenticated` anywhere in it would be applied too,
+// and the denial cases below would catch it.
+const copies = {
+  migration,
+  "schema.sql mirror": [
+    extractTable(schema, "moderation_actions"),
+    extractFunction(schema, THREAD_FN),
+    extractFunction(schema, ANSWER_FN),
+    grants(schema, THREAD_SIG),
+    grants(schema, ANSWER_SIG),
+  ].join("\n"),
+};
+
+// The real revoke_community_xp, lifted from schema.sql — the clawback is only
+// as good as the function it delegates to, including its GREATEST(0, …) floor.
+const REVOKE_XP = extractFunction(
+  schema,
+  `revoke_community_xp(
+  p_user_id UUID,
+  p_idempotency_key TEXT
+)`
+);
+
+// Minimal stand-in for the community surface these functions touch.
+const STUB_SETUP = `
+  CREATE ROLE anon;
+  CREATE ROLE authenticated;
+  CREATE ROLE service_role BYPASSRLS;
+
+  CREATE TABLE public.profiles (id uuid PRIMARY KEY, username text);
+
+  CREATE TABLE public.threads (
+    id uuid PRIMARY KEY,
+    author_id uuid NOT NULL REFERENCES public.profiles(id),
+    is_solved boolean NOT NULL DEFAULT false,
+    accepted_answer_id uuid,
+    answer_count int NOT NULL DEFAULT 0,
+    is_locked boolean NOT NULL DEFAULT false,
+    deleted_at timestamptz
+  );
+
+  CREATE TABLE public.answers (
+    id uuid PRIMARY KEY,
+    thread_id uuid NOT NULL REFERENCES public.threads(id),
+    author_id uuid NOT NULL REFERENCES public.profiles(id),
+    is_accepted boolean NOT NULL DEFAULT false,
+    deleted_at timestamptz
+  );
+
+  -- Only the columns the audit table's FK needs.
+  CREATE TABLE public.flags (id uuid PRIMARY KEY, status text NOT NULL DEFAULT 'pending');
+
+  CREATE TABLE public.user_xp (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id uuid UNIQUE NOT NULL REFERENCES public.profiles(id),
+    total_xp integer DEFAULT 0,
+    level integer DEFAULT 0
+  );
+
+  CREATE TABLE public.xp_transactions (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id uuid NOT NULL REFERENCES public.profiles(id),
+    amount integer NOT NULL,
+    reason text NOT NULL,
+    idempotency_key text,
+    source text NOT NULL DEFAULT 'community'
+  );
+`;
+
+const AUTHOR = "11111111-1111-1111-1111-111111111111";
+const ANSWERER = "22222222-2222-2222-2222-222222222222";
+const THREAD = "aaaaaaaa-0000-0000-0000-000000000001";
+const ANSWER_A = "bbbbbbbb-0000-0000-0000-000000000001";
+const ANSWER_B = "bbbbbbbb-0000-0000-0000-000000000002";
+
+interface XpRow {
+  total_xp: number;
+  level: number;
+}
+
+async function become(
+  db: PGlite,
+  role: "anon" | "authenticated" | "service_role"
+): Promise<void> {
+  await db.exec("RESET ROLE;");
+  await db.exec(`SET ROLE ${role};`);
+}
+
+async function xpOf(db: PGlite, userId: string): Promise<XpRow> {
+  await db.exec("RESET ROLE;");
+  const { rows } = await db.query<XpRow>(
+    `SELECT total_xp, level FROM public.user_xp WHERE user_id = $1`,
+    [userId]
+  );
+  return rows[0] as XpRow;
+}
+
+async function scalar<T>(db: PGlite, sql: string, args: unknown[]): Promise<T> {
+  await db.exec("RESET ROLE;");
+  const { rows } = await db.query<Record<string, T>>(sql, args);
+  return Object.values(rows[0] as Record<string, T>)[0] as T;
+}
+
+for (const [copy, ddl] of Object.entries(copies)) {
+  describe(`#1131 moderator soft-delete RPCs — ${copy}`, () => {
+    let db: PGlite;
+
+    beforeAll(async () => {
+      db = new PGlite();
+      await db.exec(STUB_SETUP);
+      await db.exec(REVOKE_XP);
+      await db.exec(ddl);
+    }, 60_000);
+
+    beforeEach(async () => {
+      await db.exec("RESET ROLE;");
+      // Re-apply the whole DDL every time: the red-proof below hands EXECUTE
+      // back to `authenticated`, and a failure partway through it must not
+      // silently disarm the rest of the suite. The audit table is dropped
+      // first because schema.sql's copy is a plain CREATE TABLE.
+      await db.exec("DROP TABLE IF EXISTS public.moderation_actions CASCADE;");
+      await db.exec(ddl);
+      await db.exec(
+        "TRUNCATE public.xp_transactions, public.user_xp, public.answers, public.threads, public.profiles CASCADE;"
+      );
+      await db.query(
+        `INSERT INTO public.profiles(id, username) VALUES ($1,'author'), ($2,'answerer')`,
+        [AUTHOR, ANSWERER]
+      );
+      await db.query(
+        `INSERT INTO public.threads(id, author_id, answer_count, is_solved, accepted_answer_id)
+         VALUES ($1, $2, 2, true, $3)`,
+        [THREAD, AUTHOR, ANSWER_A]
+      );
+      await db.query(
+        `INSERT INTO public.answers(id, thread_id, author_id, is_accepted)
+         VALUES ($1, $2, $3, true), ($4, $2, $3, false)`,
+        [ANSWER_A, THREAD, ANSWERER, ANSWER_B]
+      );
+      // XP as the community routes award it: 20 for the thread, 10 per answer,
+      // plus an upvote award that v1 deliberately does NOT claw back.
+      await db.query(
+        `INSERT INTO public.user_xp(user_id, total_xp, level) VALUES ($1, 25, 0), ($2, 30, 0)`,
+        [AUTHOR, ANSWERER]
+      );
+      await db.query(
+        `INSERT INTO public.xp_transactions(user_id, amount, reason, idempotency_key)
+         VALUES ($1, 20, 'community:thread_created', $3),
+                ($1, 5,  'community:upvote_received', 'vote:up:' || $3),
+                ($2, 10, 'community:answer_posted', $4),
+                ($2, 20, 'community:answer_posted', $5)`,
+        [
+          AUTHOR,
+          ANSWERER,
+          `thread:${THREAD}`,
+          `answer:${ANSWER_A}`,
+          `answer:${ANSWER_B}`,
+        ]
+      );
+    });
+
+    it("thread removal tombstones the thread and cascades to its live answers", async () => {
+      await become(db, "service_role");
+      await db.query(`SELECT public.moderate_soft_delete_thread($1)`, [THREAD]);
+
+      expect(
+        await scalar<string | null>(
+          db,
+          `SELECT deleted_at FROM public.threads WHERE id = $1`,
+          [THREAD]
+        )
+      ).not.toBeNull();
+      expect(
+        await scalar<number>(
+          db,
+          `SELECT count(*)::int FROM public.answers WHERE thread_id = $1 AND deleted_at IS NULL`,
+          [THREAD]
+        )
+      ).toBe(0);
+    });
+
+    it("thread removal claws back the thread's own creation XP — and only that", async () => {
+      await become(db, "service_role");
+      await db.query(`SELECT public.moderate_soft_delete_thread($1)`, [THREAD]);
+
+      // 25 - 20 (thread:<id>) = 5. The 5 XP of upvote award stays: v1 does not
+      // reverse vote XP, and this test is what pins that scope.
+      expect(await xpOf(db, AUTHOR)).toMatchObject({ total_xp: 5 });
+      expect(
+        await scalar<number>(
+          db,
+          `SELECT count(*)::int FROM public.xp_transactions WHERE idempotency_key = $1`,
+          [`thread:${THREAD}`]
+        )
+      ).toBe(0);
+      // The cascaded answers' XP is likewise NOT reversed in v1.
+      expect(await xpOf(db, ANSWERER)).toMatchObject({ total_xp: 30 });
+    });
+
+    it("RED-PROOF: the same cascade without the clawback leaves the XP behind", async () => {
+      // The literal body of the author-gated original — cascade, no revoke. If
+      // the assertion above could pass without the PERFORM line, this would
+      // show 5 as well.
+      await db.exec("RESET ROLE;");
+      await db.query(
+        `UPDATE public.threads SET deleted_at = NOW() WHERE id = $1`,
+        [THREAD]
+      );
+      await db.query(
+        `UPDATE public.answers SET deleted_at = NOW() WHERE thread_id = $1 AND deleted_at IS NULL`,
+        [THREAD]
+      );
+
+      expect(await xpOf(db, AUTHOR)).toMatchObject({ total_xp: 25 });
+    });
+
+    it("answer removal decrements answer_count, un-accepts, and revokes its XP", async () => {
+      await become(db, "service_role");
+      await db.query(`SELECT public.moderate_soft_delete_answer($1)`, [
+        ANSWER_A,
+      ]);
+
+      expect(
+        await scalar<number>(
+          db,
+          `SELECT answer_count FROM public.threads WHERE id = $1`,
+          [THREAD]
+        )
+      ).toBe(1);
+      expect(
+        await scalar<boolean>(
+          db,
+          `SELECT is_solved FROM public.threads WHERE id = $1`,
+          [THREAD]
+        )
+      ).toBe(false);
+      expect(
+        await scalar<string | null>(
+          db,
+          `SELECT accepted_answer_id FROM public.threads WHERE id = $1`,
+          [THREAD]
+        )
+      ).toBeNull();
+      // 30 - 10 (answer:<id>); the second answer's 20 is untouched.
+      expect(await xpOf(db, ANSWERER)).toMatchObject({ total_xp: 20 });
+    });
+
+    it("answer_count never goes negative", async () => {
+      await db.exec("RESET ROLE;");
+      await db.query(
+        `UPDATE public.threads SET answer_count = 0 WHERE id = $1`,
+        [THREAD]
+      );
+
+      await become(db, "service_role");
+      await db.query(`SELECT public.moderate_soft_delete_answer($1)`, [
+        ANSWER_B,
+      ]);
+
+      expect(
+        await scalar<number>(
+          db,
+          `SELECT answer_count FROM public.threads WHERE id = $1`,
+          [THREAD]
+        )
+      ).toBe(0);
+    });
+
+    it("user_xp floors at 0 when the clawback exceeds the balance", async () => {
+      await db.exec("RESET ROLE;");
+      // A learner who has since spent/lost XP: 20 owed back, 4 on hand.
+      await db.query(
+        `UPDATE public.user_xp SET total_xp = 4 WHERE user_id = $1`,
+        [AUTHOR]
+      );
+
+      await become(db, "service_role");
+      await db.query(`SELECT public.moderate_soft_delete_thread($1)`, [THREAD]);
+
+      expect(await xpOf(db, AUTHOR)).toEqual({ total_xp: 0, level: 0 });
+    });
+
+    it("refuses a second removal instead of double-revoking", async () => {
+      await become(db, "service_role");
+      await db.query(`SELECT public.moderate_soft_delete_thread($1)`, [THREAD]);
+
+      await expect(
+        db.query(`SELECT public.moderate_soft_delete_thread($1)`, [THREAD])
+      ).rejects.toThrow(/already removed/i);
+
+      await expect(
+        db.query(`SELECT public.moderate_soft_delete_answer($1)`, [ANSWER_A])
+      ).rejects.toThrow(/already removed/i);
+    });
+
+    // The security assertion: these functions have no ownership check, so
+    // execute privilege IS the authorization.
+    for (const role of ["anon", "authenticated"] as const) {
+      it(`${role} cannot execute either moderator RPC`, async () => {
+        await become(db, role);
+
+        await expect(
+          db.query(`SELECT public.moderate_soft_delete_thread($1)`, [THREAD])
+        ).rejects.toThrow(/permission denied/i);
+        await expect(
+          db.query(`SELECT public.moderate_soft_delete_answer($1)`, [ANSWER_A])
+        ).rejects.toThrow(/permission denied/i);
+
+        // Nothing was removed by the attempt.
+        expect(
+          await scalar<string | null>(
+            db,
+            `SELECT deleted_at FROM public.threads WHERE id = $1`,
+            [THREAD]
+          )
+        ).toBeNull();
+      });
+    }
+
+    it("RED-PROOF: granting EXECUTE back lets authenticated delete anything", async () => {
+      // Proves the denial above comes from the REVOKE in the DDL under test —
+      // not from the stub, the search_path, or a missing table grant. With the
+      // grant restored, a plain logged-in user removes someone else's thread.
+      await db.exec("RESET ROLE;");
+      await db.exec(
+        `GRANT EXECUTE ON FUNCTION public.moderate_soft_delete_thread(UUID) TO authenticated;`
+      );
+
+      await become(db, "authenticated");
+      await db.query(`SELECT public.moderate_soft_delete_thread($1)`, [THREAD]);
+
+      expect(
+        await scalar<string | null>(
+          db,
+          `SELECT deleted_at FROM public.threads WHERE id = $1`,
+          [THREAD]
+        )
+      ).not.toBeNull();
+    });
+  });
+}

--- a/apps/web/src/lib/supabase/__tests__/moderation-actions-execution.test.ts
+++ b/apps/web/src/lib/supabase/__tests__/moderation-actions-execution.test.ts
@@ -1,22 +1,23 @@
-// REAL SQL-execution proof of the moderator soft-delete RPCs (#1131), run in
+// REAL SQL-execution proof of the moderator action RPCs (#1131), run in
 // in-process Postgres (pglite) against BOTH copies of the DDL: the migration
 // that gets applied, and the supabase/schema.sql mirror fresh environments are
 // built from.
 //
 // What has to hold, and why:
-//   1. These functions delete content with NO ownership check — that is the
-//      whole point of a moderator action — so the only thing standing between
-//      "admin removes spam" and "any logged-in user removes anything" is the
+//   1. These functions change content with NO ownership check — that is the
+//      whole point of a moderator action — so the only thing between "admin
+//      removes spam" and "any logged-in user removes anything" is the
 //      REVOKE/GRANT. anon and authenticated must not be able to execute them.
-//      That case is red-proofed in-suite: grant EXECUTE back and the call
-//      succeeds, so the denial is provably the REVOKE and not an accident of
-//      the stub.
-//   2. The cascade semantics must match the author-gated originals (thread →
-//      its answers; answer → answer_count decrement + un-accept), because
-//      moderation removing content differently from an author deleting it is
-//      how denormalized counters drift.
-//   3. The removed target's creation XP is clawed back. Also red-proofed
-//      in-suite: the same cascade WITHOUT the revoke leaves the XP behind.
+//      Red-proofed in-suite: grant EXECUTE back and the call succeeds.
+//   2. ATOMICITY. Each RPC does the content change, the flag write, and the
+//      audit INSERT in one transaction. If any step raises, ALL of it must roll
+//      back — content must never be removed with no audit row. Red-proofed
+//      in-suite: a trigger that raises on the audit INSERT leaves the content,
+//      the XP, and the flag exactly as they were.
+//   3. The removed target's creation XP is clawed back — and only that. Also
+//      red-proofed: the same cascade WITHOUT the revoke leaves the XP behind.
+//   4. Cascade semantics match the author-gated originals (thread → its answers;
+//      answer → answer_count decrement + un-accept), so counters don't drift.
 //
 // @vitest-environment node
 import { existsSync, readFileSync } from "node:fs";
@@ -46,40 +47,6 @@ const migration = readFileSync(
 );
 const schema = readFileSync(resolve(repoRoot, "supabase/schema.sql"), "utf8");
 
-// Definitions name their parameter; grants use the bare argument type.
-const THREAD_FN = "public.moderate_soft_delete_thread(p_thread_id UUID)";
-const ANSWER_FN = "public.moderate_soft_delete_answer(p_answer_id UUID)";
-const THREAD_SIG = "public.moderate_soft_delete_thread(UUID)";
-const ANSWER_SIG = "public.moderate_soft_delete_answer(UUID)";
-
-/** Pull one `CREATE OR REPLACE FUNCTION <sig> … $$;` block out of a SQL file. */
-function extractFunction(sql: string, signature: string): string {
-  const start = sql.indexOf(`CREATE OR REPLACE FUNCTION ${signature}`);
-  if (start < 0) throw new Error(`function ${signature} not found`);
-  const end = sql.indexOf("$$;", start);
-  if (end < 0) throw new Error(`unterminated body for ${signature}`);
-  return sql.slice(start, end + 3);
-}
-
-/** Pull one single-statement `<needle>…;` out of a SQL file. */
-function extractStatement(sql: string, needle: string): string {
-  const start = sql.indexOf(needle);
-  if (start < 0) throw new Error(`statement not found: ${needle}`);
-  const end = sql.indexOf(";", start);
-  if (end < 0) throw new Error(`unterminated statement: ${needle}`);
-  return sql.slice(start, end + 1);
-}
-
-// Both copies are assembled from their OWN file's statements, never from
-// literals written here — a schema.sql that lost a REVOKE fails at extraction
-// instead of quietly testing this file's idea of it.
-function grants(sql: string, fn: string): string {
-  return [
-    extractStatement(sql, `REVOKE EXECUTE ON FUNCTION ${fn} FROM`),
-    extractStatement(sql, `GRANT EXECUTE ON FUNCTION ${fn} TO`),
-  ].join("\n");
-}
-
 /** Pull one `CREATE TABLE [IF NOT EXISTS] <name> ( … \n);` block out of a file. */
 function extractTable(sql: string, name: string): string {
   const start = sql.search(
@@ -93,27 +60,57 @@ function extractTable(sql: string, name: string): string {
 
 // The migration copy runs the file WHOLE — not a hand-picked set of statements
 // — so a stray `GRANT … TO authenticated` anywhere in it would be applied too,
-// and the denial cases below would catch it.
-const copies = {
-  migration,
-  "schema.sql mirror": [
-    extractTable(schema, "moderation_actions"),
-    extractFunction(schema, THREAD_FN),
-    extractFunction(schema, ANSWER_FN),
-    grants(schema, THREAD_SIG),
-    grants(schema, ANSWER_SIG),
-  ].join("\n"),
-};
+// and the denial cases below would catch it. The schema.sql mirror is assembled
+// from schema.sql's OWN statements so a mirror that lost a REVOKE fails at
+// extraction instead of testing this file's idea of it.
+function extractFromSchema(name: string): string {
+  const create = new RegExp(`CREATE OR REPLACE FUNCTION public\\.${name}\\(`);
+  const start = schema.search(create);
+  if (start < 0) throw new Error(`function ${name} not found in schema.sql`);
+  const end = schema.indexOf("$$;", start);
+  if (end < 0) throw new Error(`unterminated body for ${name}`);
+  return schema.slice(start, end + 3);
+}
+
+function extractGrants(name: string, args: string): string {
+  const revoke = schema.indexOf(
+    `REVOKE EXECUTE ON FUNCTION public.${name}(${args}) FROM`
+  );
+  const grant = schema.indexOf(
+    `GRANT EXECUTE ON FUNCTION public.${name}(${args}) TO`
+  );
+  if (revoke < 0 || grant < 0)
+    throw new Error(`grants for ${name} not found in schema.sql`);
+  return [
+    schema.slice(revoke, schema.indexOf(";", revoke) + 1),
+    schema.slice(grant, schema.indexOf(";", grant) + 1),
+  ].join("\n");
+}
+
+const UUID3 = "UUID, UUID, UUID";
+const mirror = [
+  extractTable(schema, "moderation_actions"),
+  extractFromSchema("moderate_soft_delete_thread"),
+  extractFromSchema("moderate_soft_delete_answer"),
+  extractFromSchema("moderate_lock_thread"),
+  extractFromSchema("moderate_resolve_flag"),
+  extractGrants("moderate_soft_delete_thread", UUID3),
+  extractGrants("moderate_soft_delete_answer", UUID3),
+  extractGrants("moderate_lock_thread", UUID3),
+  extractGrants("moderate_resolve_flag", "UUID, BOOLEAN, UUID"),
+].join("\n");
+
+const copies = { migration, "schema.sql mirror": mirror };
 
 // The real revoke_community_xp, lifted from schema.sql — the clawback is only
 // as good as the function it delegates to, including its GREATEST(0, …) floor.
-const REVOKE_XP = extractFunction(
-  schema,
-  `revoke_community_xp(
-  p_user_id UUID,
-  p_idempotency_key TEXT
-)`
-);
+const REVOKE_XP = (() => {
+  const start = schema.indexOf(
+    `CREATE OR REPLACE FUNCTION revoke_community_xp(`
+  );
+  const end = schema.indexOf("$$;", start);
+  return schema.slice(start, end + 3);
+})();
 
 // Minimal stand-in for the community surface these functions touch.
 const STUB_SETUP = `
@@ -141,8 +138,14 @@ const STUB_SETUP = `
     deleted_at timestamptz
   );
 
-  -- Only the columns the audit table's FK needs.
-  CREATE TABLE public.flags (id uuid PRIMARY KEY, status text NOT NULL DEFAULT 'pending');
+  CREATE TABLE public.flags (
+    id uuid PRIMARY KEY,
+    thread_id uuid REFERENCES public.threads(id),
+    answer_id uuid REFERENCES public.answers(id),
+    status text NOT NULL DEFAULT 'pending',
+    resolved_at timestamptz,
+    resolved_by uuid REFERENCES public.profiles(id)
+  );
 
   CREATE TABLE public.user_xp (
     id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -161,11 +164,14 @@ const STUB_SETUP = `
   );
 `;
 
+const ADMIN = "00000000-0000-0000-0000-0000000000ad";
 const AUTHOR = "11111111-1111-1111-1111-111111111111";
 const ANSWERER = "22222222-2222-2222-2222-222222222222";
 const THREAD = "aaaaaaaa-0000-0000-0000-000000000001";
 const ANSWER_A = "bbbbbbbb-0000-0000-0000-000000000001";
 const ANSWER_B = "bbbbbbbb-0000-0000-0000-000000000002";
+const FLAG_THREAD = "cccccccc-0000-0000-0000-000000000001";
+const FLAG_ANSWER = "cccccccc-0000-0000-0000-000000000002";
 
 interface XpRow {
   total_xp: number;
@@ -195,8 +201,16 @@ async function scalar<T>(db: PGlite, sql: string, args: unknown[]): Promise<T> {
   return Object.values(rows[0] as Record<string, T>)[0] as T;
 }
 
+async function auditCount(db: PGlite, flagId: string): Promise<number> {
+  return scalar<number>(
+    db,
+    `SELECT count(*)::int FROM public.moderation_actions WHERE flag_id = $1`,
+    [flagId]
+  );
+}
+
 for (const [copy, ddl] of Object.entries(copies)) {
-  describe(`#1131 moderator soft-delete RPCs — ${copy}`, () => {
+  describe(`#1131 moderator action RPCs — ${copy}`, () => {
     let db: PGlite;
 
     beforeAll(async () => {
@@ -210,16 +224,17 @@ for (const [copy, ddl] of Object.entries(copies)) {
       await db.exec("RESET ROLE;");
       // Re-apply the whole DDL every time: the red-proof below hands EXECUTE
       // back to `authenticated`, and a failure partway through it must not
-      // silently disarm the rest of the suite. The audit table is dropped
-      // first because schema.sql's copy is a plain CREATE TABLE.
+      // silently disarm the rest of the suite. The audit table is dropped first
+      // because schema.sql's copy is a plain CREATE TABLE.
       await db.exec("DROP TABLE IF EXISTS public.moderation_actions CASCADE;");
       await db.exec(ddl);
       await db.exec(
-        "TRUNCATE public.xp_transactions, public.user_xp, public.answers, public.threads, public.profiles CASCADE;"
+        "TRUNCATE public.flags, public.xp_transactions, public.user_xp, public.answers, public.threads, public.profiles CASCADE;"
       );
       await db.query(
-        `INSERT INTO public.profiles(id, username) VALUES ($1,'author'), ($2,'answerer')`,
-        [AUTHOR, ANSWERER]
+        `INSERT INTO public.profiles(id, username)
+         VALUES ($1,'admin'), ($2,'author'), ($3,'answerer')`,
+        [ADMIN, AUTHOR, ANSWERER]
       );
       await db.query(
         `INSERT INTO public.threads(id, author_id, answer_count, is_solved, accepted_answer_id)
@@ -231,8 +246,13 @@ for (const [copy, ddl] of Object.entries(copies)) {
          VALUES ($1, $2, $3, true), ($4, $2, $3, false)`,
         [ANSWER_A, THREAD, ANSWERER, ANSWER_B]
       );
-      // XP as the community routes award it: 20 for the thread, 10 per answer,
-      // plus an upvote award that v1 deliberately does NOT claw back.
+      await db.query(
+        `INSERT INTO public.flags(id, thread_id, answer_id, status)
+         VALUES ($1, $2, NULL, 'pending'), ($3, NULL, $4, 'pending')`,
+        [FLAG_THREAD, THREAD, FLAG_ANSWER, ANSWER_A]
+      );
+      // XP as the community routes award it: 20 for the thread, 10/20 per
+      // answer, plus an upvote award that v1 deliberately does NOT claw back.
       await db.query(
         `INSERT INTO public.user_xp(user_id, total_xp, level) VALUES ($1, 25, 0), ($2, 30, 0)`,
         [AUTHOR, ANSWERER]
@@ -253,9 +273,13 @@ for (const [copy, ddl] of Object.entries(copies)) {
       );
     });
 
-    it("thread removal tombstones the thread and cascades to its live answers", async () => {
+    it("thread removal: cascade + XP clawback + flag resolved + one audit row, atomically", async () => {
       await become(db, "service_role");
-      await db.query(`SELECT public.moderate_soft_delete_thread($1)`, [THREAD]);
+      await db.query(`SELECT public.moderate_soft_delete_thread($1, $2, $3)`, [
+        THREAD,
+        FLAG_THREAD,
+        ADMIN,
+      ]);
 
       expect(
         await scalar<string | null>(
@@ -271,30 +295,78 @@ for (const [copy, ddl] of Object.entries(copies)) {
           [THREAD]
         )
       ).toBe(0);
+      // 25 - 20 (thread:<id>) = 5; the 5 XP of upvote award stays (v1 scope).
+      expect(await xpOf(db, AUTHOR)).toMatchObject({ total_xp: 5 });
+      expect(await xpOf(db, ANSWERER)).toMatchObject({ total_xp: 30 });
+      // Removal settles the report, and attributes it.
+      expect(
+        await scalar<string>(
+          db,
+          `SELECT status FROM public.flags WHERE id = $1`,
+          [FLAG_THREAD]
+        )
+      ).toBe("resolved");
+      expect(
+        await scalar<string>(
+          db,
+          `SELECT resolved_by FROM public.flags WHERE id = $1`,
+          [FLAG_THREAD]
+        )
+      ).toBe(ADMIN);
+      const { rows } = await (async () => {
+        await db.exec("RESET ROLE;");
+        return db.query<{ action: string; actor_id: string }>(
+          `SELECT action, actor_id FROM public.moderation_actions WHERE flag_id = $1`,
+          [FLAG_THREAD]
+        );
+      })();
+      expect(rows).toEqual([{ action: "removed_thread", actor_id: ADMIN }]);
     });
 
-    it("thread removal claws back the thread's own creation XP — and only that", async () => {
-      await become(db, "service_role");
-      await db.query(`SELECT public.moderate_soft_delete_thread($1)`, [THREAD]);
+    it("RED-PROOF: a raise on the audit INSERT rolls the WHOLE action back", async () => {
+      // Force the last step (the audit INSERT) to fail, and prove nothing else
+      // survived: not the tombstone, not the XP clawback, not the flag resolve.
+      // This is the atomicity guarantee the gate asked for.
+      await db.exec("RESET ROLE;");
+      await db.exec(`
+        CREATE OR REPLACE FUNCTION public.boom_audit() RETURNS trigger
+        LANGUAGE plpgsql AS $$ BEGIN RAISE EXCEPTION 'boom'; END; $$;
+        CREATE TRIGGER trg_boom_audit BEFORE INSERT ON public.moderation_actions
+          FOR EACH ROW EXECUTE FUNCTION public.boom_audit();
+      `);
 
-      // 25 - 20 (thread:<id>) = 5. The 5 XP of upvote award stays: v1 does not
-      // reverse vote XP, and this test is what pins that scope.
-      expect(await xpOf(db, AUTHOR)).toMatchObject({ total_xp: 5 });
+      await become(db, "service_role");
+      await expect(
+        db.query(`SELECT public.moderate_soft_delete_thread($1, $2, $3)`, [
+          THREAD,
+          FLAG_THREAD,
+          ADMIN,
+        ])
+      ).rejects.toThrow(/boom/);
+
+      await db.exec("RESET ROLE;");
+      await db.exec(
+        "DROP TRIGGER trg_boom_audit ON public.moderation_actions;"
+      );
+
       expect(
-        await scalar<number>(
+        await scalar<string | null>(
           db,
-          `SELECT count(*)::int FROM public.xp_transactions WHERE idempotency_key = $1`,
-          [`thread:${THREAD}`]
+          `SELECT deleted_at FROM public.threads WHERE id = $1`,
+          [THREAD]
         )
-      ).toBe(0);
-      // The cascaded answers' XP is likewise NOT reversed in v1.
-      expect(await xpOf(db, ANSWERER)).toMatchObject({ total_xp: 30 });
+      ).toBeNull();
+      expect(await xpOf(db, AUTHOR)).toMatchObject({ total_xp: 25 });
+      expect(
+        await scalar<string>(
+          db,
+          `SELECT status FROM public.flags WHERE id = $1`,
+          [FLAG_THREAD]
+        )
+      ).toBe("pending");
     });
 
     it("RED-PROOF: the same cascade without the clawback leaves the XP behind", async () => {
-      // The literal body of the author-gated original — cascade, no revoke. If
-      // the assertion above could pass without the PERFORM line, this would
-      // show 5 as well.
       await db.exec("RESET ROLE;");
       await db.query(
         `UPDATE public.threads SET deleted_at = NOW() WHERE id = $1`,
@@ -304,14 +376,15 @@ for (const [copy, ddl] of Object.entries(copies)) {
         `UPDATE public.answers SET deleted_at = NOW() WHERE thread_id = $1 AND deleted_at IS NULL`,
         [THREAD]
       );
-
       expect(await xpOf(db, AUTHOR)).toMatchObject({ total_xp: 25 });
     });
 
-    it("answer removal decrements answer_count, un-accepts, and revokes its XP", async () => {
+    it("answer removal: count decrement, un-accept, XP clawback, flag resolved, audit", async () => {
       await become(db, "service_role");
-      await db.query(`SELECT public.moderate_soft_delete_answer($1)`, [
+      await db.query(`SELECT public.moderate_soft_delete_answer($1, $2, $3)`, [
         ANSWER_A,
+        FLAG_ANSWER,
+        ADMIN,
       ]);
 
       expect(
@@ -337,6 +410,20 @@ for (const [copy, ddl] of Object.entries(copies)) {
       ).toBeNull();
       // 30 - 10 (answer:<id>); the second answer's 20 is untouched.
       expect(await xpOf(db, ANSWERER)).toMatchObject({ total_xp: 20 });
+      expect(
+        await scalar<string>(
+          db,
+          `SELECT status FROM public.flags WHERE id = $1`,
+          [FLAG_ANSWER]
+        )
+      ).toBe("resolved");
+      expect(
+        await scalar<string>(
+          db,
+          `SELECT action FROM public.moderation_actions WHERE flag_id = $1`,
+          [FLAG_ANSWER]
+        )
+      ).toBe("removed_answer");
     });
 
     it("answer_count never goes negative", async () => {
@@ -345,10 +432,17 @@ for (const [copy, ddl] of Object.entries(copies)) {
         `UPDATE public.threads SET answer_count = 0 WHERE id = $1`,
         [THREAD]
       );
+      // Re-point the flag at answer B so the un-accept path is not taken.
+      await db.query(`UPDATE public.flags SET answer_id = $2 WHERE id = $1`, [
+        FLAG_ANSWER,
+        ANSWER_B,
+      ]);
 
       await become(db, "service_role");
-      await db.query(`SELECT public.moderate_soft_delete_answer($1)`, [
+      await db.query(`SELECT public.moderate_soft_delete_answer($1, $2, $3)`, [
         ANSWER_B,
+        FLAG_ANSWER,
+        ADMIN,
       ]);
 
       expect(
@@ -362,45 +456,190 @@ for (const [copy, ddl] of Object.entries(copies)) {
 
     it("user_xp floors at 0 when the clawback exceeds the balance", async () => {
       await db.exec("RESET ROLE;");
-      // A learner who has since spent/lost XP: 20 owed back, 4 on hand.
       await db.query(
         `UPDATE public.user_xp SET total_xp = 4 WHERE user_id = $1`,
         [AUTHOR]
       );
 
       await become(db, "service_role");
-      await db.query(`SELECT public.moderate_soft_delete_thread($1)`, [THREAD]);
+      await db.query(`SELECT public.moderate_soft_delete_thread($1, $2, $3)`, [
+        THREAD,
+        FLAG_THREAD,
+        ADMIN,
+      ]);
 
       expect(await xpOf(db, AUTHOR)).toEqual({ total_xp: 0, level: 0 });
     });
 
+    it("lock: locks the thread, LEAVES the flag pending, and audits the lock", async () => {
+      await become(db, "service_role");
+      await db.query(`SELECT public.moderate_lock_thread($1, $2, $3)`, [
+        THREAD,
+        FLAG_THREAD,
+        ADMIN,
+      ]);
+
+      expect(
+        await scalar<boolean>(
+          db,
+          `SELECT is_locked FROM public.threads WHERE id = $1`,
+          [THREAD]
+        )
+      ).toBe(true);
+      // A lock does NOT settle the report.
+      expect(
+        await scalar<string>(
+          db,
+          `SELECT status FROM public.flags WHERE id = $1`,
+          [FLAG_THREAD]
+        )
+      ).toBe("pending");
+      expect(
+        await scalar<string>(
+          db,
+          `SELECT action FROM public.moderation_actions WHERE flag_id = $1`,
+          [FLAG_THREAD]
+        )
+      ).toBe("locked_thread");
+    });
+
+    it("lock on an already-locked thread still audits (no-op tolerant)", async () => {
+      await db.exec("RESET ROLE;");
+      await db.query(
+        `UPDATE public.threads SET is_locked = true WHERE id = $1`,
+        [THREAD]
+      );
+
+      await become(db, "service_role");
+      await db.query(`SELECT public.moderate_lock_thread($1, $2, $3)`, [
+        THREAD,
+        FLAG_THREAD,
+        ADMIN,
+      ]);
+
+      expect(await auditCount(db, FLAG_THREAD)).toBe(1);
+    });
+
+    it("resolve: marks the flag resolved with an audit row, no content change", async () => {
+      await become(db, "service_role");
+      await db.query(`SELECT public.moderate_resolve_flag($1, false, $2)`, [
+        FLAG_THREAD,
+        ADMIN,
+      ]);
+
+      expect(
+        await scalar<string>(
+          db,
+          `SELECT status FROM public.flags WHERE id = $1`,
+          [FLAG_THREAD]
+        )
+      ).toBe("resolved");
+      expect(
+        await scalar<string | null>(
+          db,
+          `SELECT deleted_at FROM public.threads WHERE id = $1`,
+          [THREAD]
+        )
+      ).toBeNull();
+      expect(
+        await scalar<string>(
+          db,
+          `SELECT action FROM public.moderation_actions WHERE flag_id = $1`,
+          [FLAG_THREAD]
+        )
+      ).toBe("resolved");
+    });
+
+    it("dismiss: marks the flag dismissed with a matching audit row", async () => {
+      await become(db, "service_role");
+      await db.query(`SELECT public.moderate_resolve_flag($1, true, $2)`, [
+        FLAG_THREAD,
+        ADMIN,
+      ]);
+
+      expect(
+        await scalar<string>(
+          db,
+          `SELECT status FROM public.flags WHERE id = $1`,
+          [FLAG_THREAD]
+        )
+      ).toBe("dismissed");
+      expect(
+        await scalar<string>(
+          db,
+          `SELECT action FROM public.moderation_actions WHERE flag_id = $1`,
+          [FLAG_THREAD]
+        )
+      ).toBe("dismissed");
+    });
+
     it("refuses a second removal instead of double-revoking", async () => {
       await become(db, "service_role");
-      await db.query(`SELECT public.moderate_soft_delete_thread($1)`, [THREAD]);
+      await db.query(`SELECT public.moderate_soft_delete_thread($1, $2, $3)`, [
+        THREAD,
+        FLAG_THREAD,
+        ADMIN,
+      ]);
 
       await expect(
-        db.query(`SELECT public.moderate_soft_delete_thread($1)`, [THREAD])
+        db.query(`SELECT public.moderate_soft_delete_thread($1, $2, $3)`, [
+          THREAD,
+          FLAG_THREAD,
+          ADMIN,
+        ])
       ).rejects.toThrow(/already removed/i);
+    });
 
+    it("resolve refuses a non-pending flag", async () => {
+      await db.exec("RESET ROLE;");
+      await db.query(
+        `UPDATE public.flags SET status = 'resolved' WHERE id = $1`,
+        [FLAG_THREAD]
+      );
+
+      await become(db, "service_role");
       await expect(
-        db.query(`SELECT public.moderate_soft_delete_answer($1)`, [ANSWER_A])
-      ).rejects.toThrow(/already removed/i);
+        db.query(`SELECT public.moderate_resolve_flag($1, false, $2)`, [
+          FLAG_THREAD,
+          ADMIN,
+        ])
+      ).rejects.toThrow(/already resolved/i);
     });
 
     // The security assertion: these functions have no ownership check, so
     // execute privilege IS the authorization.
     for (const role of ["anon", "authenticated"] as const) {
-      it(`${role} cannot execute either moderator RPC`, async () => {
+      it(`${role} cannot execute any moderator RPC`, async () => {
         await become(db, role);
 
         await expect(
-          db.query(`SELECT public.moderate_soft_delete_thread($1)`, [THREAD])
+          db.query(`SELECT public.moderate_soft_delete_thread($1, $2, $3)`, [
+            THREAD,
+            FLAG_THREAD,
+            ADMIN,
+          ])
         ).rejects.toThrow(/permission denied/i);
         await expect(
-          db.query(`SELECT public.moderate_soft_delete_answer($1)`, [ANSWER_A])
+          db.query(`SELECT public.moderate_soft_delete_answer($1, $2, $3)`, [
+            ANSWER_A,
+            FLAG_ANSWER,
+            ADMIN,
+          ])
+        ).rejects.toThrow(/permission denied/i);
+        await expect(
+          db.query(`SELECT public.moderate_lock_thread($1, $2, $3)`, [
+            THREAD,
+            FLAG_THREAD,
+            ADMIN,
+          ])
+        ).rejects.toThrow(/permission denied/i);
+        await expect(
+          db.query(`SELECT public.moderate_resolve_flag($1, false, $2)`, [
+            FLAG_THREAD,
+            ADMIN,
+          ])
         ).rejects.toThrow(/permission denied/i);
 
-        // Nothing was removed by the attempt.
         expect(
           await scalar<string | null>(
             db,
@@ -412,16 +651,17 @@ for (const [copy, ddl] of Object.entries(copies)) {
     }
 
     it("RED-PROOF: granting EXECUTE back lets authenticated delete anything", async () => {
-      // Proves the denial above comes from the REVOKE in the DDL under test —
-      // not from the stub, the search_path, or a missing table grant. With the
-      // grant restored, a plain logged-in user removes someone else's thread.
       await db.exec("RESET ROLE;");
       await db.exec(
-        `GRANT EXECUTE ON FUNCTION public.moderate_soft_delete_thread(UUID) TO authenticated;`
+        `GRANT EXECUTE ON FUNCTION public.moderate_soft_delete_thread(UUID, UUID, UUID) TO authenticated;`
       );
 
       await become(db, "authenticated");
-      await db.query(`SELECT public.moderate_soft_delete_thread($1)`, [THREAD]);
+      await db.query(`SELECT public.moderate_soft_delete_thread($1, $2, $3)`, [
+        THREAD,
+        FLAG_THREAD,
+        ADMIN,
+      ]);
 
       expect(
         await scalar<string | null>(

--- a/apps/web/src/lib/supabase/schema-expectations.ts
+++ b/apps/web/src/lib/supabase/schema-expectations.ts
@@ -237,6 +237,38 @@ export const SCHEMA_EXPECTATIONS: readonly SchemaExpectation[] = [
     description:
       "referral completion point — a missing fn silently under-counts every season score",
   },
+  {
+    kind: "rpc",
+    rpc: "moderate_soft_delete_thread",
+    args: { p_thread_id: NIL_UUID, p_flag_id: NIL_UUID, p_actor_id: NIL_UUID },
+    migration: "20260820160000_moderation_actions.sql",
+    description:
+      "moderator thread removal (#1131) — the Remove button's hot path; a missing fn 500s every thread removal",
+  },
+  {
+    kind: "rpc",
+    rpc: "moderate_soft_delete_answer",
+    args: { p_answer_id: NIL_UUID, p_flag_id: NIL_UUID, p_actor_id: NIL_UUID },
+    migration: "20260820160000_moderation_actions.sql",
+    description:
+      "moderator answer removal (#1131) — the Remove button's hot path for answer flags; a missing fn 500s it",
+  },
+  {
+    kind: "rpc",
+    rpc: "moderate_lock_thread",
+    args: { p_thread_id: NIL_UUID, p_flag_id: NIL_UUID, p_actor_id: NIL_UUID },
+    migration: "20260820160000_moderation_actions.sql",
+    description:
+      "moderator thread lock (#1131) — the Lock button's hot path; a missing fn 500s it",
+  },
+  {
+    kind: "rpc",
+    rpc: "moderate_resolve_flag",
+    args: { p_flag_id: NIL_UUID, p_dismiss: false, p_actor_id: NIL_UUID },
+    migration: "20260820160000_moderation_actions.sql",
+    description:
+      "moderator resolve/dismiss (#1131) — the Resolve and Dismiss buttons' hot path; a missing fn 500s both",
+  },
 ];
 
 // PostgREST "not found in schema cache" + Postgres undefined-object SQLSTATEs.

--- a/apps/web/src/lib/supabase/types.ts
+++ b/apps/web/src/lib/supabase/types.ts
@@ -340,6 +340,36 @@ export type Database = {
           },
         ];
       };
+      moderation_actions: {
+        Row: {
+          id: string;
+          action: string;
+          thread_id: string | null;
+          answer_id: string | null;
+          flag_id: string | null;
+          actor_id: string | null;
+          created_at: string;
+        };
+        Insert: {
+          id?: string;
+          action: string;
+          thread_id?: string | null;
+          answer_id?: string | null;
+          flag_id?: string | null;
+          actor_id?: string | null;
+          created_at?: string;
+        };
+        Update: {
+          id?: string;
+          action?: string;
+          thread_id?: string | null;
+          answer_id?: string | null;
+          flag_id?: string | null;
+          actor_id?: string | null;
+          created_at?: string;
+        };
+        Relationships: [];
+      };
       flags: {
         Row: {
           answer_id: string | null;
@@ -1717,6 +1747,14 @@ export type Database = {
       };
       increment_view_count: {
         Args: { p_thread_id: string; p_user_id?: string };
+        Returns: undefined;
+      };
+      moderate_soft_delete_thread: {
+        Args: { p_thread_id: string };
+        Returns: undefined;
+      };
+      moderate_soft_delete_answer: {
+        Args: { p_answer_id: string };
         Returns: undefined;
       };
       soft_delete_thread: {

--- a/apps/web/src/lib/supabase/types.ts
+++ b/apps/web/src/lib/supabase/types.ts
@@ -1750,11 +1750,19 @@ export type Database = {
         Returns: undefined;
       };
       moderate_soft_delete_thread: {
-        Args: { p_thread_id: string };
+        Args: { p_thread_id: string; p_flag_id: string; p_actor_id: string };
         Returns: undefined;
       };
       moderate_soft_delete_answer: {
-        Args: { p_answer_id: string };
+        Args: { p_answer_id: string; p_flag_id: string; p_actor_id: string };
+        Returns: undefined;
+      };
+      moderate_lock_thread: {
+        Args: { p_thread_id: string; p_flag_id: string; p_actor_id: string };
+        Returns: undefined;
+      };
+      moderate_resolve_flag: {
+        Args: { p_flag_id: string; p_dismiss: boolean; p_actor_id: string };
         Returns: undefined;
       };
       soft_delete_thread: {

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -1501,7 +1501,15 @@
       "resolve": "Resolve",
       "dismiss": "Dismiss",
       "errorFetch": "Failed to update the flag. Please try again.",
-      "errorNetwork": "Network error. Please try again."
+      "errorNetwork": "Network error. Please try again.",
+      "remove": "Remove content",
+      "lock": "Lock thread",
+      "locked": "Thread locked",
+      "showContent": "Show the reported content",
+      "contentUnavailable": "The reported content could not be loaded.",
+      "errorConflict": "That content has already been removed. Reload the queue.",
+      "errorRateLimited": "Too many moderation actions in a row. Wait a minute and try again.",
+      "auditWarning": "The action went through, but it was not written to the moderation log."
     },
     "insightsScreen": {
       "title": "Insights",

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -1508,8 +1508,7 @@
       "showContent": "Show the reported content",
       "contentUnavailable": "The reported content could not be loaded.",
       "errorConflict": "That content has already been removed. Reload the queue.",
-      "errorRateLimited": "Too many moderation actions in a row. Wait a minute and try again.",
-      "auditWarning": "The action went through, but it was not written to the moderation log."
+      "errorRateLimited": "Too many moderation actions in a row. Wait a minute and try again."
     },
     "insightsScreen": {
       "title": "Insights",

--- a/apps/web/src/messages/es.json
+++ b/apps/web/src/messages/es.json
@@ -1508,8 +1508,7 @@
       "showContent": "Mostrar el contenido denunciado",
       "contentUnavailable": "No se pudo cargar el contenido denunciado.",
       "errorConflict": "Ese contenido ya fue eliminado. Recarga la cola.",
-      "errorRateLimited": "Demasiadas acciones de moderacion seguidas. Espera un minuto e intenta de nuevo.",
-      "auditWarning": "La accion se aplico, pero no se registro en el log de moderacion."
+      "errorRateLimited": "Demasiadas acciones de moderacion seguidas. Espera un minuto e intenta de nuevo."
     },
     "insightsScreen": {
       "title": "Métricas",

--- a/apps/web/src/messages/es.json
+++ b/apps/web/src/messages/es.json
@@ -1501,7 +1501,15 @@
       "resolve": "Resolver",
       "dismiss": "Descartar",
       "errorFetch": "No se pudo actualizar el reporte. Inténtalo de nuevo.",
-      "errorNetwork": "Error de red. Inténtalo de nuevo."
+      "errorNetwork": "Error de red. Inténtalo de nuevo.",
+      "remove": "Eliminar contenido",
+      "lock": "Bloquear hilo",
+      "locked": "Hilo bloqueado",
+      "showContent": "Mostrar el contenido denunciado",
+      "contentUnavailable": "No se pudo cargar el contenido denunciado.",
+      "errorConflict": "Ese contenido ya fue eliminado. Recarga la cola.",
+      "errorRateLimited": "Demasiadas acciones de moderacion seguidas. Espera un minuto e intenta de nuevo.",
+      "auditWarning": "La accion se aplico, pero no se registro en el log de moderacion."
     },
     "insightsScreen": {
       "title": "Métricas",

--- a/apps/web/src/messages/pt-BR.json
+++ b/apps/web/src/messages/pt-BR.json
@@ -1508,8 +1508,7 @@
       "showContent": "Mostrar o conteudo denunciado",
       "contentUnavailable": "Nao foi possivel carregar o conteudo denunciado.",
       "errorConflict": "Esse conteudo ja foi removido. Recarregue a fila.",
-      "errorRateLimited": "Acoes de moderacao demais em sequencia. Espere um minuto e tente de novo.",
-      "auditWarning": "A acao foi aplicada, mas nao foi registrada no log de moderacao."
+      "errorRateLimited": "Acoes de moderacao demais em sequencia. Espere um minuto e tente de novo."
     },
     "insightsScreen": {
       "title": "Métricas",

--- a/apps/web/src/messages/pt-BR.json
+++ b/apps/web/src/messages/pt-BR.json
@@ -1501,7 +1501,15 @@
       "resolve": "Resolver",
       "dismiss": "Descartar",
       "errorFetch": "Falha ao atualizar a denúncia. Tente novamente.",
-      "errorNetwork": "Erro de rede. Tente novamente."
+      "errorNetwork": "Erro de rede. Tente novamente.",
+      "remove": "Remover conteudo",
+      "lock": "Trancar topico",
+      "locked": "Topico trancado",
+      "showContent": "Mostrar o conteudo denunciado",
+      "contentUnavailable": "Nao foi possivel carregar o conteudo denunciado.",
+      "errorConflict": "Esse conteudo ja foi removido. Recarregue a fila.",
+      "errorRateLimited": "Acoes de moderacao demais em sequencia. Espere um minuto e tente de novo.",
+      "auditWarning": "A acao foi aplicada, mas nao foi registrada no log de moderacao."
     },
     "insightsScreen": {
       "title": "Métricas",

--- a/supabase/migrations/20260820160000_moderation_actions.sql
+++ b/supabase/migrations/20260820160000_moderation_actions.sql
@@ -2,9 +2,14 @@
 --
 -- The moderation queue could only ever mark a REPORT handled — resolve and
 -- dismiss both wrote flags.status and nothing else, so the reported content was
--- never touched. This adds the two things an admin needs to actually action a
--- report from the panel: moderator soft-delete RPCs, and an audit row per
--- decision.
+-- never touched. This adds what an admin needs to action a report from the
+-- panel: moderator content RPCs, and an audit row per decision.
+--
+-- ATOMICITY: each RPC does the content change, the flag write, and the audit
+-- INSERT in ONE transaction. The route used to make three separate PostgREST
+-- round-trips (delete → resolve flag → audit), so a crash between them could
+-- leave content removed with no audit row — exactly the record a destructive
+-- moderation action must never lose. Now it either all commits or none does.
 --
 -- The author-gated soft_delete_thread / soft_delete_answer are NOT reused or
 -- widened: their `author_id = p_user_id` check is what makes them safe to expose
@@ -27,10 +32,10 @@ CREATE TABLE IF NOT EXISTS public.moderation_actions (
   -- The acting admin. This column only became possible with the `admin_users`
   -- allowlist (20260819170000): under the retired shared ADMIN_SECRET every
   -- moderator was the same anonymous caller and there was no identity to store.
-  -- requireAdminAuth() now returns the acting admin's user id, so the route
-  -- stamps it here and in flags.resolved_by. Nullable because the FK is
-  -- ON DELETE SET NULL and a future non-session caller may not carry one — an
-  -- audit row without an actor still beats no audit row.
+  -- requireAdminAuth() now returns the acting admin's user id, so the RPCs stamp
+  -- it here and in flags.resolved_by. Nullable because the FK is ON DELETE SET
+  -- NULL and a future non-session caller may not carry one — an audit row
+  -- without an actor still beats no audit row.
   actor_id UUID REFERENCES public.profiles(id) ON DELETE SET NULL,
   created_at TIMESTAMPTZ NOT NULL DEFAULT now()
 );
@@ -45,8 +50,9 @@ REVOKE ALL ON public.moderation_actions FROM PUBLIC;
 REVOKE ALL ON public.moderation_actions FROM anon;
 REVOKE ALL ON public.moderation_actions FROM authenticated;
 
--- Moderator soft-delete of a thread. Same cascade as soft_delete_thread
--- (deleted_at on the thread and on its live answers), no ownership check.
+-- Moderator soft-delete of a thread + flag-resolve + audit, in one transaction.
+-- Same cascade as soft_delete_thread (deleted_at on the thread and on its live
+-- answers), no ownership check.
 --
 -- XP CLAWBACK SCOPE (v1, deliberate): only the removed thread's own creation XP
 -- is revoked, via the existing idempotency key `thread:<id>`. Upvote XP on the
@@ -55,7 +61,11 @@ REVOKE ALL ON public.moderation_actions FROM authenticated;
 -- answer, and getting the accepted-answer bonus right, which is a bigger change
 -- than the moderation buttons this ships. Removing spam therefore still leaves
 -- the spammer any vote XP it earned.
-CREATE OR REPLACE FUNCTION public.moderate_soft_delete_thread(p_thread_id UUID)
+CREATE OR REPLACE FUNCTION public.moderate_soft_delete_thread(
+  p_thread_id UUID,
+  p_flag_id UUID,
+  p_actor_id UUID
+)
 RETURNS VOID
 LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $$
 DECLARE
@@ -74,18 +84,31 @@ BEGIN
    WHERE thread_id = p_thread_id AND deleted_at IS NULL;
 
   PERFORM public.revoke_community_xp(v_author_id, 'thread:' || p_thread_id::text);
+
+  -- Removal settles the report.
+  UPDATE public.flags
+     SET status = 'resolved', resolved_at = NOW(), resolved_by = p_actor_id
+   WHERE id = p_flag_id;
+
+  INSERT INTO public.moderation_actions(action, thread_id, flag_id, actor_id)
+  VALUES ('removed_thread', p_thread_id, p_flag_id, p_actor_id);
 END;
 $$;
 
--- Moderator soft-delete of a single answer. Same bookkeeping as
--- soft_delete_answer (answer_count decrement with a zero floor, un-accept if it
--- was the accepted answer), no ownership check.
+-- Moderator soft-delete of a single answer + flag-resolve + audit, in one
+-- transaction. Same bookkeeping as soft_delete_answer (answer_count decrement
+-- with a zero floor, un-accept if it was the accepted answer), no ownership
+-- check.
 --
 -- XP CLAWBACK SCOPE (v1, deliberate): only this answer's own creation XP
 -- (`answer:<id>`), for the same reason as above. In particular the
 -- accepted-answer bonus (`accept:<thread>:<answer>`) is NOT revoked when an
 -- accepted answer is removed.
-CREATE OR REPLACE FUNCTION public.moderate_soft_delete_answer(p_answer_id UUID)
+CREATE OR REPLACE FUNCTION public.moderate_soft_delete_answer(
+  p_answer_id UUID,
+  p_flag_id UUID,
+  p_actor_id UUID
+)
 RETURNS VOID
 LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $$
 DECLARE
@@ -112,10 +135,87 @@ BEGIN
   END IF;
 
   PERFORM public.revoke_community_xp(v_author_id, 'answer:' || p_answer_id::text);
+
+  UPDATE public.flags
+     SET status = 'resolved', resolved_at = NOW(), resolved_by = p_actor_id
+   WHERE id = p_flag_id;
+
+  INSERT INTO public.moderation_actions(action, answer_id, flag_id, actor_id)
+  VALUES ('removed_answer', p_answer_id, p_flag_id, p_actor_id);
 END;
 $$;
 
-REVOKE EXECUTE ON FUNCTION public.moderate_soft_delete_thread(UUID) FROM PUBLIC, anon, authenticated;
-GRANT EXECUTE ON FUNCTION public.moderate_soft_delete_thread(UUID) TO service_role;
-REVOKE EXECUTE ON FUNCTION public.moderate_soft_delete_answer(UUID) FROM PUBLIC, anon, authenticated;
-GRANT EXECUTE ON FUNCTION public.moderate_soft_delete_answer(UUID) TO service_role;
+-- Moderator lock of a thread + audit, in one transaction. A lock stops the
+-- argument without settling the report, so it deliberately does NOT resolve the
+-- flag — the moderator still resolves or dismisses it afterwards.
+--
+-- No-op tolerant: an already-locked thread still writes the audit row (the
+-- moderator did take the action) but skips the redundant UPDATE.
+CREATE OR REPLACE FUNCTION public.moderate_lock_thread(
+  p_thread_id UUID,
+  p_flag_id UUID,
+  p_actor_id UUID
+)
+RETURNS VOID
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $$
+DECLARE
+  v_is_locked BOOLEAN;
+BEGIN
+  SELECT is_locked INTO v_is_locked
+  FROM public.threads
+  WHERE id = p_thread_id AND deleted_at IS NULL;
+
+  IF v_is_locked IS NULL THEN
+    RAISE EXCEPTION 'Thread not found or already removed';
+  END IF;
+
+  IF NOT v_is_locked THEN
+    UPDATE public.threads SET is_locked = TRUE WHERE id = p_thread_id;
+  END IF;
+
+  INSERT INTO public.moderation_actions(action, thread_id, flag_id, actor_id)
+  VALUES ('locked_thread', p_thread_id, p_flag_id, p_actor_id);
+END;
+$$;
+
+-- Resolve or dismiss a report with no content change (out-of-band handling) +
+-- audit, in one transaction. p_dismiss picks which: dismiss = the report is not
+-- valid, resolve = handled elsewhere. The target ids for the audit row are read
+-- from the flag itself so the caller cannot mis-pair them.
+CREATE OR REPLACE FUNCTION public.moderate_resolve_flag(
+  p_flag_id UUID,
+  p_dismiss BOOLEAN,
+  p_actor_id UUID
+)
+RETURNS VOID
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $$
+DECLARE
+  v_thread_id UUID;
+  v_answer_id UUID;
+  v_status TEXT := CASE WHEN p_dismiss THEN 'dismissed' ELSE 'resolved' END;
+BEGIN
+  SELECT thread_id, answer_id INTO v_thread_id, v_answer_id
+  FROM public.flags
+  WHERE id = p_flag_id AND status = 'pending';
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Flag not found or already resolved';
+  END IF;
+
+  UPDATE public.flags
+     SET status = v_status, resolved_at = NOW(), resolved_by = p_actor_id
+   WHERE id = p_flag_id;
+
+  INSERT INTO public.moderation_actions(action, thread_id, answer_id, flag_id, actor_id)
+  VALUES (v_status, v_thread_id, v_answer_id, p_flag_id, p_actor_id);
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.moderate_soft_delete_thread(UUID, UUID, UUID) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.moderate_soft_delete_thread(UUID, UUID, UUID) TO service_role;
+REVOKE EXECUTE ON FUNCTION public.moderate_soft_delete_answer(UUID, UUID, UUID) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.moderate_soft_delete_answer(UUID, UUID, UUID) TO service_role;
+REVOKE EXECUTE ON FUNCTION public.moderate_lock_thread(UUID, UUID, UUID) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.moderate_lock_thread(UUID, UUID, UUID) TO service_role;
+REVOKE EXECUTE ON FUNCTION public.moderate_resolve_flag(UUID, BOOLEAN, UUID) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.moderate_resolve_flag(UUID, BOOLEAN, UUID) TO service_role;

--- a/supabase/migrations/20260820160000_moderation_actions.sql
+++ b/supabase/migrations/20260820160000_moderation_actions.sql
@@ -24,9 +24,13 @@ CREATE TABLE IF NOT EXISTS public.moderation_actions (
   thread_id UUID REFERENCES public.threads(id) ON DELETE SET NULL,
   answer_id UUID REFERENCES public.answers(id) ON DELETE SET NULL,
   flag_id UUID REFERENCES public.flags(id) ON DELETE SET NULL,
-  -- The acting admin. Nullable because the FK is ON DELETE SET NULL and because
-  -- older rows (or a future non-session caller) may not carry one — the audit
-  -- row is still worth keeping without it.
+  -- The acting admin. This column only became possible with the `admin_users`
+  -- allowlist (20260819170000): under the retired shared ADMIN_SECRET every
+  -- moderator was the same anonymous caller and there was no identity to store.
+  -- requireAdminAuth() now returns the acting admin's user id, so the route
+  -- stamps it here and in flags.resolved_by. Nullable because the FK is
+  -- ON DELETE SET NULL and a future non-session caller may not carry one — an
+  -- audit row without an actor still beats no audit row.
   actor_id UUID REFERENCES public.profiles(id) ON DELETE SET NULL,
   created_at TIMESTAMPTZ NOT NULL DEFAULT now()
 );

--- a/supabase/migrations/20260820160000_moderation_actions.sql
+++ b/supabase/migrations/20260820160000_moderation_actions.sql
@@ -1,0 +1,117 @@
+-- Moderator-side content actions for the admin flag queue (#1131)
+--
+-- The moderation queue could only ever mark a REPORT handled — resolve and
+-- dismiss both wrote flags.status and nothing else, so the reported content was
+-- never touched. This adds the two things an admin needs to actually action a
+-- report from the panel: moderator soft-delete RPCs, and an audit row per
+-- decision.
+--
+-- The author-gated soft_delete_thread / soft_delete_answer are NOT reused or
+-- widened: their `author_id = p_user_id` check is what makes them safe to expose
+-- to the author-facing routes, and a p_user_id-optional variant would be one
+-- typo away from letting any caller delete anything. These are separate
+-- functions with the same cascade semantics and no ownership check, reachable
+-- only by service_role — i.e. only from an admin-gated API route.
+
+CREATE TABLE IF NOT EXISTS public.moderation_actions (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  action TEXT NOT NULL CHECK (action IN (
+    'removed_thread', 'removed_answer', 'locked_thread', 'resolved', 'dismissed'
+  )),
+  -- ON DELETE SET NULL, not CASCADE: the audit row must outlive the content it
+  -- describes. A hard-deleted thread is exactly the case where the record of who
+  -- removed it matters most.
+  thread_id UUID REFERENCES public.threads(id) ON DELETE SET NULL,
+  answer_id UUID REFERENCES public.answers(id) ON DELETE SET NULL,
+  flag_id UUID REFERENCES public.flags(id) ON DELETE SET NULL,
+  -- The acting admin. Nullable because the FK is ON DELETE SET NULL and because
+  -- older rows (or a future non-session caller) may not carry one — the audit
+  -- row is still worth keeping without it.
+  actor_id UUID REFERENCES public.profiles(id) ON DELETE SET NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_moderation_actions_created_at
+  ON public.moderation_actions(created_at DESC);
+
+-- Service-role only: RLS on with ZERO policies, plus explicit REVOKEs. Nothing
+-- reaches this table except createAdminClient() from an admin-gated route.
+ALTER TABLE public.moderation_actions ENABLE ROW LEVEL SECURITY;
+REVOKE ALL ON public.moderation_actions FROM PUBLIC;
+REVOKE ALL ON public.moderation_actions FROM anon;
+REVOKE ALL ON public.moderation_actions FROM authenticated;
+
+-- Moderator soft-delete of a thread. Same cascade as soft_delete_thread
+-- (deleted_at on the thread and on its live answers), no ownership check.
+--
+-- XP CLAWBACK SCOPE (v1, deliberate): only the removed thread's own creation XP
+-- is revoked, via the existing idempotency key `thread:<id>`. Upvote XP on the
+-- thread and the creation XP of the answers this cascade tombstones are LEFT IN
+-- PLACE — reversing those means walking every vote row and every cascaded
+-- answer, and getting the accepted-answer bonus right, which is a bigger change
+-- than the moderation buttons this ships. Removing spam therefore still leaves
+-- the spammer any vote XP it earned.
+CREATE OR REPLACE FUNCTION public.moderate_soft_delete_thread(p_thread_id UUID)
+RETURNS VOID
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $$
+DECLARE
+  v_author_id UUID;
+BEGIN
+  SELECT author_id INTO v_author_id
+  FROM public.threads
+  WHERE id = p_thread_id AND deleted_at IS NULL;
+
+  IF v_author_id IS NULL THEN
+    RAISE EXCEPTION 'Thread not found or already removed';
+  END IF;
+
+  UPDATE public.threads SET deleted_at = NOW() WHERE id = p_thread_id;
+  UPDATE public.answers SET deleted_at = NOW()
+   WHERE thread_id = p_thread_id AND deleted_at IS NULL;
+
+  PERFORM public.revoke_community_xp(v_author_id, 'thread:' || p_thread_id::text);
+END;
+$$;
+
+-- Moderator soft-delete of a single answer. Same bookkeeping as
+-- soft_delete_answer (answer_count decrement with a zero floor, un-accept if it
+-- was the accepted answer), no ownership check.
+--
+-- XP CLAWBACK SCOPE (v1, deliberate): only this answer's own creation XP
+-- (`answer:<id>`), for the same reason as above. In particular the
+-- accepted-answer bonus (`accept:<thread>:<answer>`) is NOT revoked when an
+-- accepted answer is removed.
+CREATE OR REPLACE FUNCTION public.moderate_soft_delete_answer(p_answer_id UUID)
+RETURNS VOID
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $$
+DECLARE
+  v_thread_id UUID;
+  v_author_id UUID;
+  v_was_accepted BOOLEAN;
+BEGIN
+  SELECT thread_id, author_id, is_accepted
+    INTO v_thread_id, v_author_id, v_was_accepted
+  FROM public.answers
+  WHERE id = p_answer_id AND deleted_at IS NULL;
+
+  IF v_thread_id IS NULL THEN
+    RAISE EXCEPTION 'Answer not found or already removed';
+  END IF;
+
+  UPDATE public.answers SET deleted_at = NOW() WHERE id = p_answer_id;
+  UPDATE public.threads SET answer_count = GREATEST(answer_count - 1, 0)
+   WHERE id = v_thread_id;
+
+  IF v_was_accepted THEN
+    UPDATE public.threads SET is_solved = FALSE, accepted_answer_id = NULL
+     WHERE id = v_thread_id;
+  END IF;
+
+  PERFORM public.revoke_community_xp(v_author_id, 'answer:' || p_answer_id::text);
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.moderate_soft_delete_thread(UUID) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.moderate_soft_delete_thread(UUID) TO service_role;
+REVOKE EXECUTE ON FUNCTION public.moderate_soft_delete_answer(UUID) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.moderate_soft_delete_answer(UUID) TO service_role;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -2047,8 +2047,9 @@ GRANT EXECUTE ON FUNCTION soft_delete_thread(UUID, UUID) TO service_role;
 REVOKE EXECUTE ON FUNCTION soft_delete_answer(UUID, UUID) FROM authenticated, anon, public;
 GRANT EXECUTE ON FUNCTION soft_delete_answer(UUID, UUID) TO service_role;
 
--- Moderator soft-delete of a thread. Same cascade as soft_delete_thread
--- (deleted_at on the thread and on its live answers), no ownership check.
+-- Moderator soft-delete of a thread + flag-resolve + audit, in one transaction.
+-- Same cascade as soft_delete_thread (deleted_at on the thread and on its live
+-- answers), no ownership check.
 --
 -- XP CLAWBACK SCOPE (v1, deliberate): only the removed thread's own creation XP
 -- is revoked, via the existing idempotency key `thread:<id>`. Upvote XP on the
@@ -2057,7 +2058,11 @@ GRANT EXECUTE ON FUNCTION soft_delete_answer(UUID, UUID) TO service_role;
 -- answer, and getting the accepted-answer bonus right, which is a bigger change
 -- than the moderation buttons this ships. Removing spam therefore still leaves
 -- the spammer any vote XP it earned.
-CREATE OR REPLACE FUNCTION public.moderate_soft_delete_thread(p_thread_id UUID)
+CREATE OR REPLACE FUNCTION public.moderate_soft_delete_thread(
+  p_thread_id UUID,
+  p_flag_id UUID,
+  p_actor_id UUID
+)
 RETURNS VOID
 LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $$
 DECLARE
@@ -2076,18 +2081,31 @@ BEGIN
    WHERE thread_id = p_thread_id AND deleted_at IS NULL;
 
   PERFORM public.revoke_community_xp(v_author_id, 'thread:' || p_thread_id::text);
+
+  -- Removal settles the report.
+  UPDATE public.flags
+     SET status = 'resolved', resolved_at = NOW(), resolved_by = p_actor_id
+   WHERE id = p_flag_id;
+
+  INSERT INTO public.moderation_actions(action, thread_id, flag_id, actor_id)
+  VALUES ('removed_thread', p_thread_id, p_flag_id, p_actor_id);
 END;
 $$;
 
--- Moderator soft-delete of a single answer. Same bookkeeping as
--- soft_delete_answer (answer_count decrement with a zero floor, un-accept if it
--- was the accepted answer), no ownership check.
+-- Moderator soft-delete of a single answer + flag-resolve + audit, in one
+-- transaction. Same bookkeeping as soft_delete_answer (answer_count decrement
+-- with a zero floor, un-accept if it was the accepted answer), no ownership
+-- check.
 --
 -- XP CLAWBACK SCOPE (v1, deliberate): only this answer's own creation XP
 -- (`answer:<id>`), for the same reason as above. In particular the
 -- accepted-answer bonus (`accept:<thread>:<answer>`) is NOT revoked when an
 -- accepted answer is removed.
-CREATE OR REPLACE FUNCTION public.moderate_soft_delete_answer(p_answer_id UUID)
+CREATE OR REPLACE FUNCTION public.moderate_soft_delete_answer(
+  p_answer_id UUID,
+  p_flag_id UUID,
+  p_actor_id UUID
+)
 RETURNS VOID
 LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $$
 DECLARE
@@ -2114,13 +2132,91 @@ BEGIN
   END IF;
 
   PERFORM public.revoke_community_xp(v_author_id, 'answer:' || p_answer_id::text);
+
+  UPDATE public.flags
+     SET status = 'resolved', resolved_at = NOW(), resolved_by = p_actor_id
+   WHERE id = p_flag_id;
+
+  INSERT INTO public.moderation_actions(action, answer_id, flag_id, actor_id)
+  VALUES ('removed_answer', p_answer_id, p_flag_id, p_actor_id);
 END;
 $$;
 
-REVOKE EXECUTE ON FUNCTION public.moderate_soft_delete_thread(UUID) FROM PUBLIC, anon, authenticated;
-GRANT EXECUTE ON FUNCTION public.moderate_soft_delete_thread(UUID) TO service_role;
-REVOKE EXECUTE ON FUNCTION public.moderate_soft_delete_answer(UUID) FROM PUBLIC, anon, authenticated;
-GRANT EXECUTE ON FUNCTION public.moderate_soft_delete_answer(UUID) TO service_role;
+-- Moderator lock of a thread + audit, in one transaction. A lock stops the
+-- argument without settling the report, so it deliberately does NOT resolve the
+-- flag — the moderator still resolves or dismisses it afterwards.
+--
+-- No-op tolerant: an already-locked thread still writes the audit row (the
+-- moderator did take the action) but skips the redundant UPDATE.
+CREATE OR REPLACE FUNCTION public.moderate_lock_thread(
+  p_thread_id UUID,
+  p_flag_id UUID,
+  p_actor_id UUID
+)
+RETURNS VOID
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $$
+DECLARE
+  v_is_locked BOOLEAN;
+BEGIN
+  SELECT is_locked INTO v_is_locked
+  FROM public.threads
+  WHERE id = p_thread_id AND deleted_at IS NULL;
+
+  IF v_is_locked IS NULL THEN
+    RAISE EXCEPTION 'Thread not found or already removed';
+  END IF;
+
+  IF NOT v_is_locked THEN
+    UPDATE public.threads SET is_locked = TRUE WHERE id = p_thread_id;
+  END IF;
+
+  INSERT INTO public.moderation_actions(action, thread_id, flag_id, actor_id)
+  VALUES ('locked_thread', p_thread_id, p_flag_id, p_actor_id);
+END;
+$$;
+
+-- Resolve or dismiss a report with no content change (out-of-band handling) +
+-- audit, in one transaction. p_dismiss picks which: dismiss = the report is not
+-- valid, resolve = handled elsewhere. The target ids for the audit row are read
+-- from the flag itself so the caller cannot mis-pair them.
+CREATE OR REPLACE FUNCTION public.moderate_resolve_flag(
+  p_flag_id UUID,
+  p_dismiss BOOLEAN,
+  p_actor_id UUID
+)
+RETURNS VOID
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $$
+DECLARE
+  v_thread_id UUID;
+  v_answer_id UUID;
+  v_status TEXT := CASE WHEN p_dismiss THEN 'dismissed' ELSE 'resolved' END;
+BEGIN
+  SELECT thread_id, answer_id INTO v_thread_id, v_answer_id
+  FROM public.flags
+  WHERE id = p_flag_id AND status = 'pending';
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Flag not found or already resolved';
+  END IF;
+
+  UPDATE public.flags
+     SET status = v_status, resolved_at = NOW(), resolved_by = p_actor_id
+   WHERE id = p_flag_id;
+
+  INSERT INTO public.moderation_actions(action, thread_id, answer_id, flag_id, actor_id)
+  VALUES (v_status, v_thread_id, v_answer_id, p_flag_id, p_actor_id);
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.moderate_soft_delete_thread(UUID, UUID, UUID) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.moderate_soft_delete_thread(UUID, UUID, UUID) TO service_role;
+REVOKE EXECUTE ON FUNCTION public.moderate_soft_delete_answer(UUID, UUID, UUID) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.moderate_soft_delete_answer(UUID, UUID, UUID) TO service_role;
+REVOKE EXECUTE ON FUNCTION public.moderate_lock_thread(UUID, UUID, UUID) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.moderate_lock_thread(UUID, UUID, UUID) TO service_role;
+REVOKE EXECUTE ON FUNCTION public.moderate_resolve_flag(UUID, BOOLEAN, UUID) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.moderate_resolve_flag(UUID, BOOLEAN, UUID) TO service_role;
+
 
 -- ============================================================
 -- Community Forum: RLS Policies

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -1527,6 +1527,29 @@ CREATE TABLE flags (
   )
 );
 
+-- Moderator decision audit (#1131). One row per action taken from the admin
+-- moderation queue. Service-role only: RLS on with ZERO policies + explicit
+-- REVOKEs. Content FKs are ON DELETE SET NULL so the record outlives the
+-- content it describes.
+CREATE TABLE moderation_actions (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  action TEXT NOT NULL CHECK (action IN (
+    'removed_thread', 'removed_answer', 'locked_thread', 'resolved', 'dismissed'
+  )),
+  thread_id UUID REFERENCES threads(id) ON DELETE SET NULL,
+  answer_id UUID REFERENCES answers(id) ON DELETE SET NULL,
+  flag_id UUID REFERENCES flags(id) ON DELETE SET NULL,
+  actor_id UUID REFERENCES profiles(id) ON DELETE SET NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_moderation_actions_created_at ON moderation_actions(created_at DESC);
+
+ALTER TABLE moderation_actions ENABLE ROW LEVEL SECURITY;
+REVOKE ALL ON moderation_actions FROM PUBLIC;
+REVOKE ALL ON moderation_actions FROM anon;
+REVOKE ALL ON moderation_actions FROM authenticated;
+
 -- ============================================================
 -- Community Forum: Indexes
 -- ============================================================
@@ -2023,6 +2046,81 @@ REVOKE EXECUTE ON FUNCTION soft_delete_thread(UUID, UUID) FROM authenticated, an
 GRANT EXECUTE ON FUNCTION soft_delete_thread(UUID, UUID) TO service_role;
 REVOKE EXECUTE ON FUNCTION soft_delete_answer(UUID, UUID) FROM authenticated, anon, public;
 GRANT EXECUTE ON FUNCTION soft_delete_answer(UUID, UUID) TO service_role;
+
+-- Moderator soft-delete of a thread. Same cascade as soft_delete_thread
+-- (deleted_at on the thread and on its live answers), no ownership check.
+--
+-- XP CLAWBACK SCOPE (v1, deliberate): only the removed thread's own creation XP
+-- is revoked, via the existing idempotency key `thread:<id>`. Upvote XP on the
+-- thread and the creation XP of the answers this cascade tombstones are LEFT IN
+-- PLACE — reversing those means walking every vote row and every cascaded
+-- answer, and getting the accepted-answer bonus right, which is a bigger change
+-- than the moderation buttons this ships. Removing spam therefore still leaves
+-- the spammer any vote XP it earned.
+CREATE OR REPLACE FUNCTION public.moderate_soft_delete_thread(p_thread_id UUID)
+RETURNS VOID
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $$
+DECLARE
+  v_author_id UUID;
+BEGIN
+  SELECT author_id INTO v_author_id
+  FROM public.threads
+  WHERE id = p_thread_id AND deleted_at IS NULL;
+
+  IF v_author_id IS NULL THEN
+    RAISE EXCEPTION 'Thread not found or already removed';
+  END IF;
+
+  UPDATE public.threads SET deleted_at = NOW() WHERE id = p_thread_id;
+  UPDATE public.answers SET deleted_at = NOW()
+   WHERE thread_id = p_thread_id AND deleted_at IS NULL;
+
+  PERFORM public.revoke_community_xp(v_author_id, 'thread:' || p_thread_id::text);
+END;
+$$;
+
+-- Moderator soft-delete of a single answer. Same bookkeeping as
+-- soft_delete_answer (answer_count decrement with a zero floor, un-accept if it
+-- was the accepted answer), no ownership check.
+--
+-- XP CLAWBACK SCOPE (v1, deliberate): only this answer's own creation XP
+-- (`answer:<id>`), for the same reason as above. In particular the
+-- accepted-answer bonus (`accept:<thread>:<answer>`) is NOT revoked when an
+-- accepted answer is removed.
+CREATE OR REPLACE FUNCTION public.moderate_soft_delete_answer(p_answer_id UUID)
+RETURNS VOID
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $$
+DECLARE
+  v_thread_id UUID;
+  v_author_id UUID;
+  v_was_accepted BOOLEAN;
+BEGIN
+  SELECT thread_id, author_id, is_accepted
+    INTO v_thread_id, v_author_id, v_was_accepted
+  FROM public.answers
+  WHERE id = p_answer_id AND deleted_at IS NULL;
+
+  IF v_thread_id IS NULL THEN
+    RAISE EXCEPTION 'Answer not found or already removed';
+  END IF;
+
+  UPDATE public.answers SET deleted_at = NOW() WHERE id = p_answer_id;
+  UPDATE public.threads SET answer_count = GREATEST(answer_count - 1, 0)
+   WHERE id = v_thread_id;
+
+  IF v_was_accepted THEN
+    UPDATE public.threads SET is_solved = FALSE, accepted_answer_id = NULL
+     WHERE id = v_thread_id;
+  END IF;
+
+  PERFORM public.revoke_community_xp(v_author_id, 'answer:' || p_answer_id::text);
+END;
+$$;
+
+REVOKE EXECUTE ON FUNCTION public.moderate_soft_delete_thread(UUID) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.moderate_soft_delete_thread(UUID) TO service_role;
+REVOKE EXECUTE ON FUNCTION public.moderate_soft_delete_answer(UUID) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.moderate_soft_delete_answer(UUID) TO service_role;
 
 -- ============================================================
 -- Community Forum: RLS Policies


### PR DESCRIPTION
The moderation queue could only mark a report handled — resolve and dismiss both wrote the same flag row and never touched the reported content, and there was nowhere else in the panel to touch it. Each card now carries Remove content (moderator soft-delete, auto-resolves the flag) and Lock thread (thread reports only), alongside the existing Resolve/Dismiss. No ban, no hard delete, no bulk actions.

Built on #1142's three-state FlagsPanel (merged); the new buttons reuse its error branches.

**DB.** Two new SECURITY DEFINER RPCs, `moderate_soft_delete_thread` / `moderate_soft_delete_answer` — same cascade semantics as the author-gated `soft_delete_thread`/`soft_delete_answer`, which are untouched, minus the ownership check, and service_role only. They also revoke the removed target's own creation XP through the existing `revoke_community_xp`. Plus a `moderation_actions` audit table (RLS on, zero policies).

**XP clawback scope, v1:** only `thread:<id>` / `answer:<id>`. Upvote XP and the creation XP of answers a thread removal cascades over are left in place — reversing those means walking every vote row and every cascaded answer and getting the accepted-answer bonus right. Removing spam still leaves the spammer any vote XP it earned. Stated in the migration comments and pinned by a test.

**Two deviations from the brief, both because the allowlist landed first:** the audit table has an `actor_id` and the route sets `flags.resolved_by`. The brief assumed admin auth was still a shared secret with no identity, but `requireAdminAuth` now returns the acting admin's user id, and the issue's done-when asks for the decision to record who made it.

**Lock does not resolve the flag.** A lock stops the argument without settling the report, so the card stays and the moderator still resolves or dismisses. `is_locked` is already enforced on answer creation.

The queue's "View" link also gained the locale prefix it was missing (`localePrefix: "always"` made the old `/community/...` href a dead path), and cards whose link can't be resolved now render the target's full body inline instead of a 200-char preview and nothing.

The migration file ships here but is **not applied** — it goes to prod via MCP after review.

Tests: 3200 pass (60 in the three touched/added files). The PGlite execution test runs both copies of the DDL — the migration file whole, and the schema.sql mirror. Red-proofed: dropping the `PERFORM revoke_community_xp` line fails the two XP tests; adding a `GRANT EXECUTE … TO authenticated` fails the authenticated-denied test.

Closes #1131
