### PR TITLE
feat(admin): Recharts insights charts, dynamically imported

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -72,6 +72,7 @@
     "react": "^18.3.0",
     "react-dom": "^18.3.0",
     "react-markdown": "^10.1.0",
+    "recharts": "^3.10.1",
     "rehype-highlight": "^7.0.2",
     "rehype-raw": "^7.0.0",
     "remark-gfm": "^4.0.1",

--- a/apps/web/src/app/[locale]/admin/insights/insights-client.tsx
+++ b/apps/web/src/app/[locale]/admin/insights/insights-client.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 import { Robot, ChartBar } from "@phosphor-icons/react";
 import type { PlatformInsights } from "@/lib/admin/insights";
 import {
@@ -89,6 +89,7 @@ const usd = (v: number): string => `$${v.toFixed(2)}`;
 
 export function InsightsClient() {
   const t = useTranslations("admin.insightsScreen");
+  const locale = useLocale();
 
   const [data, setData] = useState<PlatformInsights | null>(null);
   const [error, setError] = useState(false);
@@ -191,6 +192,7 @@ export function InsightsClient() {
             label={t("learning.completionsChartLabel")}
             dayHeader={t("learning.day")}
             valueHeader={t("learning.completions")}
+            locale={locale}
             empty={t("empty")}
           />
         </Panel>
@@ -242,6 +244,7 @@ export function InsightsClient() {
             label={t("ai.spendChartLabel")}
             dayHeader={t("ai.day")}
             valueHeader={t("ai.usd")}
+            locale={locale}
             format={usd}
             secondary={{
               header: t("ai.requests"),

--- a/apps/web/src/components/admin/__tests__/insights-chart.test.tsx
+++ b/apps/web/src/components/admin/__tests__/insights-chart.test.tsx
@@ -1,13 +1,32 @@
 // @vitest-environment jsdom
-import { describe, it, expect } from "vitest";
+import React from "react";
+import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { InsightsChart, BarCell, fillDayWindow } from "../insights-chart";
+
+// ResponsiveContainer measures 0×0 in jsdom (no ResizeObserver layout), so
+// recharts would render an empty chart. Give the chart child fixed dimensions
+// instead, and drop the ResizeObserver dependency entirely.
+vi.mock("recharts", async () => {
+  const actual = await vi.importActual<typeof import("recharts")>("recharts");
+  return {
+    ...actual,
+    ResponsiveContainer: ({ children }: { children: React.ReactElement }) =>
+      React.cloneElement(children, { width: 480, height: 180 }),
+  };
+});
+
+// Import AFTER the mock so the chart picks up the patched ResponsiveContainer.
+const { RechartsInsightsChart, InsightsChartTooltip } =
+  await import("../insights-chart-recharts");
 
 const series = (values: number[]): { day: string; value: number }[] =>
   values.map((value, i) => ({
     day: `2026-08-${String(i + 1).padStart(2, "0")}`,
     value,
   }));
+
+const usd = (v: number): string => `$${v.toFixed(2)}`;
 
 describe("fillDayWindow", () => {
   it("pads a sparse series to a continuous window ending on endDay", () => {
@@ -51,47 +70,106 @@ describe("fillDayWindow", () => {
   });
 });
 
-describe("InsightsChart", () => {
+describe("RechartsInsightsChart", () => {
+  const rechartsData = (values: number[], secondary?: number[]) =>
+    values.map((value, i) => ({
+      day: `2026-08-${String(i + 1).padStart(2, "0")}`,
+      value,
+      secondary: secondary?.[i] ?? 0,
+    }));
+
   it("draws one bar per day, zero days included", () => {
     const { container } = render(
-      <InsightsChart
+      <RechartsInsightsChart
         variant="bar"
-        data={series([3, 0, 5])}
-        label="Lessons completed per day"
-        dayHeader="Day"
+        data={rechartsData([3, 0, 5])}
+        format={String}
         valueHeader="Lessons"
-        empty="No data yet."
+        locale="en"
       />
     );
-
-    const bars = container.querySelectorAll("svg rect");
-    expect(bars).toHaveLength(3);
-    // The tallest day reaches the top of the plot; the zero day still gets a
-    // hairline so the window reads as continuous rather than as a gap.
-    const heights = [...bars].map((b) => Number(b.getAttribute("height")));
-    expect(heights[2] ?? 0).toBeGreaterThan(heights[0] ?? 0);
-    expect(heights[1]).toBe(1);
+    expect(container.querySelectorAll(".recharts-bar-rectangle")).toHaveLength(
+      3
+    );
   });
 
-  it("labels every mark with its day and value", () => {
+  it("renders an area path and axes for the spend series", () => {
     const { container } = render(
-      <InsightsChart
-        variant="bar"
-        data={series([3, 0, 5])}
-        label="Lessons completed per day"
-        dayHeader="Day"
-        valueHeader="Lessons"
-        empty="No data yet."
+      <RechartsInsightsChart
+        variant="area"
+        data={rechartsData([0.5, 1.25, 0.75])}
+        format={usd}
+        valueHeader="USD"
+        locale="en"
       />
     );
-
-    const titles = [...container.querySelectorAll("svg title")].map(
-      (t) => t.textContent
-    );
-    expect(titles).toEqual(["2026-08-01: 3", "2026-08-02: 0", "2026-08-03: 5"]);
+    expect(container.querySelector(".recharts-area-area")).toBeTruthy();
+    // The complaint that started #1148: no axes. Both must now render.
+    expect(container.querySelector(".recharts-xAxis")).toBeTruthy();
+    expect(container.querySelector(".recharts-yAxis")).toBeTruthy();
   });
 
-  it("repeats the data in a screen-reader table", () => {
+  it("thins the 30 daily x ticks to a readable subset, formatted like Aug 14", () => {
+    const days = Array.from({ length: 30 }, (_, i) => ({
+      day: `2026-08-${String(i + 1).padStart(2, "0")}`,
+      value: i,
+    }));
+    const { container } = render(
+      <RechartsInsightsChart
+        variant="bar"
+        data={days}
+        format={String}
+        valueHeader="Lessons"
+        locale="en"
+      />
+    );
+    const dayTicks = [
+      ...container.querySelectorAll(".recharts-cartesian-axis-tick-value"),
+    ]
+      .map((t) => t.textContent ?? "")
+      .filter((t) => t.startsWith("Aug"));
+    // interval=4 keeps every 5th of 30 daily ticks — far fewer than 30, not zero.
+    expect(dayTicks.length).toBeGreaterThan(0);
+    expect(dayTicks.length).toBeLessThan(15);
+    expect(dayTicks).toContain("Aug 1");
+  });
+});
+
+describe("InsightsChartTooltip", () => {
+  it("shows the date and value, with the secondary series as a second line", () => {
+    render(
+      <InsightsChartTooltip
+        active
+        payload={[
+          { payload: { day: "2026-08-14", value: 1.25, secondary: 9 } },
+        ]}
+        format={usd}
+        valueHeader="USD"
+        secondary={{ header: "Requests", format: String }}
+        locale="en"
+      />
+    );
+    expect(screen.getByText("Aug 14")).toBeTruthy();
+    expect(screen.getByText("USD: $1.25")).toBeTruthy();
+    expect(screen.getByText("Requests: 9")).toBeTruthy();
+  });
+
+  it("renders nothing when inactive", () => {
+    const { container } = render(
+      <InsightsChartTooltip
+        active={false}
+        payload={[{ payload: { day: "2026-08-14", value: 1 } }]}
+        format={String}
+        valueHeader="Lessons"
+        locale="en"
+      />
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+});
+
+describe("InsightsChart wrapper", () => {
+  it("repeats every day in a screen-reader table", () => {
     render(
       <InsightsChart
         variant="bar"
@@ -99,13 +177,11 @@ describe("InsightsChart", () => {
         label="Lessons completed per day"
         dayHeader="Day"
         valueHeader="Lessons"
+        locale="en"
         empty="No data yet."
       />
     );
 
-    expect(
-      screen.getByRole("img", { name: "Lessons completed per day" })
-    ).toBeTruthy();
     const table = screen.getByRole("table", {
       name: "Lessons completed per day",
     });
@@ -113,47 +189,24 @@ describe("InsightsChart", () => {
     expect(screen.getByRole("rowheader", { name: "2026-08-02" })).toBeTruthy();
   });
 
-  it("carries the secondary series in tooltips and the table, not a second axis", () => {
-    const { container } = render(
+  it("carries the secondary series in the table as a column, not a second axis", () => {
+    render(
       <InsightsChart
         variant="area"
         data={series([0.5, 1.25])}
         label="Daily AI spend"
         dayHeader="Day"
         valueHeader="USD"
-        format={(v) => `$${v.toFixed(2)}`}
+        locale="en"
+        format={usd}
         secondary={{ header: "Requests", values: [2, 9] }}
         empty="No data yet."
       />
     );
 
-    const titles = [...container.querySelectorAll("svg title")].map(
-      (t) => t.textContent
-    );
-    expect(titles).toEqual([
-      "2026-08-01: $0.50 · Requests 2",
-      "2026-08-02: $1.25 · Requests 9",
-    ]);
-    // One line path plus one area path — never a second scaled series.
-    expect(container.querySelectorAll("svg path")).toHaveLength(2);
     expect(screen.getByRole("columnheader", { name: "Requests" })).toBeTruthy();
-  });
-
-  it("renders an all-zero window instead of NaN coordinates", () => {
-    const { container } = render(
-      <InsightsChart
-        variant="area"
-        data={series([0, 0, 0])}
-        label="Daily AI spend"
-        dayHeader="Day"
-        valueHeader="USD"
-        empty="No data yet."
-      />
-    );
-
-    for (const path of container.querySelectorAll("svg path")) {
-      expect(path.getAttribute("d")).not.toContain("NaN");
-    }
+    expect(screen.getByRole("cell", { name: "$1.25" })).toBeTruthy();
+    expect(screen.getByRole("cell", { name: "9" })).toBeTruthy();
   });
 
   it("shows the empty message rather than an axis with nothing on it", () => {
@@ -164,6 +217,7 @@ describe("InsightsChart", () => {
         label="Lessons completed per day"
         dayHeader="Day"
         valueHeader="Lessons"
+        locale="en"
         empty="No data yet."
       />
     );

--- a/apps/web/src/components/admin/insights-chart-recharts.tsx
+++ b/apps/web/src/components/admin/insights-chart-recharts.tsx
@@ -1,0 +1,186 @@
+"use client";
+
+/**
+ * Recharts renderer for the admin Insights time series (#1148 follow-up to
+ * #1135). Split into its own module so `next/dynamic` code-splits recharts (and
+ * its d3 deps) off every non-admin route — nothing here is imported statically
+ * by `insights-chart.tsx`, only through the dynamic import.
+ *
+ * Colours come from the app's CSS tokens (`var(--primary)` …) so light/dark
+ * follow the theme with no JS. The visual is `aria-hidden`; the accessible copy
+ * is the `sr-only` table rendered by the wrapper.
+ */
+
+import {
+  Area,
+  AreaChart,
+  Bar,
+  BarChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+
+export interface RechartsInsightsChartProps {
+  variant: "bar" | "area";
+  /** One row per day, ascending; `secondary` is the raw parallel value. */
+  data: { day: string; value: number; secondary?: number }[];
+  /** Formats the primary value (tooltip + Y axis). */
+  format: (value: number) => string;
+  valueHeader: string;
+  /** Secondary series shown only in the tooltip, never as a second axis. */
+  secondary?: { header: string; format: (value: number) => string };
+  /** BCP-47 tag for month/day tick labels. */
+  locale: string;
+}
+
+const GRID = "var(--border)";
+const AXIS = "var(--text-3)";
+const SERIES = "var(--primary)";
+
+interface TooltipPayloadEntry {
+  payload: { day: string; value: number; secondary?: number };
+}
+
+function tickDay(iso: string, locale: string): string {
+  const parsed = Date.parse(`${iso}T00:00:00Z`);
+  if (Number.isNaN(parsed)) return iso;
+  return new Intl.DateTimeFormat(locale, {
+    month: "short",
+    day: "numeric",
+    timeZone: "UTC",
+  }).format(parsed);
+}
+
+export function InsightsChartTooltip({
+  active,
+  payload,
+  format,
+  valueHeader,
+  secondary,
+  locale,
+}: {
+  active?: boolean;
+  payload?: TooltipPayloadEntry[];
+  format: (value: number) => string;
+  valueHeader: string;
+  secondary?: { header: string; format: (value: number) => string };
+  locale: string;
+}) {
+  const row = active ? payload?.[0]?.payload : undefined;
+  if (!row) return null;
+  return (
+    <div className="rounded-lg border border-border bg-card px-3 py-2 text-xs shadow-card">
+      <p className="font-mono text-text-3">{tickDay(row.day, locale)}</p>
+      <p className="mt-0.5 font-semibold tabular-nums text-text">
+        {valueHeader}: {format(row.value)}
+      </p>
+      {secondary ? (
+        <p className="tabular-nums text-text-3">
+          {secondary.header}: {secondary.format(row.secondary ?? 0)}
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+export function RechartsInsightsChart({
+  variant,
+  data,
+  format,
+  valueHeader,
+  secondary,
+  locale,
+}: RechartsInsightsChartProps) {
+  const axis = { fill: AXIS, fontSize: 11 };
+  const xAxis = (
+    <XAxis
+      dataKey="day"
+      // ~30 daily ticks would overlap; show every 5th, formatted "Aug 14".
+      interval={4}
+      tickFormatter={(iso: string) => tickDay(iso, locale)}
+      tick={axis}
+      tickLine={false}
+      axisLine={{ stroke: GRID }}
+      minTickGap={8}
+    />
+  );
+  const yAxis = (
+    <YAxis
+      tickFormatter={format}
+      tick={axis}
+      tickLine={false}
+      axisLine={false}
+      width={44}
+      tickCount={4}
+    />
+  );
+  const grid = (
+    <CartesianGrid stroke={GRID} strokeDasharray="3 3" vertical={false} />
+  );
+  const tooltip = (
+    <Tooltip
+      cursor={{ fill: "var(--primary-dim)", stroke: GRID }}
+      content={
+        <InsightsChartTooltip
+          format={format}
+          valueHeader={valueHeader}
+          secondary={secondary}
+          locale={locale}
+        />
+      }
+    />
+  );
+
+  return (
+    <div aria-hidden="true" className="px-2 py-3">
+      <ResponsiveContainer width="100%" height={180}>
+        {variant === "bar" ? (
+          <BarChart
+            data={data}
+            margin={{ top: 8, right: 8, bottom: 0, left: 0 }}
+          >
+            {grid}
+            {xAxis}
+            {yAxis}
+            {tooltip}
+            {/* A zero day keeps a hairline (minPointSize) so an idle day reads
+                as continuous rather than as missing data. */}
+            <Bar
+              dataKey="value"
+              fill={SERIES}
+              radius={[2, 2, 0, 0]}
+              minPointSize={2}
+              isAnimationActive={false}
+            />
+          </BarChart>
+        ) : (
+          <AreaChart
+            data={data}
+            margin={{ top: 8, right: 8, bottom: 0, left: 0 }}
+          >
+            <defs>
+              <linearGradient id="insights-area" x1="0" y1="0" x2="0" y2="1">
+                <stop offset="0%" stopColor={SERIES} stopOpacity={0.45} />
+                <stop offset="100%" stopColor={SERIES} stopOpacity={0.02} />
+              </linearGradient>
+            </defs>
+            {grid}
+            {xAxis}
+            {yAxis}
+            {tooltip}
+            <Area
+              dataKey="value"
+              stroke={SERIES}
+              strokeWidth={2}
+              fill="url(#insights-area)"
+              isAnimationActive={false}
+            />
+          </AreaChart>
+        )}
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/apps/web/src/components/admin/insights-chart.tsx
+++ b/apps/web/src/components/admin/insights-chart.tsx
@@ -1,18 +1,35 @@
 "use client";
 
 /**
- * Hand-rolled viewBox SVG charts for the admin Insights panel (#1135).
+ * Admin Insights time-series charts (#1148, rewritten from the hand-rolled SVG
+ * of #1135 which had no axes and only a native-`title` tooltip).
  *
- * A 30-point time series rendered as table rows is the one shape that least
- * suits rows, but adding a charting library to pull two sparklines onto an
- * admin-only screen is not a trade this bundle should make. Same approach as
- * `components/gamification/skill-radar.tsx`: plain SVG, `viewBox` scaling, and
- * colours from CSS tokens so light/dark come for free.
+ * The visual is Recharts, loaded through `next/dynamic({ ssr: false })` so the
+ * library — recharts + its d3 deps, ~50 kB gz — is code-split onto the
+ * admin-only route and never ships in any other bundle. This module keeps only
+ * the data prep (`fillDayWindow`), the `BarCell` table fill, and the wrapper
+ * that pairs the lazy chart with an always-present `sr-only` table.
  *
- * Accessibility: the SVG is `role="img"` with an `aria-label`, every mark
- * carries a `<title>` for pointer hover, and the same numbers are repeated in a
- * `sr-only` table — a screen reader reads the data, not "chart".
+ * Accessibility: the chart itself is `aria-hidden`; screen readers get the same
+ * numbers from the `sr-only` table, so nobody hears "chart" with no data.
  */
+
+import dynamic from "next/dynamic";
+
+const RechartsInsightsChart = dynamic(
+  () =>
+    import("./insights-chart-recharts").then((mod) => ({
+      default: mod.RechartsInsightsChart,
+    })),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="px-2 py-3">
+        <div className="bg-card-alt h-[180px] w-full animate-pulse rounded-lg" />
+      </div>
+    ),
+  }
+);
 
 export interface DayPoint {
   /** `YYYY-MM-DD`, ascending, one entry per day of the window. */
@@ -23,14 +40,16 @@ export interface DayPoint {
 interface InsightsChartProps {
   variant: "bar" | "area";
   data: DayPoint[];
-  /** Describes the whole chart (`aria-label`). */
+  /** Describes the whole chart (table caption + tooltip context). */
   label: string;
   dayHeader: string;
   valueHeader: string;
-  /** Renders a value for the `<title>` tooltips and the table. */
+  /** BCP-47 tag for localised month/day tick labels. */
+  locale: string;
+  /** Renders a value for the tooltip, Y axis, and the table. */
   format?: (value: number) => string;
   /**
-   * A second series shown ONLY in tooltips and the table. Deliberately not a
+   * A second series shown ONLY in the tooltip and the table. Deliberately not a
    * second axis: two y-scales on one plot invite reading a crossing as
    * meaningful when it is an artefact of the scaling.
    */
@@ -75,10 +94,6 @@ export function fillDayWindow<T extends { day: string }>(
   return out;
 }
 
-const W = 320;
-const H = 96;
-const PAD_Y = 6;
-
 const identity = (v: number): string => String(v);
 
 export function InsightsChart({
@@ -87,6 +102,7 @@ export function InsightsChart({
   label,
   dayHeader,
   valueHeader,
+  locale,
   format = identity,
   secondary,
   empty,
@@ -95,112 +111,24 @@ export function InsightsChart({
     return <p className="p-4 text-sm text-text-3">{empty}</p>;
   }
 
-  // A flat all-zero window would divide by zero; treat it as a full-height
-  // scale of 1 so the baseline still renders instead of NaN coordinates.
-  const max = Math.max(1, ...data.map((d) => d.value));
-  const n = data.length;
-  const plotH = H - PAD_Y * 2;
-  const y = (value: number): number => PAD_Y + plotH * (1 - value / max);
-
-  const slot = W / n;
-  const barW = Math.max(1, slot * 0.68);
-
-  const points = data.map((d, i) => ({
-    x: slot * i + slot / 2,
-    y: y(d.value),
-  }));
-  const line = points
-    .map((p, i) => `${i === 0 ? "M" : "L"}${p.x.toFixed(2)},${p.y.toFixed(2)}`)
-    .join(" ");
-  const firstX = slot / 2;
-  const lastX = slot * (n - 1) + slot / 2;
-  const baseline = H - PAD_Y;
-  const area = `${line} L${lastX.toFixed(2)},${baseline} L${firstX.toFixed(2)},${baseline} Z`;
-
-  const tooltip = (d: DayPoint, i: number): string => {
-    const head = `${d.day}: ${format(d.value)}`;
-    if (!secondary) return head;
-    const raw = secondary.values[i] ?? 0;
-    return `${head} · ${secondary.header} ${(secondary.format ?? identity)(raw)}`;
-  };
-
   return (
-    <div className="px-4 py-3">
-      <svg
-        viewBox={`0 0 ${W} ${H}`}
-        role="img"
-        aria-label={label}
-        className="h-24 w-full overflow-visible"
-        preserveAspectRatio="none"
-      >
-        <defs>
-          <linearGradient id="insights-area" x1="0" y1="0" x2="0" y2="1">
-            <stop offset="0%" stopColor="var(--primary)" stopOpacity="0.45" />
-            <stop offset="100%" stopColor="var(--primary)" stopOpacity="0.02" />
-          </linearGradient>
-        </defs>
-
-        <line
-          x1="0"
-          y1={H - PAD_Y}
-          x2={W}
-          y2={H - PAD_Y}
-          stroke="var(--border)"
-          strokeWidth="1"
-          vectorEffect="non-scaling-stroke"
-        />
-
-        {variant === "bar"
-          ? data.map((d, i) => {
-              const top = y(d.value);
-              return (
-                <rect
-                  key={d.day}
-                  x={slot * i + (slot - barW) / 2}
-                  y={top}
-                  width={barW}
-                  // A zero day still gets a hairline so the window reads as
-                  // continuous rather than as missing data.
-                  height={Math.max(1, H - PAD_Y - top)}
-                  rx="1"
-                  fill="var(--primary)"
-                  opacity={d.value === 0 ? 0.25 : 0.85}
-                >
-                  <title>{tooltip(d, i)}</title>
-                </rect>
-              );
-            })
-          : null}
-
-        {variant === "area" ? (
-          <>
-            <path d={area} fill="url(#insights-area)" />
-            <path
-              d={line}
-              fill="none"
-              stroke="var(--primary)"
-              strokeWidth="2"
-              strokeLinejoin="round"
-              strokeLinecap="round"
-              vectorEffect="non-scaling-stroke"
-            />
-            {data.map((d, i) => (
-              // Invisible hit target per day: the line itself is too thin to
-              // hover, and a 2px dot per day would clutter 30 points.
-              <rect
-                key={d.day}
-                x={slot * i}
-                y="0"
-                width={slot}
-                height={H}
-                fill="transparent"
-              >
-                <title>{tooltip(d, i)}</title>
-              </rect>
-            ))}
-          </>
-        ) : null}
-      </svg>
+    <div>
+      <RechartsInsightsChart
+        variant={variant}
+        data={data.map((d, i) => ({
+          day: d.day,
+          value: d.value,
+          secondary: secondary?.values[i] ?? 0,
+        }))}
+        format={format}
+        valueHeader={valueHeader}
+        secondary={
+          secondary
+            ? { header: secondary.header, format: secondary.format ?? identity }
+            : undefined
+        }
+        locale={locale}
+      />
 
       <table className="sr-only">
         <caption>{label}</caption>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -227,6 +227,9 @@ importers:
       react-markdown:
         specifier: ^10.1.0
         version: 10.1.0(@types/react@18.3.28)(react@18.3.1)
+      recharts:
+        specifier: ^3.10.1
+        version: 3.10.1(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(redux@5.0.1)
       rehype-highlight:
         specifier: ^7.0.2
         version: 7.0.2
@@ -2832,6 +2835,17 @@ packages:
       '@types/react':
         optional: true
 
+  '@reduxjs/toolkit@2.12.0':
+    resolution: {integrity: sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw==}
+    peerDependencies:
+      react: ^16.9.0 || ^17.0.0 || ^18 || ^19
+      react-redux: ^7.2.1 || ^8.1.3 || ^9.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-redux:
+        optional: true
+
   '@rollup/plugin-commonjs@28.0.1':
     resolution: {integrity: sha512-+tNWdlWKbpB3WgBN7ijjYkq9X5uhjmcvyjEght4NmH5fAU++zfQzAJ6wumLS+dNcvwEZhKx2Z+skY8m7v0wGSA==}
     engines: {node: '>=16.0.0 || 14 >= 14.17'}
@@ -3399,6 +3413,9 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
+  '@standard-schema/utils@0.3.0':
+    resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
+
   '@starknet-io/types-js@0.7.10':
     resolution: {integrity: sha512-1VtCqX4AHWJlRRSYGSn+4X1mqolI1Tdq62IwzoU2vUuEE72S1OlEeGhpvd6XsdqXcfHmVzYfj8k1XtKBQqwo9w==}
 
@@ -3638,6 +3655,33 @@ packages:
   '@types/connect@3.4.38':
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
 
+  '@types/d3-array@3.2.2':
+    resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
+
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-ease@3.0.2':
+    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-path@3.1.1':
+    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
+
+  '@types/d3-scale@4.0.9':
+    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
+
+  '@types/d3-shape@3.1.8':
+    resolution: {integrity: sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==}
+
+  '@types/d3-time@3.0.4':
+    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
+
+  '@types/d3-timer@3.0.2':
+    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
+
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
 
@@ -3744,6 +3788,9 @@ packages:
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
+
+  '@types/use-sync-external-store@0.0.6':
+    resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
 
   '@types/uuid@8.3.4':
     resolution: {integrity: sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==}
@@ -4817,6 +4864,50 @@ packages:
   csv-stringify@6.8.0:
     resolution: {integrity: sha512-Ya0OOHb6XbgPaZKH7dcdmwXe3azUS0TwmlbVdS75HoAhnHApSkiQcfEJoC/s5WwGsrXwOjBDr3FTmCZPjkssgg==}
 
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.2:
+    resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
 
@@ -4877,6 +4968,9 @@ packages:
   decamelize@4.0.0:
     resolution: {integrity: sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==}
     engines: {node: '>=10'}
+
+  decimal.js-light@2.5.1:
+    resolution: {integrity: sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==}
 
   decimal.js@10.6.0:
     resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
@@ -5744,6 +5838,9 @@ packages:
     engines: {node: '>=16.x'}
     hasBin: true
 
+  immer@11.1.18:
+    resolution: {integrity: sha512-EQyQtLiYW029lyoczMl/Hh4Xu7cDecSc58JRYpHyL4tIAu3eqd1yJzQX04d2BZHDkzFFvm6qJEJWOtfDSWAXbQ==}
+
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
@@ -5776,6 +5873,10 @@ packages:
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
+
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
 
   intl-messageformat@11.2.12:
     resolution: {integrity: sha512-KW70Xxfcvy7vV3qODfvShWkFDPMqKDAa4N+hSyVBWGNtVhTUFYaqlD/l88DaYPKiVcPP4rPQ3qnH7i5K82Mg7g==}
@@ -7279,6 +7380,18 @@ packages:
       '@types/react':
         optional: true
 
+  react-redux@9.3.0:
+    resolution: {integrity: sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==}
+    peerDependencies:
+      '@types/react': ^18.2.25 || ^19
+      react: ^18.0 || ^19
+      redux: ^5.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      redux:
+        optional: true
+
   react-refresh@0.14.2:
     resolution: {integrity: sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==}
     engines: {node: '>=0.10.0'}
@@ -7336,12 +7449,28 @@ packages:
     resolution: {integrity: sha512-r/H9MzAWtrv8aSVjPCMFpDMl5q66GqtmmRkRjpHTsp4zBAa+snZyiQNlMONiUmEJcsnaw0wCauJ2GWODr/aFkg==}
     engines: {node: '>= 12.13.0'}
 
+  recharts@3.10.1:
+    resolution: {integrity: sha512-QXFrvt6IVcw7eeZCoyXTwkIJAX3Dv1nyVhMicXJ47GsGDDpcN8z6o644DibE9XjpBTThtsomLKnTV6lc+cVFUA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-is: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   redent@3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
     engines: {node: '>=8'}
 
   redeyed@2.1.1:
     resolution: {integrity: sha512-FNpGGo1DycYAdnrKFxCMmKYgo/mILAqtRYbkdQD8Ep/Hk2PQ5+aEAEx+IU713RTDmuBaH0c8P5ZozurNu5ObRQ==}
+
+  redux-thunk@3.1.0:
+    resolution: {integrity: sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==}
+    peerDependencies:
+      redux: ^5.0.0
+
+  redux@5.0.1:
+    resolution: {integrity: sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==}
 
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
@@ -7389,6 +7518,9 @@ packages:
 
   requires-port@1.0.0:
     resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
+
+  reselect@5.2.0:
+    resolution: {integrity: sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==}
 
   resolve-alpn@1.2.1:
     resolution: {integrity: sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==}
@@ -7887,6 +8019,9 @@ packages:
   through@2.3.8:
     resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
 
+  tiny-invariant@1.3.3:
+    resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
+
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
@@ -8245,6 +8380,9 @@ packages:
 
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
+
+  victory-vendor@37.3.6:
+    resolution: {integrity: sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==}
 
   viem@2.31.0:
     resolution: {integrity: sha512-U7OMQ6yqK+bRbEIarf2vqxL7unSEQvNxvML/1zG7suAmKuJmipqdVTVJGKBCJiYsm/EremyO2FS4dHIPpGv+eA==}
@@ -11370,6 +11508,18 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.28
 
+  '@reduxjs/toolkit@2.12.0(react-redux@9.3.0(@types/react@18.3.28)(react@18.3.1)(redux@5.0.1))(react@18.3.1)':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@standard-schema/utils': 0.3.0
+      immer: 11.1.18
+      redux: 5.0.1
+      redux-thunk: 3.1.0(redux@5.0.1)
+      reselect: 5.2.0
+    optionalDependencies:
+      react: 18.3.1
+      react-redux: 9.3.0(@types/react@18.3.28)(react@18.3.1)(redux@5.0.1)
+
   '@rollup/plugin-commonjs@28.0.1(rollup@4.57.1)':
     dependencies:
       '@rollup/pluginutils': 5.3.0(rollup@4.57.1)
@@ -12173,6 +12323,8 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
+  '@standard-schema/utils@0.3.0': {}
+
   '@starknet-io/types-js@0.7.10': {}
 
   '@supabase/auth-js@2.95.3':
@@ -12409,6 +12561,30 @@ snapshots:
     dependencies:
       '@types/node': 22.19.9
 
+  '@types/d3-array@3.2.2': {}
+
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-ease@3.0.2': {}
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-path@3.1.1': {}
+
+  '@types/d3-scale@4.0.9':
+    dependencies:
+      '@types/d3-time': 3.0.4
+
+  '@types/d3-shape@3.1.8':
+    dependencies:
+      '@types/d3-path': 3.1.1
+
+  '@types/d3-time@3.0.4': {}
+
+  '@types/d3-timer@3.0.2': {}
+
   '@types/debug@4.1.12':
     dependencies:
       '@types/ms': 2.1.0
@@ -12520,6 +12696,8 @@ snapshots:
   '@types/unist@2.0.11': {}
 
   '@types/unist@3.0.3': {}
+
+  '@types/use-sync-external-store@0.0.6': {}
 
   '@types/uuid@8.3.4': {}
 
@@ -13916,6 +14094,44 @@ snapshots:
 
   csv-stringify@6.8.0: {}
 
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-color@3.1.0: {}
+
+  d3-ease@3.0.1: {}
+
+  d3-format@3.1.2: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-path@3.1.0: {}
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
+  d3-shape@3.2.0:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-timer@3.0.1: {}
+
   damerau-levenshtein@1.0.8: {}
 
   data-urls@7.0.0(@noble/hashes@1.8.0):
@@ -13964,6 +14180,8 @@ snapshots:
   decamelize@1.2.0: {}
 
   decamelize@4.0.0: {}
+
+  decimal.js-light@2.5.1: {}
 
   decimal.js@10.6.0: {}
 
@@ -15089,6 +15307,8 @@ snapshots:
     dependencies:
       queue: 6.0.2
 
+  immer@11.1.18: {}
+
   import-fresh@3.3.1:
     dependencies:
       parent-module: 1.0.1
@@ -15139,6 +15359,8 @@ snapshots:
       es-errors: 1.3.0
       hasown: 2.0.2
       side-channel: 1.1.0
+
+  internmap@2.0.3: {}
 
   intl-messageformat@11.2.12:
     dependencies:
@@ -17041,6 +17263,15 @@ snapshots:
       - supports-color
       - utf-8-validate
 
+  react-redux@9.3.0(@types/react@18.3.28)(react@18.3.1)(redux@5.0.1):
+    dependencies:
+      '@types/use-sync-external-store': 0.0.6
+      react: 18.3.1
+      use-sync-external-store: 1.6.0(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+      redux: 5.0.1
+
   react-refresh@0.14.2: {}
 
   react-remove-scroll-bar@2.3.8(@types/react@18.3.28)(react@18.3.1):
@@ -17092,6 +17323,26 @@ snapshots:
 
   real-require@0.1.0: {}
 
+  recharts@3.10.1(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react-is@18.3.1)(react@18.3.1)(redux@5.0.1):
+    dependencies:
+      '@reduxjs/toolkit': 2.12.0(react-redux@9.3.0(@types/react@18.3.28)(react@18.3.1)(redux@5.0.1))(react@18.3.1)
+      clsx: 2.1.1
+      decimal.js-light: 2.5.1
+      es-toolkit: 1.39.3
+      eventemitter3: 5.0.4
+      immer: 11.1.18
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-is: 18.3.1
+      react-redux: 9.3.0(@types/react@18.3.28)(react@18.3.1)(redux@5.0.1)
+      reselect: 5.2.0
+      tiny-invariant: 1.3.3
+      use-sync-external-store: 1.6.0(react@18.3.1)
+      victory-vendor: 37.3.6
+    transitivePeerDependencies:
+      - '@types/react'
+      - redux
+
   redent@3.0.0:
     dependencies:
       indent-string: 4.0.0
@@ -17100,6 +17351,12 @@ snapshots:
   redeyed@2.1.1:
     dependencies:
       esprima: 4.0.1
+
+  redux-thunk@3.1.0(redux@5.0.1):
+    dependencies:
+      redux: 5.0.1
+
+  redux@5.0.1: {}
 
   reflect.getprototypeof@1.0.10:
     dependencies:
@@ -17185,6 +17442,8 @@ snapshots:
   require-main-filename@2.0.0: {}
 
   requires-port@1.0.0: {}
+
+  reselect@5.2.0: {}
 
   resolve-alpn@1.2.1: {}
 
@@ -17798,6 +18057,8 @@ snapshots:
 
   through@2.3.8: {}
 
+  tiny-invariant@1.3.3: {}
+
   tinybench@2.9.0: {}
 
   tinyexec@1.0.2: {}
@@ -18146,6 +18407,23 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
+
+  victory-vendor@37.3.6:
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/d3-ease': 3.0.2
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-scale': 4.0.9
+      '@types/d3-shape': 3.1.8
+      '@types/d3-time': 3.0.4
+      '@types/d3-timer': 3.0.2
+      d3-array: 3.2.4
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-scale: 4.0.2
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-timer: 3.0.1
 
   viem@2.31.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@4.0.5):
     dependencies:


### PR DESCRIPTION
The #1135 insights charts had no axes and only a native-\`title\` tooltip. Replaced the hand-rolled SVG with Recharts — BarChart for lessons-by-day, AreaChart for AI spend — with real X/Y axes (30 daily x-ticks thinned to every 5th, formatted "Aug 14"), a styled custom tooltip carrying requests as a secondary line (not a second axis), and a subtle grid.

Recharts loads through \`next/dynamic({ ssr: false })\` from a separate \`insights-chart-recharts.tsx\` module, so it and its d3 deps code-split into an admin-only chunk instead of shipping on any other route.

Colours are the app's CSS tokens, so light/dark follow the theme. \`fillDayWindow\` zero-fill and the sr-only data table are unchanged; the visual is \`aria-hidden\` so screen readers read the table.

**Bundle evidence** (\`pnpm --filter web build\`): recharts lands in one async chunk (~397 kB raw / ~112 kB gz) with 0 references in the shared build-manifest; the react-loadable-manifest maps the \`insights-chart-recharts\` dynamic import to it, and the insights page chunk contains no recharts statically.

Tests: rewrote \`insights-chart.test.tsx\` for the Recharts version (bars/area/axis-tick counts with ResponsiveContainer mocked to fixed dims, tooltip content asserted directly, sr-only table parity) — 13 pass; i18n parity unchanged (no new keys).