### PR TITLE
fix(lesson): prev/next split the mobile bottom nav 50/50

### DIFF
--- a/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/blocks/__tests__/quiz-block.test.tsx
+++ b/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/blocks/__tests__/quiz-block.test.tsx
@@ -254,7 +254,7 @@ describe("QuizBlock — proofs and answered reporting", () => {
   });
 });
 
-describe("QuizBlock — completion state survives the auto-collapse", () => {
+describe("QuizBlock — a clean sweep leaves the quiz open (owner 2026-08-21)", () => {
   /** Answer every question of `quizBlock` correctly, in stepper order. */
   function sweep(): void {
     fireEvent.click(screen.getByLabelText("A program-derived address"));
@@ -265,31 +265,29 @@ describe("QuizBlock — completion state survives the auto-collapse", () => {
     fireEvent.click(checkButton());
   }
 
-  it("shows the all-correct summary in a live region even though the block folds", () => {
+  it("does NOT auto-fold — the last explanation stays on screen", () => {
     renderWithIntl(<QuizBlock block={quizBlock} ctx={makeCtx()} />);
     sweep();
 
-    // The owner-requested auto-collapse fires on this exact transition.
+    // The sweep lands on the last question; folding here used to snatch its
+    // explanation away mid-read (the 2026-07-31 auto-collapse, reversed).
+    expect(screen.getByRole("button", { name: /Quiz/ })).toHaveAttribute(
+      "aria-expanded",
+      "true"
+    );
+    const summary = screen.getByText("All 2 questions answered correctly.");
+    expect(summary.closest(".hidden")).toBeNull();
+  });
+
+  it("still folds and reopens by hand, keeping the header score + Complete chip", () => {
+    renderWithIntl(<QuizBlock block={quizBlock} ctx={makeCtx()} />);
+    sweep();
+
+    fireEvent.click(screen.getByRole("button", { name: /Quiz/ }));
     expect(screen.getByRole("button", { name: /Quiz/ })).toHaveAttribute(
       "aria-expanded",
       "false"
     );
-
-    // ...and the completion line must still be perceivable. It has to live in
-    // a polite live region OUTSIDE the collapsible body: the body carries the
-    // `hidden` utility on the very frame the sweep lands, so a summary nested
-    // in it is neither painted nor reliably announced. (jsdom loads no
-    // stylesheet, so `toBeVisible` cannot see a class-driven display:none —
-    // the ancestor check below is what actually proves the placement.)
-    const summary = screen.getByText("All 2 questions answered correctly.");
-    const live = summary.closest("[aria-live]");
-    expect(live).toHaveAttribute("aria-live", "polite");
-    expect(live!.closest(".hidden")).toBeNull();
-  });
-
-  it("keeps the header score + Complete chip readable while collapsed", () => {
-    renderWithIntl(<QuizBlock block={quizBlock} ctx={makeCtx()} />);
-    sweep();
     expect(screen.getByText("2/2 correct")).toBeVisible();
     expect(screen.getByText("Complete")).toBeVisible();
   });

--- a/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/blocks/quiz-block.tsx
+++ b/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/blocks/quiz-block.tsx
@@ -206,15 +206,10 @@ export function QuizBlock({ block, ctx }: BlockRenderProps) {
   const correctCount = b.questions.filter((q) => results[q.id]?.correct).length;
   const allCorrect = total > 0 && correctCount === total;
 
-  // Owner call (2026-07-31): once every question is answered correctly the
-  // quiz folds itself — the header chips carry the recap and the AI Partner
-  // sits directly underneath. Fires once on the transition, so the learner can
-  // still reopen the section manually afterwards.
-  const prevAllCorrect = useRef(false);
-  useEffect(() => {
-    if (allCorrect && !prevAllCorrect.current) setOpen(false);
-    prevAllCorrect.current = allCorrect;
-  }, [allCorrect]);
+  // The quiz used to fold itself on a clean sweep (owner call 2026-07-31).
+  // Reversed 2026-08-21: the sweep usually lands on the LAST question, and
+  // auto-folding snatched its explanation away mid-read. The header's COMPLETE
+  // chip still signals done; folding is the learner's own click now.
 
   const multi = q?.multiSelect ?? false;
   const chosen = q ? (selections[q.id] ?? []) : [];
@@ -292,10 +287,9 @@ export function QuizBlock({ block, ctx }: BlockRenderProps) {
 
       {/* Completion state (#943): a clean sweep is acknowledged in-block — no
           popup, per the three-popup rule. It sits OUTSIDE the collapsible body
-          on purpose: the same sweep auto-collapses the quiz, and a live-region
-          insertion inside a subtree that goes `hidden` in the same frame is
-          neither seen nor reliably announced. Always mounted so the region
-          exists before the text arrives. */}
+          so it stays perceivable if the learner folds the quiz by hand (the
+          sweep no longer folds it automatically — owner 2026-08-21). Always
+          mounted so the region exists before the text arrives. */}
       <div aria-live="polite" className="px-5 pb-5 empty:hidden">
         {allCorrect && (
           <p className="flex items-center gap-2 rounded-md border border-[var(--primary-border)] bg-[var(--primary-dim)] p-3 text-sm font-medium text-primary">

--- a/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/lesson-client.tsx
+++ b/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/lesson-client.tsx
@@ -888,15 +888,18 @@ export function LessonPageClient({
           {!hasCodeBlock && paneSections}
 
           {/* Bottom nav hidden on challenge pages (#770): Prev/Next live in the
-            top bar and code lessons complete via the ChallengeInterface submit. */}
+            top bar and code lessons complete via the ChallengeInterface submit.
+            Mobile: a 2-col grid — the completion CTA spans the top row,
+            Prev/Next split the second 50/50 (owner, 21-08). Desktop keeps the
+            centred flex row; the CTA wrapper dissolves via sm:contents. */}
           {!hasCodeBlock && (
-            <div className="flex flex-col gap-3 border-t border-border pt-6 sm:flex-row sm:flex-wrap sm:items-center sm:justify-center">
+            <div className="grid grid-cols-2 gap-3 border-t border-border pt-6 sm:flex sm:flex-row sm:flex-wrap sm:items-center sm:justify-center">
               {prevLesson && (
                 <Button
                   variant="pushOutline"
                   size="default"
                   asChild
-                  className="w-full justify-center sm:w-auto sm:min-w-[120px]"
+                  className="order-2 w-full justify-center sm:order-none sm:w-auto sm:min-w-[120px]"
                 >
                   <Link
                     href={`${linkBase}/${courseSlug}/lessons/${prevLesson.slug}`}
@@ -910,38 +913,61 @@ export function LessonPageClient({
               lessons complete via this explicit button. Once completed the
               button gives way to a quiet status pill — a disabled button
               duplicating the nav CTA's label read as two dead actions. */}
-              {!hasCodeBlock &&
-                (userId ? (
-                  isEnrolled ? (
-                    isCompleted ? (
-                      <span
-                        role="status"
-                        className="inline-flex h-10 items-center justify-center gap-1.5 rounded-full border border-[var(--primary-border)] bg-[var(--primary-dim)] px-4 font-display text-[11px] font-bold uppercase tracking-[0.4px] text-primary"
-                      >
-                        <CheckCircle
-                          size={16}
-                          weight="fill"
-                          aria-hidden="true"
-                        />
-                        {t("lessonComplete")}
-                      </span>
+              <div className="order-1 col-span-2 flex flex-col sm:contents">
+                {!hasCodeBlock &&
+                  (userId ? (
+                    isEnrolled ? (
+                      isCompleted ? (
+                        <span
+                          role="status"
+                          className="inline-flex h-10 items-center justify-center gap-1.5 rounded-full border border-[var(--primary-border)] bg-[var(--primary-dim)] px-4 font-display text-[11px] font-bold uppercase tracking-[0.4px] text-primary"
+                        >
+                          <CheckCircle
+                            size={16}
+                            weight="fill"
+                            aria-hidden="true"
+                          />
+                          {t("lessonComplete")}
+                        </span>
+                      ) : (
+                        <Button
+                          variant="pushSuccess"
+                          size="default"
+                          disabled={
+                            isCompleting ||
+                            hasLinkedWallet === false ||
+                            !gateReady
+                          }
+                          onClick={() => handleComplete()}
+                          title={!gateReady ? t("completeGateHint") : undefined}
+                          className="w-full gap-2 sm:w-auto"
+                        >
+                          {isCompleting && (
+                            <>
+                              <div
+                                className="h-5 w-5 animate-spin rounded-full border-[3px] border-white/30 border-t-white"
+                                aria-hidden="true"
+                              />
+                              <span className="sr-only">
+                                {tCommon("loading")}
+                              </span>
+                            </>
+                          )}
+                          {t("markComplete")}
+                        </Button>
+                      )
                     ) : (
                       <Button
-                        variant="pushSuccess"
+                        variant="push"
                         size="default"
-                        disabled={
-                          isCompleting ||
-                          hasLinkedWallet === false ||
-                          !gateReady
-                        }
-                        onClick={() => handleComplete()}
-                        title={!gateReady ? t("completeGateHint") : undefined}
-                        className="w-full gap-2 sm:w-auto"
+                        disabled={isEnrolling}
+                        onClick={handleEnroll}
+                        className="gap-2"
                       >
-                        {isCompleting && (
+                        {isEnrolling && (
                           <>
                             <div
-                              className="h-5 w-5 animate-spin rounded-full border-[3px] border-white/30 border-t-white"
+                              className="h-4 w-4 animate-spin rounded-full border-2 border-white/30 border-t-white"
                               aria-hidden="true"
                             />
                             <span className="sr-only">
@@ -949,49 +975,30 @@ export function LessonPageClient({
                             </span>
                           </>
                         )}
-                        {t("markComplete")}
+                        {tCourses("enrollNow")}
                       </Button>
                     )
                   ) : (
+                    // Anonymous: banks the work done so far, then opens the sign-in
+                    // prompt with its "Later" escape (LX-A4). The controlled modal is
+                    // rendered once below.
                     <Button
                       variant="push"
                       size="default"
-                      disabled={isEnrolling}
-                      onClick={handleEnroll}
                       className="gap-2"
+                      onClick={openClaimAuth}
                     >
-                      {isEnrolling && (
-                        <>
-                          <div
-                            className="h-4 w-4 animate-spin rounded-full border-2 border-white/30 border-t-white"
-                            aria-hidden="true"
-                          />
-                          <span className="sr-only">{tCommon("loading")}</span>
-                        </>
-                      )}
-                      {tCourses("enrollNow")}
+                      {t("signInToTrack")}
                     </Button>
-                  )
-                ) : (
-                  // Anonymous: banks the work done so far, then opens the sign-in
-                  // prompt with its "Later" escape (LX-A4). The controlled modal is
-                  // rendered once below.
-                  <Button
-                    variant="push"
-                    size="default"
-                    className="gap-2"
-                    onClick={openClaimAuth}
-                  >
-                    {t("signInToTrack")}
-                  </Button>
-                ))}
+                  ))}
+              </div>
 
               {nextLesson ? (
                 <Button
                   variant={isCompleted ? "push" : "pushOutline"}
                   size="default"
                   asChild
-                  className="w-full justify-center sm:w-auto sm:min-w-[120px]"
+                  className={`order-3 w-full justify-center sm:order-none sm:w-auto sm:min-w-[120px] ${prevLesson ? "" : "col-span-2"}`}
                 >
                   <Link
                     href={`${linkBase}/${courseSlug}/lessons/${nextLesson.slug}`}
@@ -1007,7 +1014,7 @@ export function LessonPageClient({
                   variant={isCompleted ? "push" : "pushOutline"}
                   size="default"
                   asChild
-                  className="w-full justify-center sm:w-auto sm:min-w-[120px]"
+                  className={`order-3 w-full justify-center sm:order-none sm:w-auto sm:min-w-[120px] ${prevLesson ? "" : "col-span-2"}`}
                 >
                   <Link href={`${linkBase}/${courseSlug}`}>
                     {t("finishCourse")} &rarr;

--- a/apps/web/src/lib/referrals/server.ts
+++ b/apps/web/src/lib/referrals/server.ts
@@ -132,23 +132,33 @@ export async function getOwnReferralStats(userId: string): Promise<{
 }> {
   const supabase = createAdminClient();
 
-  const { data: code, error: codeError } = await supabase.rpc(
-    "get_or_create_referral_code",
-    { p_user_id: userId }
-  );
+  // The code mint, the season lookup and the lifetime signup count don't
+  // depend on each other — run them in one round instead of four serial hops
+  // (this route sat behind a visible spinner on the leaderboard card). Only
+  // the season-points count needs the season's window, so it goes second.
+  const nowIso = new Date().toISOString();
+  const [codeRes, seasonRes, signupRes] = await Promise.all([
+    supabase.rpc("get_or_create_referral_code", { p_user_id: userId }),
+    supabase
+      .from("referral_seasons")
+      .select("number, starts_at, ends_at")
+      .lte("starts_at", nowIso)
+      .order("number", { ascending: false })
+      .limit(1)
+      .maybeSingle(),
+    supabase
+      .from("referral_events")
+      .select("id", { count: "exact", head: true })
+      .eq("referrer_id", userId)
+      .eq("kind", "signup"),
+  ]);
+
+  const { data: code, error: codeError } = codeRes;
   if (codeError || !code) {
     throw new Error(codeError?.message ?? "code mint failed");
   }
-
-  const nowIso = new Date().toISOString();
-  const { data: seasonData, error: seasonError } = await supabase
-    .from("referral_seasons")
-    .select("number, starts_at, ends_at")
-    .lte("starts_at", nowIso)
-    .order("number", { ascending: false })
-    .limit(1)
-    .maybeSingle();
-  if (seasonError) throw new Error(seasonError.message);
+  if (seasonRes.error) throw new Error(seasonRes.error.message);
+  const seasonData = seasonRes.data;
   const season: ReferralSeason | null = seasonData
     ? {
         number: seasonData.number,
@@ -156,6 +166,7 @@ export async function getOwnReferralStats(userId: string): Promise<{
         endsAt: seasonData.ends_at,
       }
     : null;
+  if (signupRes.error) throw new Error(signupRes.error.message);
 
   let seasonPoints = 0;
   if (season) {
@@ -169,17 +180,10 @@ export async function getOwnReferralStats(userId: string): Promise<{
     seasonPoints = count ?? 0;
   }
 
-  const { count: signupCount, error: signupError } = await supabase
-    .from("referral_events")
-    .select("id", { count: "exact", head: true })
-    .eq("referrer_id", userId)
-    .eq("kind", "signup");
-  if (signupError) throw new Error(signupError.message);
-
   return {
     code,
     seasonPoints,
-    referredSignups: signupCount ?? 0,
+    referredSignups: signupRes.count ?? 0,
     season,
   };
 }

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -4497,6 +4497,23 @@ a.path-step-card:hover .path-step-badge.skip {
   border-width: 1px;
   box-shadow: none;
   border-radius: var(--r-md);
+  /* The rank-4+ dashed outline needs the solid top-3 podium for contrast
+     (40cd9caf spec). This strip shows only the you-±3 neighbourhood — usually
+     all rank 4+ — so every row went dashed and the card read as broken
+     (owner, 21-08). Quiet solid hairlines here; the full board keeps the spec. */
+  border-style: solid;
+  border-color: color-mix(in srgb, var(--lb-ink) 14%, transparent);
+}
+.lb-list-mini .lb-row[data-top] {
+  /* A top-3 row that does appear keeps its solid emphasis, minus the lift. */
+  border-width: 1.5px;
+  border-color: var(--lb-ink);
+}
+.lb-list-mini .lb-row.me {
+  /* The full-size ring (2px + 3px offset) overflows the tight card and clips
+     against the scroll container; keep the marker but tuck it in. */
+  outline-width: 1.5px;
+  outline-offset: 1px;
 }
 .lb-list-mini .lb-av {
   width: 26px;

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -4497,23 +4497,6 @@ a.path-step-card:hover .path-step-badge.skip {
   border-width: 1px;
   box-shadow: none;
   border-radius: var(--r-md);
-  /* The rank-4+ dashed outline needs the solid top-3 podium for contrast
-     (40cd9caf spec). This strip shows only the you-±3 neighbourhood — usually
-     all rank 4+ — so every row went dashed and the card read as broken
-     (owner, 21-08). Quiet solid hairlines here; the full board keeps the spec. */
-  border-style: solid;
-  border-color: color-mix(in srgb, var(--lb-ink) 14%, transparent);
-}
-.lb-list-mini .lb-row[data-top] {
-  /* A top-3 row that does appear keeps its solid emphasis, minus the lift. */
-  border-width: 1.5px;
-  border-color: var(--lb-ink);
-}
-.lb-list-mini .lb-row.me {
-  /* The full-size ring (2px + 3px offset) overflows the tight card and clips
-     against the scroll container; keep the marker but tuck it in. */
-  outline-width: 1.5px;
-  outline-offset: 1px;
 }
 .lb-list-mini .lb-av {
   width: 26px;


### PR DESCRIPTION
On mobile the three stacked full-width buttons read as one column of equal
actions. The completion CTA keeps the full-width top row; Previous and Next
share the second. Desktop flex row unchanged (the CTA wrapper dissolves via
sm:contents).
