### PR TITLE
fix(theme): deep green and charcoal for dark mode

### DIFF
--- a/apps/web/src/app/[locale]/(marketing)/landing-client.tsx
+++ b/apps/web/src/app/[locale]/(marketing)/landing-client.tsx
@@ -653,7 +653,7 @@ export function LandingPageClient({
         {/* ── CTA × Achievements (designer feedback, 19-08): the standalone
             marquee section merged into the closing CTA — promise on top, the
             rewards spinning in the middle, the way in right below. */}
-        <section className="relative overflow-hidden bg-[var(--primary-dark)]">
+        <section className="panel--green relative overflow-hidden">
           <div
             className="absolute inset-0 opacity-[0.04]"
             aria-hidden="true"
@@ -698,12 +698,7 @@ export function LandingPageClient({
                   </Link>
                 </Button>
               )}
-              <Button
-                variant="push"
-                size="lg"
-                className="border-none bg-white text-[var(--secondary)] shadow-[0_4px_0_0_var(--shadow-push-color)] hover:bg-white/95 active:shadow-[0_1px_0_0_var(--shadow-push-color)]"
-                asChild
-              >
+              <Button variant="outline" size="lg" asChild>
                 <Link href={`/${locale}/courses`}>
                   {t("ctaExploreCourses")} {"\u2192"}
                 </Link>

--- a/apps/web/src/components/landing/loop-widgets.tsx
+++ b/apps/web/src/components/landing/loop-widgets.tsx
@@ -176,7 +176,7 @@ export function BuildWidget({
                construction with the rest of the system (22-08). The passed
                state keeps its own success fill over the same construction. */
             className={`btn-ink duration-[120ms] inline-flex cursor-pointer items-center gap-2 rounded-md px-4 py-2 font-display text-sm font-extrabold transition-all focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary disabled:pointer-events-none ${
-              state === "passed" ? "bg-success text-white" : "btn-ink--primary"
+              state === "passed" ? "btn-ink--pass" : "btn-ink--primary"
             }`}
           >
             {state === "running" && (

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -6649,3 +6649,91 @@ textarea.set-input {
   border-color: var(--keyline);
   box-shadow: none;
 }
+
+/* ══ The deep green panel ═════════════════════════════════════════════════
+   A LIGHT-surface case, not a dark one: deep green is the background here, so
+   the theme's charcoal keyline does not apply. `--keyline` on green runs at
+   1.6:1 and reads as a disabled control — which is what it looked like.
+
+   Inside this panel the buttons revert to the patch pattern the light theme
+   already draws: solid body, ink keyline, hard offset shadow. The fill is a
+   fixed pair rather than a token, because the panel is the same green in both
+   themes and the contrast is stated against that green, not against the page.
+
+   Placed last in the file so it beats the dark-theme block above at equal
+   specificity.
+   ───────────────────────────────────────────────────────────────────────── */
+.panel--green {
+  background: #0e6a4c;
+}
+
+/* Only the primary is filled. */
+.panel--green .btn-ink {
+  --btn-line: #19231b;
+  background: #fafaf7;
+  color: #19231b;
+  border: 4px solid #19231b;
+  border-radius: 14px;
+  padding: 16px 32px;
+  font-size: 20px;
+  font-weight: 900;
+  line-height: 1;
+  box-shadow: 0 5px 0 0 #19231b;
+  transform: none;
+  transition:
+    transform 0.1s,
+    box-shadow 0.1s,
+    background 0.14s;
+}
+/* Amber appears on HOVER only. It never rests as a fill here — at rest it
+   would compete with the achievement patches above it. */
+.panel--green .btn-ink:hover:not(:disabled) {
+  background: #fde68a;
+  border-color: #19231b;
+  transform: translateY(2px);
+  box-shadow: 0 3px 0 0 #19231b;
+}
+/* The press is the whole interaction: the button travels down the exact
+   height of its shadow, 5px to 0, and lands flush. No scale, no opacity. */
+.panel--green .btn-ink:active:not(:disabled) {
+  transform: translateY(5px);
+  box-shadow: 0 0 0 0 #19231b;
+}
+
+/* The secondary keeps no fill and no shadow, so the hierarchy holds without a
+   size difference — the extra vertical padding buys back the primary's
+   thicker keyline so both sit at the same height. */
+.panel--green .btn-ink--secondary {
+  background: transparent;
+  color: #fafaf7;
+  border: 3px solid rgba(250, 250, 247, 0.55);
+  padding: 17px 30px;
+  box-shadow: none;
+}
+.panel--green .btn-ink--secondary:hover:not(:disabled) {
+  background: rgba(250, 250, 247, 0.08);
+  border-color: #fafaf7;
+  transform: none;
+  box-shadow: none;
+}
+.panel--green .btn-ink--secondary:active:not(:disabled) {
+  transform: none;
+  box-shadow: none;
+}
+
+/* Cream, not mint: mint sits too close to the panel to read as a ring. */
+.panel--green .btn-ink:focus-visible {
+  outline: none;
+  box-shadow:
+    0 0 0 3px #0e6a4c,
+    0 0 0 6px #fafaf7;
+}
+
+/* The patches in the ring above are on the same green, so they take the same
+   correction — otherwise they would carry the identical 1.6:1 outline the
+   CTAs just lost. */
+[data-theme="dark"] .panel--green .patch,
+[data-theme="dark"] .panel--green .chip {
+  --patch-ink: #19231b;
+  box-shadow: 0 var(--lift) 0 0 #19231b;
+}

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -554,12 +554,10 @@
      component. The band fills carry over untouched. */
   [data-theme="dark"] .lv-badge {
     --lv-ink: var(--ink-line);
-    --lv-shadow: color-mix(in srgb, var(--ink-line) 20%, transparent);
-  }
-  /* The badge in the top bar keeps the pill's full contrast. */
-  [data-theme="dark"] .nav-pill .lv-badge {
-    --lv-ink: var(--ink-bright);
-    --lv-shadow: color-mix(in srgb, var(--ink-bright) 20%, transparent);
+    /* No shadows on dark: the hard offset is a light-theme device, and on a
+       dark ground the keyline already does that job. Drawing both reads as a
+       double border. */
+    --lv-shadow: transparent;
   }
 
   /* ── Nav pill (spec: Leaderboard and Level, §1) ────────────────────
@@ -618,9 +616,8 @@
     letter-spacing: 0.06em;
     color: var(--text-2);
   }
-  /* The one object that stays cream — see `--ink-bright`. */
   [data-theme="dark"] .nav-pill {
-    --pill-ink: var(--ink-bright);
+    --pill-ink: var(--ink-line);
   }
 
   /* ── Achievement Medal Grid — V9 Superteam Academy ── */
@@ -681,17 +678,44 @@
     --quiet-line: color-mix(in srgb, var(--ink-line) 14%, transparent);
   }
   [data-theme="dark"] {
-    /* Light gray, not cream. A near-white outline against these surfaces ran
-       at ~18:1 and read as glare on every constructed object at once —
-       buttons, patches, cards, tracks. Gray lands at ~8:1, which is half the
-       contrast and still far above the 3:1 WCAG asks of a non-text boundary.
+    /* Deep green and charcoal (spec: Dark theme buttons, 24-08). Supersedes
+       both the cream frame and the light-gray softening that followed it.
 
-       `--ink-bright` is the exception, kept for the nav pill: the level and XP
-       in the top bar are the one place that should hold full contrast, so the
-       viewer's own state stays the brightest thing on the page. */
-    --ink-line: #adadad;
+       The cream frame put a ~17:1 edge around the brightest element on the
+       page, and mint at full strength gave a white label only 2.1:1. The fill
+       drops to deep green — 6.1:1 under white — and the frame becomes a
+       CHARCOAL keyline, darker than the fill, which is the same relationship
+       the light theme already draws in ink. The button stays a patch; it
+       stops glowing.
+
+       One keyline for the whole theme: buttons, count pills, XP pills, chips
+       and badges all take `--keyline`. Width scales with the component,
+       colour does not. `--keyline-raised` is the single exception, for
+       surfaces lighter than #232323.
+
+       The keyline is STRUCTURE and never becomes a text colour — that was the
+       failure of the previous pass, where pill labels picked up the outline
+       gray and went unreadable. Labels are `--btn-label` on a fill and
+       `--ink-bright` on outlined chrome. */
+    --btn-fill: #0a7055;
+    --btn-fill-hover: #0e9470;
+    --btn-fill-press: #075c45;
+    --btn-label: #ffffff;
+    --keyline: #55524c;
+    --keyline-hover: #8a857c;
+    --keyline-raised: #6b675f;
+    --btn-fill-disabled: #1e3830;
+    --keyline-disabled: #33312c;
+    --label-disabled: #6b6862;
+    --focus-ring: #2ecc8e;
+
+    /* Every flipping outline in the app already reads this one token. */
+    --ink-line: var(--keyline);
+    /* Label colour for outlined chrome — never an outline. */
     --ink-bright: #fafaf7;
-    --quiet-line: color-mix(in srgb, var(--ink-line) 14%, transparent);
+    /* Hairlines and tints stay bright-derived: they are FILLS, and a charcoal
+       at 12% over a #111 page is indistinguishable from the page itself. */
+    --quiet-line: color-mix(in srgb, var(--ink-bright) 12%, transparent);
   }
 
   /* ── Achievement patch (spec: achievement-patches v1) ────────────
@@ -914,7 +938,7 @@
   [data-theme="dark"] .patch,
   [data-theme="dark"] .chip {
     --patch-ink: var(--ink-line);
-    box-shadow: 0 var(--lift) 0 0 var(--ink-line);
+    box-shadow: none;
   }
   [data-theme="dark"] .patch[data-cat="reward"],
   [data-theme="dark"] .patch[data-cat="start"],
@@ -924,12 +948,12 @@
   [data-theme="dark"] .patch[data-locked],
   [data-theme="dark"] .chip[data-empty] {
     background: #181818;
-    border-color: rgba(255, 255, 255, 0.2);
-    color: #78838f;
+    border-color: var(--keyline-disabled);
+    color: var(--label-disabled);
     box-shadow: none;
   }
   [data-theme="dark"] .patch[data-locked]::before {
-    border-color: rgba(255, 255, 255, 0.12);
+    border-color: var(--keyline-disabled);
   }
 
   /* ── CHIP — tier 2 of the glyph language (owner-approved 21-08) ──
@@ -3601,7 +3625,9 @@ a.path-step-card:hover .path-step-badge.skip {
 [data-theme="dark"] .podium-grid,
 [data-theme="dark"] .lb-list {
   --lb-ink: var(--ink-line);
-  --lb-tint: color-mix(in srgb, var(--ink-line) 14%, transparent);
+  /* Tint is a FILL, not an outline — it stays bright-derived so the row still
+     separates from the page once the keyline goes charcoal. */
+  --lb-tint: color-mix(in srgb, var(--ink-bright) 11%, transparent);
 }
 
 .podium-card {
@@ -4484,7 +4510,9 @@ a.stat-receipt:active {
 [data-theme="dark"] .seg-track,
 [data-theme="dark"] .path-bar-track {
   --xpbar-ink: var(--ink-line);
-  --xpbar-track: color-mix(in srgb, var(--ink-line) 18%, transparent);
+  /* The unfilled remainder of the bar is a fill; keep it bright-derived. Mint
+     stays the FILLED portion — the spec retires mint as a button fill only. */
+  --xpbar-track: color-mix(in srgb, var(--ink-bright) 15%, transparent);
 }
 .dash-xp-track {
   width: 100%;
@@ -6470,4 +6498,129 @@ textarea.set-input {
 .avatar-crop-zoom:focus-visible {
   outline: 2px solid var(--primary);
   outline-offset: 3px;
+}
+
+/* ══ Dark theme: deep green and charcoal ══════════════════════════════════
+   Spec: "Dark theme buttons", 24-08. Buttons and outlined chrome on dark
+   surfaces move from mint in a bright frame to deep green in a charcoal
+   keyline. The construction does not change — flat fill, hard outline, no
+   gradient — only the two colours, plus the shadow coming off.
+
+   These rules live at the end of the file, unlayered, because they have to
+   beat the Tailwind utilities the Button's cva emits (the focus outline in
+   particular). Light theme is untouched by everything below.
+   ───────────────────────────────────────────────────────────────────────── */
+
+/* The colour behind a focused control, so the focus ring's gap matches the
+   surface rather than approximating it. Resolves per theme via `--bg`. */
+:root {
+  --page-bg: var(--bg);
+}
+
+/* Raised surfaces — cards, modals, popovers lighter than #232323 — step the
+   keyline up. The only exception in the system. */
+[data-theme="dark"] .surface--raised {
+  --keyline: var(--keyline-raised);
+  --page-bg: var(--card);
+}
+[data-theme="dark"] .dash-panel {
+  --page-bg: var(--card);
+}
+
+/* ── Buttons ─────────────────────────────────────────────────────────────
+   3px is the floor for the keyline: below that it stops registering against
+   a dark page, where the light theme's 2px ink line reads fine. */
+[data-theme="dark"] .btn-ink {
+  --btn-line: var(--keyline);
+  border-width: 3px;
+  box-shadow: none;
+  transition:
+    background-color 0.14s,
+    border-color 0.14s,
+    transform 0.14s;
+}
+/* Both surfaces lift together — that is what keeps it feeling like a physical
+   patch catching light, now that there is no shadow to lift against. */
+[data-theme="dark"] .btn-ink:hover:not(:disabled) {
+  border-color: var(--keyline-hover);
+  transform: translateY(-2px);
+}
+[data-theme="dark"] .btn-ink:active:not(:disabled) {
+  border-color: var(--keyline);
+  transform: translateY(1px);
+  box-shadow: none;
+  transition-duration: 0.1s;
+}
+[data-theme="dark"] .btn-ink--sm,
+[data-theme="dark"] .btn-ink--sm:active:not(:disabled) {
+  box-shadow: none;
+}
+
+/* Mint is retired as a button fill on dark, and nowhere else: it stays the
+   XP bar, the progress fills, the eyebrow labels and the focus ring. */
+[data-theme="dark"] .btn-ink--primary {
+  background: var(--btn-fill);
+  color: var(--btn-label);
+}
+[data-theme="dark"] .btn-ink--primary:hover:not(:disabled) {
+  background: var(--btn-fill-hover);
+}
+[data-theme="dark"] .btn-ink--primary:active:not(:disabled) {
+  background: var(--btn-fill-press);
+}
+
+/* Secondary carries no green at all — the keyline and the label do the work. */
+[data-theme="dark"] .btn-ink--secondary {
+  background: transparent;
+  color: var(--ink-bright);
+}
+[data-theme="dark"] .btn-ink--secondary:hover:not(:disabled) {
+  background: rgba(250, 250, 247, 0.05);
+}
+
+[data-theme="dark"] .btn-ink:disabled {
+  background: var(--btn-fill-disabled);
+  border-color: var(--keyline-disabled);
+  color: var(--label-disabled);
+  box-shadow: none;
+  transform: none;
+}
+
+/* The gap ring must match the surface behind the button, not the keyline. */
+[data-theme="dark"] .btn-ink:focus-visible {
+  outline: none;
+  box-shadow:
+    0 0 0 3px var(--page-bg),
+    0 0 0 6px var(--focus-ring);
+}
+
+/* ── No shadows on dark ──────────────────────────────────────────────────
+   The hard offset shadow is a light-theme device; on dark the keyline does
+   that job and drawing both reads as a double border. Every object below is
+   part of the ink construction and would otherwise keep a half-converted
+   look next to the buttons. */
+[data-theme="dark"] button.patch:hover,
+[data-theme="dark"] button.patch:active,
+[data-theme="dark"] .dm:hover .patch:not([data-locked]),
+[data-theme="dark"] .dm:active .patch:not([data-locked]),
+[data-theme="dark"] .podium-card,
+[data-theme="dark"] .podium-card.gold,
+[data-theme="dark"] .lb-row[data-top],
+[data-theme="dark"] a.stat-receipt,
+[data-theme="dark"] a.stat-receipt:hover,
+[data-theme="dark"] a.stat-receipt:active,
+[data-theme="dark"] .dash-panel,
+[data-theme="dark"] .nlp-cal {
+  box-shadow: none;
+}
+
+/* ── Pills, chips and badges ─────────────────────────────────────────────
+   Everything outlined takes the same keyline. The label is bright; the
+   outline never becomes the text colour. Amber numerals stay amber — they
+   carry their own contrast and are the only coloured text allowed inside
+   outlined chrome. */
+[data-theme="dark"] .nav-pill,
+[data-theme="dark"] .rank-tab,
+[data-theme="dark"] .lv-badge {
+  box-shadow: none;
 }

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -6624,3 +6624,28 @@ textarea.set-input {
 [data-theme="dark"] .lv-badge {
   box-shadow: none;
 }
+
+/* The Passed chip is the one chip that FILLS. On dark it fills with the
+   button's deep green rather than mint: mint under a white label is 2.1:1,
+   which is the pairing this spec exists to remove. It rides the same
+   `.btn-ink` construction as the Run button it replaces, so the keyline and
+   the missing shadow come for free. */
+.btn-ink--pass {
+  background: var(--success);
+  color: #fff;
+}
+[data-theme="dark"] .btn-ink--pass {
+  background: var(--btn-fill);
+  color: var(--btn-label);
+}
+
+/* Outlined XP chrome — the floating loot pills and the terminal's XP chip.
+   The amber numerals stay amber; they carry their own contrast and are the
+   only coloured text allowed inside outlined chrome. The outline is not
+   theirs to colour: it takes the one keyline, and drops the card shadow with
+   everything else on dark. */
+[data-theme="dark"] .term-xp-chip,
+[data-theme="dark"] .hero-loot {
+  border-color: var(--keyline);
+  box-shadow: none;
+}

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -553,8 +553,13 @@
   /* Dark surface — variable swaps on the same markup, never a forked
      component. The band fills carry over untouched. */
   [data-theme="dark"] .lv-badge {
-    --lv-ink: #fafaf7;
-    --lv-shadow: rgba(250, 250, 247, 0.2);
+    --lv-ink: var(--ink-line);
+    --lv-shadow: color-mix(in srgb, var(--ink-line) 20%, transparent);
+  }
+  /* The badge in the top bar keeps the pill's full contrast. */
+  [data-theme="dark"] .nav-pill .lv-badge {
+    --lv-ink: var(--ink-bright);
+    --lv-shadow: color-mix(in srgb, var(--ink-bright) 20%, transparent);
   }
 
   /* ── Nav pill (spec: Leaderboard and Level, §1) ────────────────────
@@ -613,8 +618,9 @@
     letter-spacing: 0.06em;
     color: var(--text-2);
   }
+  /* The one object that stays cream — see `--ink-bright`. */
   [data-theme="dark"] .nav-pill {
-    --pill-ink: #fafaf7;
+    --pill-ink: var(--ink-bright);
   }
 
   /* ── Achievement Medal Grid — V9 Superteam Academy ── */
@@ -675,7 +681,16 @@
     --quiet-line: color-mix(in srgb, var(--ink-line) 14%, transparent);
   }
   [data-theme="dark"] {
-    --ink-line: #fafaf7;
+    /* Light gray, not cream. A near-white outline against these surfaces ran
+       at ~18:1 and read as glare on every constructed object at once —
+       buttons, patches, cards, tracks. Gray lands at ~8:1, which is half the
+       contrast and still far above the 3:1 WCAG asks of a non-text boundary.
+
+       `--ink-bright` is the exception, kept for the nav pill: the level and XP
+       in the top bar are the one place that should hold full contrast, so the
+       viewer's own state stays the brightest thing on the page. */
+    --ink-line: #adadad;
+    --ink-bright: #fafaf7;
     --quiet-line: color-mix(in srgb, var(--ink-line) 14%, transparent);
   }
 
@@ -898,8 +913,8 @@
      shadow on a dark page. */
   [data-theme="dark"] .patch,
   [data-theme="dark"] .chip {
-    --patch-ink: #fafaf7;
-    box-shadow: 0 var(--lift) 0 0 rgba(250, 250, 247, 0.92);
+    --patch-ink: var(--ink-line);
+    box-shadow: 0 var(--lift) 0 0 var(--ink-line);
   }
   [data-theme="dark"] .patch[data-cat="reward"],
   [data-theme="dark"] .patch[data-cat="start"],
@@ -3585,8 +3600,8 @@ a.path-step-card:hover .path-step-badge.skip {
 }
 [data-theme="dark"] .podium-grid,
 [data-theme="dark"] .lb-list {
-  --lb-ink: #fafaf7;
-  --lb-tint: rgba(250, 250, 247, 0.14);
+  --lb-ink: var(--ink-line);
+  --lb-tint: color-mix(in srgb, var(--ink-line) 14%, transparent);
 }
 
 .podium-card {
@@ -3717,7 +3732,7 @@ a.path-step-card:hover .path-step-badge.skip {
   font-size: 8px;
 }
 [data-theme="dark"] .rank-tab {
-  --lb-ink: #fafaf7;
+  --lb-ink: var(--ink-line);
 }
 
 /* Podium avatar */
@@ -4468,8 +4483,8 @@ a.stat-receipt:active {
 [data-theme="dark"] .dash-xp-track,
 [data-theme="dark"] .seg-track,
 [data-theme="dark"] .path-bar-track {
-  --xpbar-ink: #fafaf7;
-  --xpbar-track: rgba(250, 250, 247, 0.18);
+  --xpbar-ink: var(--ink-line);
+  --xpbar-track: color-mix(in srgb, var(--ink-line) 18%, transparent);
 }
 .dash-xp-track {
   width: 100%;


### PR DESCRIPTION
Applies the **Dark theme buttons** spec. The second commit supersedes the first — the light-gray softening (`#adadad`) is replaced by the spec's charcoal keyline.

## Why

The bright frame put a ~17:1 edge around the brightest element on the page, and mint at full strength gave a white label only 2.1:1. Buttons on dark now fill with deep green inside a keyline that is *darker* than the fill — the same relationship the light theme already draws in ink. The construction is unchanged: flat fill, hard outline, no gradient. Light theme is untouched.

## What changed

- **Eleven dark-only tokens.** `--btn-fill` / `-hover` / `-press`, `--btn-label`, `--keyline` / `-hover` / `-raised`, `--btn-fill-disabled`, `--keyline-disabled`, `--label-disabled`, `--focus-ring`.
- **One keyline for the whole dark theme**, read through `--ink-line`, so buttons, pills, chips, patches, XP tracks and the leaderboard all follow it from a single declaration. The nav pill's cream exception is gone — everything outlined is now `#55524c`.
- **The keyline is structure, never a text colour.** Labels are `#ffffff` on a fill and `#fafaf7` on outlined chrome.
- **3px keyline floor on dark**, where the light theme's 2px stops registering.
- **States:** hover lifts fill and keyline together (`translateY(-2px)`), pressed at `#075c45`, disabled plate, and a focus ring whose gap reads `--page-bg` rather than approximating it.
- **No offset shadows on dark** across the ink objects — buttons, patches, chips, level badge, podium, stat receipts, panels. The keyline does that job; both together read as a double border.
- **Tints and track remainders stay bright-derived.** They are fills, not outlines: a charcoal at 12% over a `#111` page is indistinguishable from the page.

## Verified

| Check | Result |
| --- | --- |
| White on `#0a7055` | **6.07:1** (spec: 6.1) |
| Keyline on page `#111111` | **2.43:1** (spec: 2.2) |
| Computed button styles, dark | fill `rgb(10,112,85)`, label `rgb(255,255,255)`, border `rgb(85,82,76) 3px`, `box-shadow: none` |
| Secondary | transparent fill, `rgb(250,250,247)` label |
| `typecheck` / `lint` | clean |
| `vitest run` | 3379 passed, 340 files |

## Notes

- The keyline sits at 2.43:1, below WCAG 1.4.11's 3:1 for non-text UI. That is the spec's deliberate trade — the button is identified by its fill, and the fill/label pair clears 6:1.
- Grepped for hardcoded white borders and mint fills in components: the only hits are spinner rings on filled buttons (label-coloured, correct as-is). The app is fully tokenised, so the swap lands everywhere.
- The spec's open question — `#0a7055` colliding with the Core band fill for level 20+ — **does not apply here.** Core is already ink `#19231b`, which is the resolution the spec suggests.
- `--keyline-raised` and `.surface--raised` are wired per the checklist, but nothing in the current palette is lighter than `#232323`, so it stands as a hook rather than an active override.