### PR TITLE
feat(ui): unify learner progress bars on the XP-bar construction

### DIFF
--- a/apps/web/src/app/[locale]/(platform)/courses/[slug]/course-detail-client.tsx
+++ b/apps/web/src/app/[locale]/(platform)/courses/[slug]/course-detail-client.tsx
@@ -283,8 +283,8 @@ export function CourseDetailClient({
                 {isEnrolled && (
                   <div className="mb-5 space-y-2">
                     <div className="flex items-center justify-between text-sm">
-                      <span className="font-display text-[13px] font-bold text-text-2">
-                        {completedCount} / {totalLessons} {t("lessons")}
+                      <span className="font-mono text-xs font-semibold uppercase tabular-nums tracking-wider text-text-2">
+                        {completedCount}/{totalLessons} {t("lessons")}
                       </span>
                       <span className="font-display text-[13px] font-bold text-text-3">
                         {isComplete ? t("completed") : t("inProgress")}
@@ -293,7 +293,7 @@ export function CourseDetailClient({
                     <ProgressBar
                       value={completedCount}
                       max={totalLessons}
-                      showLabel
+                      segmented
                     />
                   </div>
                 )}

--- a/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/lesson-client.tsx
+++ b/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/lesson-client.tsx
@@ -823,11 +823,17 @@ export function LessonPageClient({
             <span className="font-mono text-xs tabular-nums text-text-3">
               {currentIndex + 1}/{allLessons.length}
             </span>
-            <ProgressBar
-              value={currentIndex + 1}
-              max={allLessons.length}
-              className="hidden w-16 sm:block sm:w-20"
-            />
+            {/* The width/visibility classes ride on a wrapper: `.seg-track`
+                sets display outside Tailwind's layer, so `hidden`/`sm:block`
+                on the bar itself would never win. */}
+            <div className="hidden w-16 sm:block sm:w-20">
+              <ProgressBar
+                value={currentIndex + 1}
+                max={allLessons.length}
+                segmented
+                size="slim"
+              />
+            </div>
           </div>
         </div>
       </div>

--- a/apps/web/src/components/course/__tests__/progress-bar.test.tsx
+++ b/apps/web/src/components/course/__tests__/progress-bar.test.tsx
@@ -1,0 +1,76 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { ProgressBar, SEGMENT_CAP } from "../progress-bar";
+
+describe("ProgressBar — segment math", () => {
+  it("renders one cell per lesson and lights the completed ones", () => {
+    const { container } = render(<ProgressBar value={9} max={15} segmented />);
+
+    expect(container.querySelectorAll(".seg-cell")).toHaveLength(15);
+    expect(container.querySelectorAll(".seg-cell--on")).toHaveLength(9);
+    expect(container.querySelector(".seg-fill")).toBeNull();
+  });
+
+  it("keeps segments at the cap and falls back to a smooth fill past it", () => {
+    const { container: atCap } = render(
+      <ProgressBar value={1} max={SEGMENT_CAP} segmented />
+    );
+    expect(atCap.querySelectorAll(".seg-cell")).toHaveLength(SEGMENT_CAP);
+
+    const { container: overCap } = render(
+      <ProgressBar value={20} max={SEGMENT_CAP + 1} segmented />
+    );
+    expect(overCap.querySelectorAll(".seg-cell")).toHaveLength(0);
+    expect(overCap.querySelector<HTMLElement>(".seg-fill")!.style.width).toBe(
+      `${(20 / 25) * 100}%`
+    );
+  });
+
+  it("lights one cell for an endowed fill with nothing completed", () => {
+    const { container } = render(
+      <ProgressBar value={0} max={8} displayFraction={0.06} segmented />
+    );
+
+    expect(container.querySelectorAll(".seg-cell--on")).toHaveLength(1);
+  });
+
+  it("leaves the bar empty when there is no progress and no endowment", () => {
+    const { container } = render(<ProgressBar value={0} max={8} segmented />);
+
+    expect(container.querySelectorAll(".seg-cell--on")).toHaveLength(0);
+  });
+
+  it("reports the honest count to assistive tech, not the endowed fill", () => {
+    render(
+      <ProgressBar
+        value={0}
+        max={8}
+        displayFraction={0.06}
+        segmented
+        aria-label="0 of 8 lessons completed"
+      />
+    );
+
+    const bar = screen.getByRole("progressbar", {
+      name: "0 of 8 lessons completed",
+    });
+    expect(bar).toHaveAttribute("aria-valuenow", "0");
+    expect(bar).toHaveAttribute("aria-valuemin", "0");
+    expect(bar).toHaveAttribute("aria-valuemax", "8");
+  });
+
+  it("clamps a count above the total", () => {
+    const { container } = render(<ProgressBar value={99} max={5} segmented />);
+
+    expect(container.querySelectorAll(".seg-cell--on")).toHaveLength(5);
+  });
+
+  it("carries the size variant class", () => {
+    const { container } = render(
+      <ProgressBar value={1} max={4} segmented size="micro" />
+    );
+
+    expect(container.querySelector(".seg-track--micro")).not.toBeNull();
+  });
+});

--- a/apps/web/src/components/course/progress-bar.tsx
+++ b/apps/web/src/components/course/progress-bar.tsx
@@ -1,46 +1,83 @@
 import { cn } from "@/lib/utils";
 
+/**
+ * Learner-facing progress bar — the dashboard XP bar's construction (ink
+ * outline, muted track, solid mint fill, pill radius) in three sizes.
+ *
+ * Lesson counts are discrete, so `segmented` renders one cell per lesson
+ * instead of a continuous fill. Past `SEGMENT_CAP` cells the ticks stop
+ * reading as countable units and turn into noise, so the bar falls back to a
+ * smooth fill on its own.
+ */
+
+/** Above this many units, segments read as noise — render a smooth fill. */
+export const SEGMENT_CAP = 24;
+
+type Size = "card" | "slim" | "micro";
+
 interface ProgressBarProps {
+  /** Units completed (lessons done). */
   value: number;
+  /** Total units (lessons in the course). */
   max?: number;
-  variant?: "primary" | "xp" | "success";
+  /** Render one cell per unit rather than a continuous fill. */
+  segmented?: boolean;
+  size?: Size;
+  /**
+   * Visual fill (0..1) overriding `value / max` — for endowed progress, where
+   * an enrolled learner with nothing completed still gets a first tick. Never
+   * changes the reported `aria-valuenow`, which stays the honest count.
+   */
+  displayFraction?: number;
   className?: string;
-  showLabel?: boolean;
+  /** Accessible name; the visible fraction usually carries the meaning. */
+  "aria-label"?: string;
 }
 
-const fillVariantClass = {
-  primary: "pf-primary",
-  xp: "pf-xp",
-  success: "pf-success",
-} as const;
+const sizeClass: Record<Size, string> = {
+  card: "",
+  slim: "seg-track--slim",
+  micro: "seg-track--micro",
+};
 
 export function ProgressBar({
   value,
   max = 100,
-  variant = "primary",
+  segmented = false,
+  size = "card",
+  displayFraction,
   className,
-  showLabel = false,
+  "aria-label": ariaLabel,
 }: ProgressBarProps) {
-  const percent = Math.min(Math.round((value / max) * 100), 100);
+  const total = Math.max(0, max);
+  const done = Math.min(Math.max(0, value), total);
+  const earned = total > 0 ? done / total : 0;
+  const fraction = Math.min(Math.max(displayFraction ?? earned, 0), 1);
+
+  const useSegments = segmented && total > 0 && total <= SEGMENT_CAP;
+  // An endowed fill with nothing completed still lights one cell — otherwise
+  // the head-start the ring used to show would vanish in the segmented bar.
+  const lit = done === 0 && fraction > 0 ? 1 : done;
 
   return (
-    <div className={cn("flex items-center gap-3", className)}>
-      <div
-        className="prog-track w-full"
-        role="progressbar"
-        aria-valuenow={percent}
-        aria-valuemin={0}
-        aria-valuemax={100}
-      >
-        <div
-          className={cn("prog-fill", fillVariantClass[variant])}
-          style={{ width: `${percent}%` }}
-        />
-      </div>
-      {showLabel && (
-        <span className="text-sm font-medium tabular-nums text-text-3">
-          {percent}%
-        </span>
+    <div
+      className={cn("seg-track", sizeClass[size], className)}
+      role="progressbar"
+      aria-valuenow={done}
+      aria-valuemin={0}
+      aria-valuemax={total}
+      aria-label={ariaLabel}
+    >
+      {useSegments ? (
+        Array.from({ length: total }, (_, i) => (
+          <span
+            key={i}
+            className={cn("seg-cell", i < lit && "seg-cell--on")}
+            data-filled={i < lit}
+          />
+        ))
+      ) : (
+        <div className="seg-fill" style={{ width: `${fraction * 100}%` }} />
       )}
     </div>
   );

--- a/apps/web/src/components/dashboard/__tests__/current-courses-endowed.test.tsx
+++ b/apps/web/src/components/dashboard/__tests__/current-courses-endowed.test.tsx
@@ -61,12 +61,14 @@ describe("CurrentCoursesSection — endowed progress (LX-B12)", () => {
     ).toBeInTheDocument();
 
     // The honest count is still 0 of 8 — the tick never inflates it.
-    expect(
-      screen.getByRole("img", { name: "0 of 8 lessons completed" })
-    ).toBeInTheDocument();
+    const bar = screen.getByRole("progressbar", {
+      name: "0 of 8 lessons completed",
+    });
+    expect(bar).toHaveAttribute("aria-valuenow", "0");
+    expect(bar).toHaveAttribute("aria-valuemax", "8");
   });
 
-  it("renders a non-zero fill after enrollment (ring is not empty at 0%)", () => {
+  it("renders a non-zero fill after enrollment (bar is not empty at 0%)", () => {
     const { container } = renderWithIntl(
       <CurrentCoursesSection
         currentCourses={[
@@ -82,12 +84,10 @@ describe("CurrentCoursesSection — endowed progress (LX-B12)", () => {
       />
     );
 
-    const fill = container.querySelector(".cc-ring-fill") as SVGCircleElement;
-    const circumference = 2 * Math.PI * 15;
-    const offset = Number(fill.getAttribute("stroke-dashoffset"));
-    // A 0% ring would be fully offset (offset === circumference). The endowed
-    // tick fills a sliver, so the offset is strictly less.
-    expect(offset).toBeLessThan(circumference);
+    // Zero completions, but the endowed tick still lights exactly one cell —
+    // an all-dark strip would drop the head-start the ring used to show.
+    expect(container.querySelectorAll(".seg-cell")).toHaveLength(8);
+    expect(container.querySelectorAll(".seg-cell--on")).toHaveLength(1);
   });
 
   it("surfaces the near-goal nudge and intensifies the ring near completion", () => {
@@ -111,6 +111,8 @@ describe("CurrentCoursesSection — endowed progress (LX-B12)", () => {
       screen.getByText(messages.dashboard.endowedProgress.nearGoal)
     ).toBeInTheDocument();
     expect(container.querySelector(".cc-card--near-goal")).not.toBeNull();
+    // 6 of 8 lit — the strip never runs ahead of the honest count.
+    expect(container.querySelectorAll(".seg-cell--on")).toHaveLength(6);
     // No enrollment reason once lessons are earned.
     expect(
       screen.queryByText(messages.dashboard.endowedProgress.enrolledFirstStep)

--- a/apps/web/src/components/dashboard/current-courses-section.tsx
+++ b/apps/web/src/components/dashboard/current-courses-section.tsx
@@ -15,6 +15,7 @@ import {
 import type { CurrentCourse } from "@/lib/dashboard/types";
 import { deriveEndowedProgress } from "@/lib/courses/endowed-progress";
 import { CourseCompletionMint } from "@/components/certificates/course-completion-mint";
+import { ProgressBar } from "@/components/course/progress-bar";
 import { Button } from "@/components/ui/button";
 import { dispatchToast } from "@/components/ui/toast-container";
 
@@ -124,9 +125,6 @@ export function CurrentCoursesSection({
               course.totalLessons
             );
             const isComplete = ep.isComplete;
-            const ringR = 15;
-            const ringC = 2 * Math.PI * ringR;
-            const ringOffset = ringC * (1 - ep.displayFraction);
             const progressAria = t("lessonsDone", {
               completed: course.completedLessons,
               total: course.totalLessons,
@@ -160,39 +158,24 @@ export function CurrentCoursesSection({
                     <div className="cc-meta">
                       <div className="cc-title">{course.title}</div>
                     </div>
-                    <span
-                      className="cc-progress"
-                      role="img"
-                      aria-label={progressAria}
-                    >
-                      <span className="cc-ring-wrap" aria-hidden="true">
-                        <svg className="cc-ring" viewBox="0 0 36 36">
-                          <circle
-                            cx="18"
-                            cy="18"
-                            r={ringR}
-                            className="cc-ring-track"
-                          />
-                          <circle
-                            cx="18"
-                            cy="18"
-                            r={ringR}
-                            strokeDasharray={ringC}
-                            strokeDashoffset={ringOffset}
-                            transform="rotate(-90 18 18)"
-                            className="cc-ring-fill"
-                          />
-                        </svg>
-                        <span className="cc-ring-count">
-                          <span className="cc-ring-done">
-                            {course.completedLessons}
-                          </span>
-                          /{course.totalLessons}
+                    <span className="cc-progress">
+                      <span className="cc-count" aria-hidden="true">
+                        <span className="cc-count-done">
+                          {course.completedLessons}
+                        </span>
+                        /{course.totalLessons}
+                        <span className="cc-count-label">
+                          {tCourses("lessons")}
                         </span>
                       </span>
-                      <span className="cc-ring-label" aria-hidden="true">
-                        {tCourses("lessons")}
-                      </span>
+                      <ProgressBar
+                        value={course.completedLessons}
+                        max={course.totalLessons}
+                        displayFraction={ep.displayFraction}
+                        segmented
+                        size="micro"
+                        aria-label={progressAria}
+                      />
                     </span>
                   </div>
                   {/* Stated reason for a pre-credited tick, or the near-goal

--- a/apps/web/src/lib/styles/styleClasses.ts
+++ b/apps/web/src/lib/styles/styleClasses.ts
@@ -189,16 +189,6 @@ export const PROGRESS_STYLES = {
   /** Track container — fat 16px with chunky border */
   track:
     "w-full h-4 bg-subtle rounded-full border-[2.5px] border-border overflow-hidden",
-  /** Fill base — gradient + inner highlight pseudo-element */
-  fillBase: "h-full rounded-full relative progress-fat-fill",
-  /** Teal fill — course progress */
-  fillTeal: "h-full rounded-full relative progress-fat-fill progress-fill-teal",
-  /** Amber fill — XP/level progress */
-  fillAmber:
-    "h-full rounded-full relative progress-fat-fill progress-fill-amber",
-  /** Green fill — completed */
-  fillGreen:
-    "h-full rounded-full relative progress-fat-fill progress-fill-green",
   /** Label above progress bar */
   label: "font-display font-bold text-sm text-text",
   /** Value text beside label */

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -1246,57 +1246,6 @@
   color: var(--primary);
 }
 
-/* Legacy compat aliases */
-.progress-fat {
-  width: 100%;
-  height: 14px;
-  background: var(--input);
-  border-radius: var(--r-full);
-  border: 1px solid var(--border);
-  overflow: hidden;
-}
-.progress-fat-fill {
-  height: 100%;
-  border-radius: var(--r-full);
-  position: relative;
-  overflow: hidden;
-  transition: width 0.7s cubic-bezier(0.4, 0, 0.2, 1);
-}
-.progress-fat-fill::after {
-  content: "";
-  position: absolute;
-  inset: 0;
-  background: linear-gradient(
-    90deg,
-    transparent 0%,
-    rgba(255, 255, 255, 0.08) 25%,
-    rgba(255, 255, 255, 0.32) 50%,
-    rgba(255, 255, 255, 0.08) 75%,
-    transparent 100%
-  );
-  animation: shimmer 2.2s ease-in-out infinite;
-}
-.progress-fat-fill::before {
-  content: "";
-  position: absolute;
-  top: 2px;
-  left: 6px;
-  right: 6px;
-  height: 3px;
-  background: rgba(255, 255, 255, 0.28);
-  border-radius: var(--r-full);
-  z-index: 1;
-}
-.progress-fill-teal {
-  background: linear-gradient(90deg, var(--primary-dark), var(--primary));
-}
-.progress-fill-amber {
-  background: linear-gradient(90deg, var(--xp-dark), var(--xp));
-}
-.progress-fill-green {
-  background: linear-gradient(90deg, var(--primary-dark), var(--success));
-}
-
 /* ── Achievement medal keyframes (outside @layer for animation compat) ── */
 @keyframes patch-pop {
   from {
@@ -2375,51 +2324,8 @@
   transform: rotate(180deg);
 }
 
-/* ── Full-width progress bar — the hero visual ── */
-.path-bar-track {
-  width: 100%;
-  height: 7px;
-  background: var(--border);
-  border-radius: 99px;
-  overflow: hidden;
-  position: relative;
-}
-.path-bar-fill {
-  height: 100%;
-  border-radius: 99px;
-  background: linear-gradient(
-    90deg,
-    var(--primary-dark, var(--primary)),
-    var(--primary)
-  );
-  transition: width 1s cubic-bezier(0.4, 0, 0.2, 1);
-  position: relative;
-  min-width: 0;
-  overflow: hidden;
-}
-/* Shimmer sweep — like dashboard XP bar */
-.path-bar-fill::after {
-  content: "";
-  position: absolute;
-  inset: 0;
-  background: linear-gradient(
-    90deg,
-    transparent 0%,
-    rgba(255, 255, 255, 0.1) 25%,
-    rgba(255, 255, 255, 0.35) 50%,
-    rgba(255, 255, 255, 0.1) 75%,
-    transparent 100%
-  );
-  animation: path-shimmer 2.2s ease-in-out infinite;
-}
-@keyframes path-shimmer {
-  0% {
-    transform: translateX(-100%);
-  }
-  100% {
-    transform: translateX(100%);
-  }
-}
+/* The path bar itself is the progress standard — see `.path-bar-track` in the
+   progress-bar block next to `.dash-xp-track`. */
 
 /* Row 2: Stats footer */
 .path-header-foot {
@@ -4258,9 +4164,23 @@ a.path-step-card:hover .path-step-badge.skip {
    the level ring and used for nothing else. No inner shadow, no cap on the
    fill, no gradient. Dark swaps the outline and the track only; the mint
    carries over untouched. */
-.dash-xp-track {
+/* The three tokens every learner-facing progress bar is built from. Declared
+   once, on every construction that uses them, so a value can never drift
+   between the XP bar, the segmented lesson bars and the path bar. */
+.dash-xp-track,
+.seg-track,
+.path-bar-track {
   --xpbar-ink: #19231b;
   --xpbar-track: rgba(25, 35, 27, 0.12);
+  --xpbar-fill: #2ecc8e;
+}
+[data-theme="dark"] .dash-xp-track,
+[data-theme="dark"] .seg-track,
+[data-theme="dark"] .path-bar-track {
+  --xpbar-ink: #fafaf7;
+  --xpbar-track: rgba(250, 250, 247, 0.18);
+}
+.dash-xp-track {
   width: 100%;
   max-width: 200px;
   height: 16px;
@@ -4269,17 +4189,82 @@ a.path-step-card:hover .path-step-badge.skip {
   border-radius: var(--r-full);
   overflow: hidden;
 }
-[data-theme="dark"] .dash-xp-track {
-  --xpbar-ink: #fafaf7;
-  --xpbar-track: rgba(250, 250, 247, 0.18);
-}
 .dash-xp-fill {
   height: 100%;
-  background: #2ecc8e;
+  background: var(--xpbar-fill);
   transition: width 1.2s cubic-bezier(0.4, 0, 0.2, 1);
 }
 @media (prefers-reduced-motion: reduce) {
   .dash-xp-fill {
+    transition: none;
+  }
+}
+
+/* ── Segmented variant — discrete counts (lessons) ──────────────────────────
+   Same track, outline and fill as the XP bar; the only difference is that the
+   inside is divided into one cell per lesson. Ink hairlines are drawn ON TOP
+   of each cell's left edge, so they read at any height and never depend on a
+   translucent gap compositing correctly. Sizes are set with two custom
+   properties, so a variant is a height + a border weight, not a new bar. */
+/* No `width` on the base: block-level auto already fills its container, and an
+   explicit 100% here (unlayered) would beat any Tailwind width a caller sets. */
+.seg-track {
+  display: flex;
+  height: var(--seg-h, 13px);
+  background: var(--xpbar-track);
+  border: var(--seg-border, 2.5px) solid var(--xpbar-ink);
+  border-radius: var(--r-full);
+  overflow: hidden;
+}
+.seg-track--slim {
+  --seg-h: 10px;
+  --seg-border: 2px;
+}
+.seg-track--micro {
+  --seg-h: 8px;
+  --seg-border: 1.5px;
+  width: 64px;
+}
+.seg-cell {
+  flex: 1 1 0;
+  min-width: 0;
+}
+.seg-cell + .seg-cell {
+  box-shadow: inset 1.5px 0 0 var(--xpbar-ink);
+}
+.seg-cell--on {
+  background: var(--xpbar-fill);
+}
+/* Smooth fill inside the same track — used for continuous shares, and as the
+   fallback when a course has too many lessons for legible ticks. */
+.seg-fill {
+  height: 100%;
+  background: var(--xpbar-fill);
+  transition: width 1.2s cubic-bezier(0.4, 0, 0.2, 1);
+}
+@media (prefers-reduced-motion: reduce) {
+  .seg-fill {
+    transition: none;
+  }
+}
+
+/* ── Learning-path bar — smooth, never segmented: a path spans whole courses,
+   so ticks would read as lessons and mislead. ── */
+.path-bar-track {
+  width: 100%;
+  height: 10px;
+  background: var(--xpbar-track);
+  border: 2px solid var(--xpbar-ink);
+  border-radius: var(--r-full);
+  overflow: hidden;
+}
+.path-bar-fill {
+  height: 100%;
+  background: var(--xpbar-fill);
+  transition: width 1s cubic-bezier(0.4, 0, 0.2, 1);
+}
+@media (prefers-reduced-motion: reduce) {
+  .path-bar-fill {
     transition: none;
   }
 }
@@ -5364,58 +5349,35 @@ a.path-step-card:hover .path-step-title {
   border: 1.5px solid var(--border);
   white-space: nowrap;
 }
-/* ── Progress ring with count inside + label — pushed right ── */
+/* ── Lesson count over a micro segmented strip — pushed right ── */
 .cc-card .cc-progress {
   display: inline-flex;
-  align-items: center;
-  gap: 6px;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 5px;
   flex-shrink: 0;
 }
-.cc-progress .cc-ring-wrap {
-  position: relative;
-  width: 42px;
-  height: 42px;
-}
-.cc-ring {
-  width: 42px;
-  height: 42px;
-}
-.cc-ring-track {
-  fill: none;
-  stroke: var(--border-default);
-  stroke-width: 3;
-}
-.cc-ring-fill {
-  fill: none;
-  stroke: var(--primary);
-  stroke-width: 3;
-  stroke-linecap: round;
-  transition: stroke-dashoffset 0.6s cubic-bezier(0.34, 1.56, 0.64, 1);
-}
-.cc-ring-count {
-  position: absolute;
-  inset: 0;
-  display: flex;
-  align-items: center;
-  justify-content: center;
+.cc-count {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 4px;
   font-family: var(--font-mono, var(--font-m));
   font-weight: 700;
   font-size: 11px;
   color: var(--text-3);
   letter-spacing: -0.3px;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
 }
-.cc-ring-done {
+.cc-count-done {
   color: var(--primary);
   font-weight: 800;
 }
-.cc-ring-label {
-  font-family: var(--font-mono, var(--font-m));
-  font-size: 10px;
+.cc-count-label {
+  font-size: 9px;
   font-weight: 600;
-  color: var(--text-3);
   text-transform: uppercase;
   letter-spacing: 0.06em;
-  margin-left: 4px;
 }
 
 /* ── Endowed-progress reason (LX-B12) — stated cause for a pre-credited tick,
@@ -5440,15 +5402,14 @@ a.path-step-card:hover .path-step-title {
   color: var(--primary);
 }
 
-/* Near-goal intensification: a thicker, glowing ring as a course approaches
+/* Near-goal intensification: a glowing strip as a course approaches
    completion. Emphasis is purely visual — the counts stay honest. */
-.cc-card--near-goal .cc-ring-fill {
-  stroke-width: 4;
+.cc-card--near-goal .seg-track {
   filter: drop-shadow(
-    0 0 3px color-mix(in srgb, var(--primary) 55%, transparent)
+    0 0 3px color-mix(in srgb, var(--xpbar-fill) 55%, transparent)
   );
 }
-.cc-card--near-goal .cc-ring-done {
+.cc-card--near-goal .cc-count-done {
   font-size: 12px;
 }
 


### PR DESCRIPTION
The dashboard XP bar is the progress-bar standard (muted track, 2.5px ink outline, solid mint fill, pill radius). The remaining learner-facing bars each had their own construction — a 1px soft-bordered track, a 7px gradient sliver, an SVG donut. They now all derive from the same three custom properties (`--xpbar-ink`, `--xpbar-track`, `--xpbar-fill`), declared once on every construction that uses them, the way `.sidebar-prog` already did.

Lesson counts are discrete, so course and lesson bars render one cell per lesson inside the ink outline rather than a continuous fill. Past 24 lessons the ticks stop reading as countable units, so `ProgressBar` falls back to a smooth fill on its own (`SEGMENT_CAP`). Continuous shares stay smooth: the learning-path bar spans whole courses, so ticks there would read as lessons and mislead.

The Current Courses donut becomes a mono fraction over a 64px micro strip — narrower than the donut plus its label, so the card doesn't widen. `deriveEndowedProgress` is preserved: with nothing completed, the endowed fill lights exactly one cell, and `aria-valuenow` still reports the honest count, never the endowed fill.

Also dropped the redundant "60%" next to the course-detail fraction, and deleted `.progress-fat*` / `.progress-fill-{teal,amber,green}` plus their `PROGRESS_STYLES` fill entries — grep found no consumers. Admin bars (`components/ui/progress.tsx`), the XP bar itself, `.sidebar-prog`, `.lb-*` and the "Plan your next lesson" card are untouched.

**Numbers**: 75 vitest tests pass across `components/course` + `components/dashboard` (13 files), including 7 new segment-math cases; `tsc --noEmit` clean; eslint on the changed files reports only the two pre-existing warnings.

**Red-proofs**: replacing the endowed minimum with `lit = done` fails 2 tests (the component case and the dashboard card case); rendering `total - 1` cells fails 4.

**Verification**: the dashboard is auth-gated so I could not browser-probe it — I verified by token construction instead, rendering the copied CSS block in both themes (ink outline, mint fill, hairline ticks legible at card/slim/micro, smooth cap fallback, smooth path bar).

**Overlap**: #1156 also edits `globals.css` (`.chip`/`.mark` near the `.patch` section). This change sits next to `.dash-xp-track` and in the `.cc-*` / `.path-*` blocks, so the two should not collide; whichever lands second may still need a trivial rebase.
