### PR TITLE
fix: mobile styling on the landing page and the leaderboard

### DIFF
--- a/apps/web/src/app/[locale]/(platform)/leaderboard/__tests__/leaderboard-client.test.tsx
+++ b/apps/web/src/app/[locale]/(platform)/leaderboard/__tests__/leaderboard-client.test.tsx
@@ -161,13 +161,18 @@ describe("LeaderboardClient — the League podium", () => {
     expect(container.querySelector(".podium-card.bronze")).not.toBeNull();
   });
 
-  it("stands the winner in the middle (2-1-3)", () => {
+  /* The DOM carries RANK order, which is the reading order and the order the
+     podium stacks in on a phone. Standing the winner in the middle is a
+     side-by-side arrangement and now lives in CSS, applied only above the
+     stacking breakpoint — as 2-1-3 markup it put second place on top of a
+     phone's stack. */
+  it("renders the podium in rank order", () => {
     const { container } = renderClient(five);
 
     const ranks = [...container.querySelectorAll(".podium-card")].map((card) =>
       card.querySelector(".rank-tab")?.getAttribute("data-rank")
     );
-    expect(ranks).toEqual(["2", "1", "3"]);
+    expect(ranks).toEqual(["1", "2", "3"]);
   });
 
   it("leaves the rows below the podium dashed — no data-top", () => {

--- a/apps/web/src/app/[locale]/(platform)/leaderboard/leaderboard-client.tsx
+++ b/apps/web/src/app/[locale]/(platform)/leaderboard/leaderboard-client.tsx
@@ -190,7 +190,7 @@ function LeagueBoard({
     );
   }
 
-  const { podiumOrdered, rest, compact } = splitPodium(cohort.entries);
+  const { podium, rest, compact } = splitPodium(cohort.entries);
 
   return (
     <>
@@ -223,7 +223,7 @@ function LeagueBoard({
           including its rank 1 — the dashed treatment only reads correctly
           against a solid podium. */}
       <div className={cn("podium-grid", compact && "podium-compact")}>
-        {podiumOrdered.map((entry) => (
+        {podium.map((entry) => (
           <CohortPodiumCard key={entry.rank} entry={entry} locale={locale} />
         ))}
       </div>
@@ -292,7 +292,7 @@ function GlobalBoard({
   const t = useTranslations("gamification");
   const tCommon = useTranslations("common");
 
-  const { podiumOrdered, rest: restEntries, compact } = splitPodium(entries);
+  const { podium, rest: restEntries, compact } = splitPodium(entries);
 
   const TIMEFRAMES: Timeframe[] = ["weekly", "monthly", "alltime"];
 
@@ -323,7 +323,7 @@ function GlobalBoard({
       ) : (
         <>
           <div className={cn("podium-grid", compact && "podium-compact")}>
-            {podiumOrdered.map((entry) => (
+            {podium.map((entry) => (
               <GlobalPodiumCard
                 key={entry.userId}
                 entry={entry}

--- a/apps/web/src/components/gamification/__tests__/achievement-patch-3d.test.tsx
+++ b/apps/web/src/components/gamification/__tests__/achievement-patch-3d.test.tsx
@@ -1,0 +1,59 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import { AchievementPatch3D } from "../achievement-patch-3d";
+
+/**
+ * The slab's faces sit at `±var(--t)/2`, and `--t` changes per breakpoint.
+ * Slice offsets must therefore be expressed against that same variable: when
+ * they were absolute pixels, shrinking `--t` on mobile left the outermost
+ * slices in FRONT of the faces, covering the glyph and the stitch and
+ * rendering every badge as a blank coloured blob.
+ */
+describe("AchievementPatch3D — the edge band tracks the thickness", () => {
+  const renderPatch = () =>
+    render(
+      <AchievementPatch3D
+        id="achievement-first-steps"
+        glyph="01"
+        category="progress"
+      />
+    );
+
+  it("positions every slice against --t, never in pixels", () => {
+    const { container } = renderPatch();
+    const slices = [
+      ...container.querySelectorAll<HTMLElement>(".patch3d__slice"),
+    ];
+
+    expect(slices.length).toBeGreaterThan(0);
+    for (const slice of slices) {
+      expect(slice.style.transform).toContain("var(--t)");
+      // A bare px offset is the bug this test exists to catch.
+      expect(slice.style.transform).not.toMatch(/translateZ\(-?[\d.]+px\)/);
+    }
+  });
+
+  it("keeps every slice strictly inside the faces", () => {
+    const { container } = renderPatch();
+    const slices = [
+      ...container.querySelectorAll<HTMLElement>(".patch3d__slice"),
+    ];
+
+    // transform reads `translateZ(calc(var(--t) / 2 * <fraction>))`; the faces
+    // are at a fraction of exactly 1, so every slice must be under it.
+    for (const slice of slices) {
+      const fraction = Number(
+        /\*\s*(-?[\d.]+)\)/.exec(slice.style.transform)?.[1]
+      );
+      expect(Number.isNaN(fraction)).toBe(false);
+      expect(Math.abs(fraction)).toBeLessThan(1);
+    }
+  });
+
+  it("renders both faces, each carrying the glyph", () => {
+    const { container } = renderPatch();
+    expect(container.querySelectorAll(".patch3d__face")).toHaveLength(2);
+    expect(container.querySelectorAll(".patch-text")).toHaveLength(2);
+  });
+});

--- a/apps/web/src/components/gamification/achievement-patch-3d.tsx
+++ b/apps/web/src/components/gamification/achievement-patch-3d.tsx
@@ -22,17 +22,25 @@ import { PatchGlyph } from "@/components/gamification/patch-glyph";
  * patch, so the two can never drift apart.
  */
 /**
- * The edge band. Slices are zero-thickness planes, so their spacing is what
- * decides whether the rim reads as a solid edge or as a comb: at the 2px pitch
- * the spec sketches you can see between them as a patch turns, and the 2px
- * inset leaves the band visibly narrower than the silhouette it belongs to.
- * A 1px pitch across the full thickness closes both gaps, and a 1px inset is
- * still enough to keep the slices from breaking the faces' outline.
+ * The edge band, expressed as fractions of the slab's own thickness.
+ *
+ * Slices are zero-thickness planes, so their spacing is what decides whether
+ * the rim reads as a solid edge or as a comb; thirteen of them across the
+ * thickness closes the gaps.
+ *
+ * They are FRACTIONS, not pixels, because the faces sit at `±var(--t)/2` and
+ * the thickness is a CSS variable that changes per breakpoint. Absolute
+ * offsets drifted the moment `--t` shrank on mobile: the outermost slices
+ * ended up in FRONT of the faces, and since a slice is a solid fill inset
+ * only 1px, it covered the face entirely — the badges rendered as blank
+ * coloured blobs with no glyph and no stitch. A fraction cannot drift: the
+ * outermost lands at 6/7 of the half-thickness, always inside the faces.
  */
-const THICKNESS = 14;
+const SLICE_COUNT = 13;
+const HALF = (SLICE_COUNT - 1) / 2;
 const SLICES = Array.from(
-  { length: THICKNESS - 1 },
-  (_, i) => i - (THICKNESS - 2) / 2
+  { length: SLICE_COUNT },
+  (_, i) => (i - HALF) / (HALF + 1)
 );
 
 export function AchievementPatch3D({
@@ -67,11 +75,11 @@ export function AchievementPatch3D({
       data-cat={look.cat}
       aria-hidden="true"
     >
-      {SLICES.map((z) => (
+      {SLICES.map((f) => (
         <div
-          key={z}
+          key={f}
           className="patch3d__slice"
-          style={{ transform: `translateZ(${z}px)` }}
+          style={{ transform: `translateZ(calc(var(--t) / 2 * ${f}))` }}
         />
       ))}
       {/* Rim panels. The slices run parallel to the faces, so edge-on they

--- a/apps/web/src/components/leaderboard/podium-card.tsx
+++ b/apps/web/src/components/leaderboard/podium-card.tsx
@@ -121,22 +121,22 @@ export function PodiumCard({
 }
 
 /**
- * Splits a ranked list into the podium (top 3) and the rows below it, with the
- * podium reordered 2-1-3 so the winner stands in the middle.
+ * Splits a ranked list into the podium (top 3) and the rows below it.
+ *
+ * The podium comes back in RANK order. It used to be reordered 2-1-3 here so
+ * the winner stood in the middle, but that is a side-by-side idea: stacked on
+ * a phone it put second place on top, and it made the DOM order disagree with
+ * the reading order on every screen. The 2-1-3 arrangement is now done in CSS,
+ * and only where there are three columns to do it in.
  *
  * A short board keeps whatever it has — one or two entries render as a
  * compact podium rather than leaving gaps (`podium-compact`).
  */
 export function splitPodium<T>(entries: T[]): {
   podium: T[];
-  podiumOrdered: T[];
   rest: T[];
   compact: boolean;
 } {
   const podium = entries.slice(0, 3);
-  const rest = entries.slice(3);
-  const podiumOrdered =
-    podium.length >= 3 ? [podium[1]!, podium[0]!, podium[2]!] : podium;
-
-  return { podium, podiumOrdered, rest, compact: podium.length < 3 };
+  return { podium, rest: entries.slice(3), compact: podium.length < 3 };
 }

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -3546,6 +3546,21 @@ a.path-step-card:hover .path-step-badge.skip {
   align-items: end;
   margin-bottom: 8px;
 }
+/* The cards are in RANK order in the DOM — which is the reading order, and
+   the order they stack in on a phone. The 2-1-3 podium arrangement is a
+   side-by-side idea, so it is done here, visually, only where there are three
+   columns to do it in. */
+@media (min-width: 541px) {
+  .podium-grid > :nth-child(1) {
+    order: 2;
+  }
+  .podium-grid > :nth-child(2) {
+    order: 1;
+  }
+  .podium-grid > :nth-child(3) {
+    order: 3;
+  }
+}
 .podium-compact {
   grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
 }
@@ -3919,8 +3934,15 @@ a.stat-receipt:active {
 /* ── Responsive: stack podium on small screens ── */
 @media (max-width: 540px) {
   .podium-grid {
-    grid-template-columns: 1fr;
+    /* minmax(0, …), not 1fr: a bare `1fr` floors at the column's min-content,
+       and one long username kept the row wider than the phone. */
+    grid-template-columns: minmax(0, 1fr);
     gap: 10px;
+  }
+  /* Each card is wrapped in a Link, which is the grid item — it has to be
+     allowed to shrink too, or the floor just moves up one level. */
+  .podium-grid > * {
+    min-width: 0;
   }
   .podium-card {
     flex-direction: row;
@@ -3954,6 +3976,12 @@ a.stat-receipt:active {
     flex-direction: row;
     text-align: left;
     flex: 1;
+    min-width: 0;
+  }
+  /* The truncating span is itself a flex child, so it needs the same escape
+     from `min-width: auto` — without it the name's longest word is the row's
+     hard floor and the ellipsis never gets a chance to do its job. */
+  .podium-name > span {
     min-width: 0;
   }
   .podium-xp {

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -2208,6 +2208,18 @@
     --size: 64px;
     --t: 10px;
   }
+  /* The 72px badge is a desktop card's proportion. On a phone the same
+     hexagon dominates the card it sits in, so it steps down to 60 — the
+     spec's floor for keeping the LV lock-up, so the label stays legitimate
+     rather than being shrunk past the point it reads. */
+  .lv-badge[data-size="72"] {
+    --lv-h: 60px;
+    --lv-w: 53px;
+    --lv-inset: 2.5px;
+    --lv-num: 24px;
+    --lv-kicker: 8px;
+    --lv-lift: 3px;
+  }
   .ach-name {
     font-size: 10px;
   }


### PR DESCRIPTION
Four mobile issues, all measured at a 390px viewport.

## Landing

### 1 · The carousel badges were empty coloured blobs

Not a missing glyph — a **covered** one.

The 3D patch's faces sit at `±var(--t)/2`, but the slice offsets that make up the edge band were absolute pixels, baked from a JS constant of `THICKNESS = 14`. Mobile overrides `--t` to `10px`, which moves the faces in to ±5 while the outermost slices stayed at ±6 — **in front of them**. A slice is a solid fill inset only 1px, so it covered the face entirely, taking the glyph and the dashed stitch with it.

Slice offsets are now **fractions of `--t`**, so the band can't drift from the faces at any thickness: the outermost lands at 6/7 of the half-thickness, always inside. Desktop geometry is unchanged — the fractions reproduce the old `-6..6` exactly at `--t: 14px`.

Verified by hit-testing the front face's centre:

| | topmost element at face centre |
|---|---|
| before | `.patch3d__slice` |
| after | `.patch-text` |

### 2 · The hero card's level badge dominated the card

72px is a desktop card's proportion. On mobile it steps down to **60** — the spec's floor for keeping the LV lock-up, so the label stays legitimate rather than being shrunk past the point it reads.

## Leaderboard

### 3 · Second place sat on top of the stack

The podium was built 2-1-3 in the DOM so the winner stands in the middle. That's a side-by-side arrangement, and it only reads as one while there are three columns: stacked on a phone it put second place first, and it made the DOM order disagree with the reading order on every screen.

The markup is now rank order and the 2-1-3 arrangement is CSS, applied only above the stacking breakpoint. `splitPodium` loses `podiumOrdered` with it — dead once the arrangement moved.

### 4 · The Global podium ran off the screen

26px of horizontal overflow, with the level badge clipped.

Two floors were holding the row open. The name's truncating span is itself a flex child, so it kept `min-width: auto` and its longest word — a username — became the row's minimum; the ellipsis never got the chance to do its job. Above that, the stacked grid's `1fr` column floors at its own min-content, and each card is wrapped in a Link that inherits the same default. All three now get an explicit zero floor.

The League board escaped this only because it carries no level badge — it was 26px under the limit rather than correct.

| | before | after |
|---|---|---|
| page overflow | 26px | 0 |
| card width | 403.5px | 366px |
| stacked order | 2, 1, 3 | 1, 2, 3 |
| desktop order | 2, 1, 3 | 2, 1, 3 |

## Testing

A regression test locks the slice contract, since that class of bug is invisible until someone changes a breakpoint: every offset must reference `var(--t)`, a bare pixel offset fails outright, and every slice must sit strictly inside the faces.

The podium-order test asserted the old 2-1-3 markup and now asserts rank order.

`pnpm typecheck` clean, `pnpm lint` clean, full suite **3370 passing** across 339 files.

## Note

The offline instance has no achievements or leaderboard data, so neither surface renders there. Every issue and fix was reproduced at 390px from the real stylesheet and the real component markup, and confirmed by measurement as well as visually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MJMV9QpjXQ42PVjgEeMQp4