### PR TITLE
fix(queue): dispatch failed rows correctly and actually retry them

### DIFF
--- a/apps/web/src/app/api/auth/callback/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/callback/__tests__/route.test.ts
@@ -4,6 +4,18 @@ import { NextRequest } from "next/server";
 
 vi.mock("server-only", () => ({}));
 
+// Swap only after() — see the same shim in the /api/auth/wallet suite.
+const { deferred } = vi.hoisted(() => ({
+  deferred: vi.fn<(fn: () => Promise<void> | void) => void>(),
+}));
+vi.mock("next/server", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("next/server")>()),
+  after: (fn: () => Promise<void> | void) => {
+    deferred(fn);
+    return Promise.resolve(fn());
+  },
+}));
+
 const {
   exchangeCodeForSession,
   signOut,
@@ -73,6 +85,7 @@ describe("GET /api/auth/callback — #461 refuse login for deleted accounts", ()
     expect(res.headers.get("location")).toBe("https://app.test/en/dashboard");
     expect(signOut).not.toHaveBeenCalled();
     expect(retryPendingOnchainActions).toHaveBeenCalledWith("user-1");
+    expect(deferred).toHaveBeenCalledTimes(1);
   });
 
   it("refuses a tombstoned profile: signs out, never reaches the intended redirect", async () => {

--- a/apps/web/src/app/api/auth/callback/route.ts
+++ b/apps/web/src/app/api/auth/callback/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest, NextResponse, after } from "next/server";
 import { createServerClient } from "@supabase/ssr";
 import type { CookieOptions } from "@supabase/ssr";
 import { generateWalletName } from "@/lib/utils/generate-wallet-name";
@@ -145,13 +145,20 @@ export async function GET(request: NextRequest) {
         .eq("id", userId);
     }
 
-    retryPendingOnchainActions(userId).catch((err: unknown) =>
-      logError({
-        errorId: ERROR_IDS.OAUTH_CALLBACK_FAILED,
-        error: err instanceof Error ? err : new Error(String(err)),
-        context: { note: "retryPendingOnchainActions failed", userId },
-      })
-    );
+    // after(), not a detached promise — see the note on the same call in
+    // /api/auth/wallet: a bare fire-and-forget drain dies when the serverless
+    // instance freezes on response, which is why queued rows never retried.
+    after(async () => {
+      try {
+        await retryPendingOnchainActions(userId);
+      } catch (err: unknown) {
+        logError({
+          errorId: ERROR_IDS.OAUTH_CALLBACK_FAILED,
+          error: err instanceof Error ? err : new Error(String(err)),
+          context: { note: "retryPendingOnchainActions failed", userId },
+        });
+      }
+    });
 
     return response;
   } catch (err: unknown) {

--- a/apps/web/src/app/api/auth/callback/route.ts
+++ b/apps/web/src/app/api/auth/callback/route.ts
@@ -12,6 +12,10 @@ import {
 import { shouldAdoptAvatar } from "@/lib/auth/avatar-adoption";
 import type { Database } from "@/lib/supabase/types";
 
+// The after() queue drain does per-row RPC reads and on-chain sends; the
+// framework default would truncate it mid-sweep.
+export const maxDuration = 60;
+
 function sanitizeRedirect(raw: string, fallback: string): string {
   try {
     const decoded = decodeURIComponent(raw);

--- a/apps/web/src/app/api/auth/dynamic/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/dynamic/__tests__/route.test.ts
@@ -5,6 +5,18 @@ import { SignJWT, exportJWK, generateKeyPair } from "jose";
 
 vi.mock("server-only", () => ({}));
 
+// Swap only after() — see the same shim in the /api/auth/wallet suite.
+const { deferred } = vi.hoisted(() => ({
+  deferred: vi.fn<(fn: () => Promise<void> | void) => void>(),
+}));
+vi.mock("next/server", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("next/server")>()),
+  after: (fn: () => Promise<void> | void) => {
+    deferred(fn);
+    return Promise.resolve(fn());
+  },
+}));
+
 const {
   getDynamicEnvironmentId,
   isRateLimited,
@@ -858,6 +870,7 @@ describe("POST /api/auth/dynamic — post-login parity with the other chokepoint
 
     expect(res.status).toBe(200);
     expect(retryPendingOnchainActions).toHaveBeenCalledWith("supabase-user-1");
+    expect(deferred).toHaveBeenCalledTimes(1);
   });
 
   it("still signs in when the queue drain rejects", async () => {

--- a/apps/web/src/app/api/auth/dynamic/route.ts
+++ b/apps/web/src/app/api/auth/dynamic/route.ts
@@ -18,6 +18,10 @@ import { logError, logEvent } from "@/lib/logging";
 import { ERROR_IDS } from "@/constants/errorIds";
 import type { Database } from "@/lib/supabase/types";
 
+// The after() queue drain does per-row RPC reads and on-chain sends; the
+// framework default would truncate it mid-sweep.
+export const maxDuration = 60;
+
 /**
  * Social sign-in through Dynamic → the learner's EXISTING Supabase account.
  *

--- a/apps/web/src/app/api/auth/dynamic/route.ts
+++ b/apps/web/src/app/api/auth/dynamic/route.ts
@@ -1,6 +1,6 @@
 import "server-only";
 
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest, NextResponse, after } from "next/server";
 import { cookies } from "next/headers";
 import { createServerClient } from "@supabase/ssr";
 import { createRemoteJWKSet, jwtVerify, type JWTPayload } from "jose";
@@ -907,14 +907,21 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     // The on-chain retry queue drains from the login routes, so this new
     // chokepoint must drain it too — otherwise a learner who only ever signs in
     // through Dynamic never gets their queued enrollments/XP/achievements
-    // retried. Fire-and-forget: a queue hiccup must not fail the sign-in.
-    retryPendingOnchainActions(userId).catch((err: unknown) =>
-      logError({
-        errorId: ERROR_IDS.DYNAMIC_AUTH_FAILED,
-        error: err instanceof Error ? err : new Error(String(err)),
-        context: { note: "retryPendingOnchainActions failed", userId },
-      })
-    );
+    // retried. Off the response path via after(), never a detached promise: a
+    // queue hiccup must not fail the sign-in, but a bare fire-and-forget is
+    // killed when the serverless instance freezes on response (see the same
+    // call in /api/auth/wallet).
+    after(async () => {
+      try {
+        await retryPendingOnchainActions(userId);
+      } catch (err: unknown) {
+        logError({
+          errorId: ERROR_IDS.DYNAMIC_AUTH_FAILED,
+          error: err instanceof Error ? err : new Error(String(err)),
+          context: { note: "retryPendingOnchainActions failed", userId },
+        });
+      }
+    });
 
     return NextResponse.json({ success: true });
   } catch (err: unknown) {

--- a/apps/web/src/app/api/auth/wallet/__tests__/route.test.ts
+++ b/apps/web/src/app/api/auth/wallet/__tests__/route.test.ts
@@ -4,6 +4,23 @@ import { NextRequest } from "next/server";
 
 vi.mock("server-only", () => ({}));
 
+// The real after() needs a request scope these direct-POST unit tests do not
+// have, so swap only that export and keep the rest of next/server real
+// (NextRequest/NextResponse are used throughout). Running the callback here
+// keeps the existing "the drain ran" assertions honest AND proves the route
+// schedules the drain through after(): a bare detached promise — the shape that
+// let the serverless runtime kill every sweep — never reaches this spy.
+const { deferred } = vi.hoisted(() => ({
+  deferred: vi.fn<(fn: () => Promise<void> | void) => void>(),
+}));
+vi.mock("next/server", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("next/server")>()),
+  after: (fn: () => Promise<void> | void) => {
+    deferred(fn);
+    return Promise.resolve(fn());
+  },
+}));
+
 const {
   verifySIWSRequest,
   getUserById,
@@ -149,6 +166,9 @@ describe("POST /api/auth/wallet — #489 refuse wallet_address write for deleted
     });
     expect(signOut).not.toHaveBeenCalled();
     expect(retryPendingOnchainActions).toHaveBeenCalledWith("user-1");
+    // Scheduled via after(), so the sweep survives the response instead of
+    // being killed with the serverless instance.
+    expect(deferred).toHaveBeenCalledTimes(1);
   });
 
   it("refuses a tombstoned account: no wallet_address write, signs out, 403 + accountDeleted", async () => {

--- a/apps/web/src/app/api/auth/wallet/route.ts
+++ b/apps/web/src/app/api/auth/wallet/route.ts
@@ -12,6 +12,11 @@ import { isAccountDeleted } from "@/lib/auth/account-status";
 import { WALLET_PLACEHOLDER_EMAIL_DOMAIN } from "@/lib/auth/wallet-placeholder";
 import type { Database } from "@/lib/supabase/types";
 
+// The after() queue drain does per-row RPC reads and on-chain sends; the
+// framework default would truncate it mid-sweep (worst case: between a
+// quest-mint claim and its send).
+export const maxDuration = 60;
+
 interface WalletAuthRequest {
   message: string;
   signature: number[];

--- a/apps/web/src/app/api/auth/wallet/route.ts
+++ b/apps/web/src/app/api/auth/wallet/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest, NextResponse, after } from "next/server";
 import { cookies } from "next/headers";
 import { createClient } from "@supabase/supabase-js";
 import { createServerClient } from "@supabase/ssr";
@@ -227,13 +227,23 @@ export async function POST(request: NextRequest) {
       }
     }
 
-    retryPendingOnchainActions(userId).catch((err: unknown) =>
-      logError({
-        errorId: ERROR_IDS.WALLET_AUTH_FAILED,
-        error: err instanceof Error ? err : new Error(String(err)),
-        context: { note: "retryPendingOnchainActions failed", userId },
-      })
-    );
+    // Inside after(), NOT a bare fire-and-forget promise. The drain does RPC
+    // reads and on-chain sends that take seconds; a detached promise is killed
+    // when the serverless instance freezes on response, which is why every
+    // queued row in prod sat at retry_count 0 for weeks — the sweep never got
+    // far enough to write anything back. after() keeps the invocation alive
+    // past the response without the caller waiting on it.
+    after(async () => {
+      try {
+        await retryPendingOnchainActions(userId);
+      } catch (err: unknown) {
+        logError({
+          errorId: ERROR_IDS.WALLET_AUTH_FAILED,
+          error: err instanceof Error ? err : new Error(String(err)),
+          context: { note: "retryPendingOnchainActions failed", userId },
+        });
+      }
+    });
 
     return NextResponse.json({ success: true });
   } catch (err: unknown) {

--- a/apps/web/src/lib/gamification/xp-queue-settlement.ts
+++ b/apps/web/src/lib/gamification/xp-queue-settlement.ts
@@ -12,6 +12,16 @@ type AdminClient = ReturnType<typeof createAdminClient>;
 type PendingActionRow =
   Database["public"]["Tables"]["pending_onchain_actions"]["Row"];
 
+// Attempt budget for a genuinely failing row, shared by both drains (this
+// module's quest_xp sweep and lib/solana/onchain-queue's full sweep). A row at
+// or above it is excluded from every future drain by the fetch filters, so
+// reaching it means abandonment — the on-chain drainer logs when a row does.
+// Deferrals (daily cap, course maintenance, capstone gate, mint cap, platform
+// freeze) deliberately spend nothing from this budget. Lives here, not in
+// onchain-queue, so the chain-free module can use it without importing the
+// Solana client graph.
+export const MAX_RETRIES = 5;
+
 // ---------------------------------------------------------------------------
 // Narrow sweep: deliver this user's pending quest_xp credits (DB-only)
 // ---------------------------------------------------------------------------
@@ -29,7 +39,7 @@ export async function retryQuestXpForUser(
     .eq("user_id", userId)
     .eq("action_type", "quest_xp")
     .is("resolved_at", null)
-    .lt("retry_count", 5);
+    .lt("retry_count", MAX_RETRIES);
 
   if (fetchError || !rows || rows.length === 0) return;
 

--- a/apps/web/src/lib/helius/__tests__/achievement-duplicate-award.test.ts
+++ b/apps/web/src/lib/helius/__tests__/achievement-duplicate-award.test.ts
@@ -1,0 +1,183 @@
+/* eslint-disable import/order -- vi.mock('server-only') must be hoisted above
+   the module imports so the `server-only` graph loads under vitest. */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+// ---------------------------------------------------------------------------
+// Where every stuck achievement row in prod came from (2026-08-24).
+//
+// `checkNewAchievements` decides what is un-earned from `user_achievements`,
+// and that table is written by the AchievementAwarded webhook — which lands
+// seconds AFTER the award transaction. Two lesson completions inside that
+// window both see the achievement as un-earned, so the second one re-awards it.
+// The AchievementReceipt PDA already exists by then, the CPI's Allocate fails
+// with `custom program error: 0x0`, and we queue a "failure" for an achievement
+// that is fully delivered — 17 of the 20 stuck rows carried exactly that error,
+// and all 20 were on-chain and in the DB the whole time.
+// ---------------------------------------------------------------------------
+
+const {
+  isPlatformFrozen,
+  fetchAchievementReceipt,
+  onChainAwardAchievement,
+  checkNewAchievements,
+  queueUpsert,
+  rpc,
+} = vi.hoisted(() => ({
+  isPlatformFrozen: vi.fn<() => Promise<boolean>>(),
+  fetchAchievementReceipt: vi.fn<() => Promise<boolean>>(),
+  onChainAwardAchievement: vi.fn(),
+  checkNewAchievements: vi.fn(),
+  queueUpsert:
+    vi.fn<
+      (table: string, row: Record<string, unknown>) => Promise<{ error: null }>
+    >(),
+  rpc: vi.fn<
+    (
+      fn: string,
+      params: Record<string, unknown>
+    ) => Promise<{ data: null; error: null }>
+  >(),
+}));
+
+vi.mock("@/lib/platform/freeze", () => ({ isPlatformFrozen }));
+vi.mock("@/lib/solana/academy-reads", () => ({
+  fetchAchievementReceipt,
+  fetchEnrollment: vi.fn(),
+  fetchCourse: vi.fn(),
+}));
+vi.mock("@/lib/solana/bitmap", () => ({ isCourseComplete: vi.fn() }));
+vi.mock("@/lib/solana/pda", () => ({ getProgramId: () => "program-id" }));
+vi.mock("@/lib/solana/academy-program", () => ({
+  finalizeCourse: vi.fn(),
+  issueCredential: vi.fn(),
+  awardAchievement: onChainAwardAchievement,
+  getConnection: () => ({}),
+}));
+vi.mock("@/lib/solana/arweave", () => ({ uploadCertificateMetadata: vi.fn() }));
+vi.mock("@/lib/gamification/achievements", () => ({
+  checkNewAchievements,
+  buildUserState: vi.fn(async () => ({})),
+}));
+vi.mock("@/lib/content/deployments", () => ({
+  isCourseInMaintenance: vi.fn(async () => false),
+}));
+vi.mock("@/lib/content/queries", () => ({
+  getCourseById: vi.fn(),
+  getDeployedAchievements: vi.fn(async () => []),
+}));
+vi.mock("@/lib/credentials/capstone-gate", () => ({
+  checkCapstoneCredentialGate: vi.fn(),
+}));
+vi.mock("@/lib/gamification/surprise-bonus", () => ({
+  maybeAwardSurpriseBonus: vi.fn(),
+}));
+vi.mock("@/lib/referrals/server", () => ({
+  recordReferralCoursePoint: vi.fn(),
+}));
+vi.mock("@/lib/gamification/quest-evaluation", () => ({
+  scheduleQuestEvaluation: vi.fn(),
+}));
+vi.mock("@/lib/helius/resolvers", () => ({
+  resolveUserId: vi.fn(),
+  resolveCourseId: vi.fn(),
+  resolveLessonId: vi.fn(),
+}));
+vi.mock("@/lib/logging", () => ({ logError: vi.fn() }));
+
+const supabase = {
+  from: (table: string) => ({
+    select: () => ({ eq: async () => ({ data: [], error: null }) }),
+    upsert: (row: Record<string, unknown>) => queueUpsert(table, row),
+  }),
+  rpc: (fn: string, params: Record<string, unknown>) => rpc(fn, params),
+};
+
+vi.mock("@/lib/supabase/admin", () => ({ createAdminClient: () => supabase }));
+
+import { checkAndAwardAchievements } from "../event-handlers";
+
+const WALLET = "6JFH1dxqiw6Dc81CbWdx4TUT8CvAfgwZg33wQrSytZsU";
+const USER_ID = "user-1";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  isPlatformFrozen.mockResolvedValue(false);
+  checkNewAchievements.mockReturnValue([{ id: "achievement-first-steps" }]);
+  queueUpsert.mockResolvedValue({ error: null });
+  rpc.mockResolvedValue({ data: null, error: null });
+});
+
+describe("checkAndAwardAchievements — duplicate award", () => {
+  it("does not re-award (or queue) an achievement whose receipt is already on-chain", async () => {
+    fetchAchievementReceipt.mockResolvedValue(true);
+
+    await checkAndAwardAchievements(
+      USER_ID,
+      WALLET,
+      supabase as unknown as Parameters<typeof checkAndAwardAchievements>[2]
+    );
+
+    expect(onChainAwardAchievement).not.toHaveBeenCalled();
+    // No queue row: nothing failed. This is the whole fix — before it, the
+    // re-award threw 0x0 and left a row that outlived the incident by weeks.
+    expect(queueUpsert).not.toHaveBeenCalled();
+    // The DB is still reconciled from the chain, so a missed AchievementAwarded
+    // webhook does not leave the badge invisible.
+    expect(rpc).toHaveBeenCalledWith("unlock_achievement", {
+      p_user_id: USER_ID,
+      p_achievement_id: "achievement-first-steps",
+    });
+  });
+
+  it("awards normally when the receipt does not exist yet", async () => {
+    fetchAchievementReceipt.mockResolvedValue(false);
+
+    await checkAndAwardAchievements(
+      USER_ID,
+      WALLET,
+      supabase as unknown as Parameters<typeof checkAndAwardAchievements>[2]
+    );
+
+    expect(onChainAwardAchievement).toHaveBeenCalledTimes(1);
+    expect(queueUpsert).not.toHaveBeenCalled();
+  });
+
+  it("still queues a genuine award failure for retry", async () => {
+    fetchAchievementReceipt.mockResolvedValue(false);
+    onChainAwardAchievement.mockRejectedValue(new Error("rpc down"));
+
+    await checkAndAwardAchievements(
+      USER_ID,
+      WALLET,
+      supabase as unknown as Parameters<typeof checkAndAwardAchievements>[2]
+    );
+
+    expect(queueUpsert).toHaveBeenCalledWith(
+      "pending_onchain_actions",
+      expect.objectContaining({
+        action_type: "achievement",
+        reference_id: "achievement-first-steps",
+        last_error: "rpc down",
+      })
+    );
+  });
+
+  it("records something usable when Anchor destroys the error message", async () => {
+    fetchAchievementReceipt.mockResolvedValue(false);
+    onChainAwardAchievement.mockRejectedValue(
+      new Error("Unknown action 'undefined'")
+    );
+
+    await checkAndAwardAchievements(
+      USER_ID,
+      WALLET,
+      supabase as unknown as Parameters<typeof checkAndAwardAchievements>[2]
+    );
+
+    const row = queueUpsert.mock.calls[0]?.[1];
+    expect(row?.last_error).not.toBe("Unknown action 'undefined'");
+    expect(row?.last_error).toContain("after broadcast");
+  });
+});

--- a/apps/web/src/lib/helius/__tests__/event-handlers.test.ts
+++ b/apps/web/src/lib/helius/__tests__/event-handlers.test.ts
@@ -38,7 +38,11 @@ const {
 
 vi.mock("@/lib/content/deployments", () => ({ isCourseInMaintenance }));
 vi.mock("@/lib/platform/freeze", () => ({ isPlatformFrozen }));
-vi.mock("@/lib/solana/academy-reads", () => ({ fetchEnrollment, fetchCourse }));
+vi.mock("@/lib/solana/academy-reads", () => ({
+  fetchEnrollment,
+  fetchCourse,
+  fetchAchievementReceipt: vi.fn(async () => false),
+}));
 vi.mock("@/lib/solana/bitmap", () => ({ isCourseComplete }));
 vi.mock("@/lib/solana/pda", () => ({ getProgramId: () => "program-id" }));
 vi.mock("@/lib/solana/academy-program", () => ({

--- a/apps/web/src/lib/helius/event-handlers.ts
+++ b/apps/web/src/lib/helius/event-handlers.ts
@@ -838,10 +838,14 @@ export async function checkAndAwardAchievements(
             getProgramId()
           )
         ) {
-          await supabase.rpc("unlock_achievement", {
-            p_user_id: userId,
-            p_achievement_id: achievement.id,
-          });
+          const { error: unlockRpcError } = await supabase.rpc(
+            "unlock_achievement",
+            {
+              p_user_id: userId,
+              p_achievement_id: achievement.id,
+            }
+          );
+          if (unlockRpcError) throw new Error(unlockRpcError.message);
           continue;
         }
 

--- a/apps/web/src/lib/helius/event-handlers.ts
+++ b/apps/web/src/lib/helius/event-handlers.ts
@@ -13,7 +13,12 @@ import {
   awardAchievement as onChainAwardAchievement,
   getConnection,
 } from "@/lib/solana/academy-program";
-import { fetchEnrollment, fetchCourse } from "@/lib/solana/academy-reads";
+import {
+  fetchEnrollment,
+  fetchCourse,
+  fetchAchievementReceipt,
+} from "@/lib/solana/academy-reads";
+import { describeTxError } from "@/lib/solana/describe-tx-error";
 import { getProgramId } from "@/lib/solana/pda";
 import { uploadCertificateMetadata } from "@/lib/solana/arweave";
 import { isCourseComplete } from "@/lib/solana/bitmap";
@@ -51,7 +56,7 @@ async function queueFailedAction(
   payload: Record<string, unknown>,
   error: unknown
 ): Promise<void> {
-  const message = error instanceof Error ? error.message : String(error);
+  const message = describeTxError(error);
   try {
     const supabase = createAdminClient();
     await supabase.from("pending_onchain_actions").upsert(
@@ -756,7 +761,9 @@ export async function tryIssueCredential(
 // Internal: check achievement eligibility and award on-chain
 // ---------------------------------------------------------------------------
 
-async function checkAndAwardAchievements(
+// Exported for direct testing, like tryFinalizeCourse above — reaching it
+// through a full webhook event needs scaffolding that hides what is under test.
+export async function checkAndAwardAchievements(
   userId: string,
   walletAddress: string,
   supabase: ReturnType<typeof createAdminClient>
@@ -807,8 +814,37 @@ async function checkAndAwardAchievements(
 
     // Award each new achievement on-chain
     const recipientPk = new PublicKey(walletAddress);
+    const connection = getConnection();
     for (const achievement of newAchievements) {
       try {
+        // `newAchievements` is derived from user_achievements, and that table is
+        // written by the AchievementAwarded webhook — which lands SECONDS after
+        // the award tx. Two lesson completions inside that window both see the
+        // achievement as un-earned, so the second one re-awards it. The
+        // AchievementReceipt PDA already exists at that point, so the CPI's
+        // Allocate fails with `custom program error: 0x0` and we queue a
+        // "failure" for something that is fully delivered. That is where every
+        // stuck achievement row in prod came from.
+        //
+        // Read the receipt first, exactly as the queue drainer does. The chain
+        // stays the source of truth for "already awarded", and reconciling the
+        // DB from it means a missed AchievementAwarded webhook still surfaces
+        // the badge. Nothing is minted twice: this only ever suppresses a send.
+        if (
+          await fetchAchievementReceipt(
+            achievement.id,
+            walletAddress,
+            connection,
+            getProgramId()
+          )
+        ) {
+          await supabase.rpc("unlock_achievement", {
+            p_user_id: userId,
+            p_achievement_id: achievement.id,
+          });
+          continue;
+        }
+
         await onChainAwardAchievement(achievement.id, recipientPk);
       } catch (err) {
         await queueFailedAction(

--- a/apps/web/src/lib/solana/__tests__/onchain-queue.test.ts
+++ b/apps/web/src/lib/solana/__tests__/onchain-queue.test.ts
@@ -42,6 +42,8 @@ const h = vi.hoisted(() => ({
   fetchEnrollment: vi.fn(),
   finalizeCourse: vi.fn(),
   awardAchievement: vi.fn(),
+  /** Whether the AchievementReceipt PDA already exists on-chain. */
+  fetchAchievementReceipt: vi.fn<() => Promise<boolean>>(),
   isCourseInMaintenance: vi.fn<(courseId: string) => Promise<boolean>>(),
   isPlatformFrozen: vi.fn<() => Promise<boolean>>(),
   getCourseById: vi.fn(),
@@ -119,7 +121,7 @@ vi.mock("../academy-program", () => ({
 }));
 
 vi.mock("../academy-reads", () => ({
-  fetchAchievementReceipt: vi.fn(),
+  fetchAchievementReceipt: () => h.fetchAchievementReceipt(),
   fetchEnrollment: (...args: unknown[]) => h.fetchEnrollment(...args),
   fetchCourse: vi.fn(),
 }));
@@ -259,13 +261,18 @@ vi.mock("@/lib/supabase/admin", () => {
   return {
     createAdminClient: () => ({
       from: (table: string) => new Chain(table),
-      rpc: (_fn: string, params: Record<string, unknown>) =>
-        Promise.resolve(h.awardXp(params)),
+      // Only award_xp is driven per-test; every other SECURITY DEFINER call
+      // (unlock_achievement) succeeds quietly, as it does in practice.
+      rpc: (fn: string, params: Record<string, unknown>) =>
+        fn === "award_xp"
+          ? Promise.resolve(h.awardXp(params))
+          : Promise.resolve({ data: null, error: null }),
     }),
   };
 });
 
 import { retryPendingOnchainActions } from "../onchain-queue";
+import { MAX_RETRIES } from "@/lib/gamification/xp-queue-settlement";
 
 const USER_ID = "user-1";
 
@@ -282,6 +289,12 @@ beforeEach(() => {
   h.fetchEnrollment.mockReset();
   h.finalizeCourse.mockReset();
   h.awardAchievement.mockReset();
+  h.awardAchievement.mockResolvedValue({
+    signature: "AWARD_SIG",
+    assetAddress: { toBase58: () => "ASSET_ADDR" },
+  });
+  h.fetchAchievementReceipt.mockReset();
+  h.fetchAchievementReceipt.mockResolvedValue(false);
   h.isCourseInMaintenance.mockReset();
   h.isPlatformFrozen.mockReset();
   h.isPlatformFrozen.mockResolvedValue(false);
@@ -1207,5 +1220,137 @@ describe("retryPendingOnchainActions — quest XP on-chain leg", () => {
     const patch = patchFor("r-mint");
     expect(patch?.resolved_at).toBeUndefined();
     expect(patch?.retry_count).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The stuck-row shapes actually found in prod on 2026-08-24.
+//
+// 20 achievement rows and 3 quest_xp_mint rows sat unresolved for up to four
+// weeks with retry_count 0 — the drain had never once processed them, because
+// the login routes fired it as a detached promise that the serverless runtime
+// kills at response. These feed the drain each row exactly as it sits in the
+// table and assert it dispatches to the right handler and settles.
+// ---------------------------------------------------------------------------
+
+describe("retryPendingOnchainActions — prod stuck rows (2026-08-24)", () => {
+  it("resolves an achievement row whose receipt is already on-chain, without re-awarding", async () => {
+    // The real shape: the webhook re-awarded an achievement that was already
+    // on-chain, the CPI's Allocate failed with `custom program error: 0x0`, and
+    // the row has carried that as last_error ever since.
+    h.rows = [
+      {
+        id: "r-ach",
+        action_type: "achievement",
+        reference_id: "achievement-first-steps",
+        retry_count: 0,
+        payload: {
+          achievementId: "achievement-first-steps",
+          walletAddress: "WALLET_ADDR",
+        },
+      },
+    ];
+    h.fetchAchievementReceipt.mockResolvedValue(true);
+
+    await retryPendingOnchainActions(USER_ID);
+
+    // Never a second mint: the chain already has the receipt.
+    expect(h.awardAchievement).not.toHaveBeenCalled();
+    expect(typeof patchFor("r-ach")?.resolved_at).toBe("string");
+  });
+
+  it("awards and resolves an achievement row with no receipt yet", async () => {
+    h.rows = [
+      {
+        id: "r-ach",
+        action_type: "achievement",
+        reference_id: "achievement-early-adopter",
+        retry_count: 0,
+        payload: {
+          achievementId: "achievement-early-adopter",
+          walletAddress: "WALLET_ADDR",
+        },
+      },
+    ];
+    h.fetchAchievementReceipt.mockResolvedValue(false);
+
+    await retryPendingOnchainActions(USER_ID);
+
+    expect(h.awardAchievement).toHaveBeenCalledWith(
+      "achievement-early-adopter",
+      expect.anything()
+    );
+    expect(typeof patchFor("r-ach")?.resolved_at).toBe("string");
+  });
+
+  it("mints a never-attempted quest_xp_mint row (last_error NULL, no claim)", async () => {
+    // The 3 prod quest_xp_mint rows: last_error NULL, retry_count 0, and their
+    // xp_transactions row carries NO signature. Not the #1159 phantom-claim
+    // case — genuinely owed mints that were never attempted.
+    h.rows = [
+      {
+        id: "r-mint-prod",
+        action_type: "quest_xp_mint",
+        reference_id: "quest-login-streak:2026-08-22",
+        retry_count: 0,
+        payload: { xpAmount: 40, memo: "daily_quest:quest-login-streak" },
+      },
+    ];
+    h.xpLedgerRow = { id: "xptx-1", tx_signature: null };
+
+    await retryPendingOnchainActions(USER_ID);
+
+    expect(h.buildSignedRewardXpTx).toHaveBeenCalledTimes(1);
+    expect(h.sendSignedTransaction).toHaveBeenCalledTimes(1);
+    expect(typeof patchFor("r-mint-prod")?.resolved_at).toBe("string");
+  });
+
+  it("bumps retry_count and records a usable error when the award genuinely fails", async () => {
+    h.rows = [
+      {
+        id: "r-ach",
+        action_type: "achievement",
+        reference_id: "achievement-first-steps",
+        retry_count: 0,
+        payload: { achievementId: "achievement-first-steps" },
+      },
+    ];
+    h.fetchAchievementReceipt.mockResolvedValue(false);
+    // Anchor's post-broadcast failure path destroys the message; the queue must
+    // not persist the bare "Unknown action 'undefined'" sentinel.
+    h.awardAchievement.mockRejectedValue(
+      new Error("Unknown action 'undefined'")
+    );
+
+    await retryPendingOnchainActions(USER_ID);
+
+    const patch = patchFor("r-ach");
+    expect(patch?.resolved_at).toBeUndefined();
+    expect(patch?.retry_count).toBe(1);
+    expect(patch?.last_error).not.toBe("Unknown action 'undefined'");
+    expect(patch?.last_error).toContain("after broadcast");
+  });
+
+  it("says so loudly when a row exhausts its attempt budget", async () => {
+    h.rows = [
+      {
+        id: "r-ach",
+        action_type: "achievement",
+        reference_id: "achievement-first-steps",
+        retry_count: MAX_RETRIES - 1,
+        payload: { achievementId: "achievement-first-steps" },
+      },
+    ];
+    h.fetchAchievementReceipt.mockResolvedValue(false);
+    h.awardAchievement.mockRejectedValue(new Error("rpc down"));
+    const logged = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await retryPendingOnchainActions(USER_ID);
+
+    expect(patchFor("r-ach")?.retry_count).toBe(MAX_RETRIES);
+    expect(logged.mock.calls.flat().join(" ")).toContain(
+      "exhausted its 5-attempt budget"
+    );
+    logged.mockRestore();
   });
 });

--- a/apps/web/src/lib/solana/describe-tx-error.ts
+++ b/apps/web/src/lib/solana/describe-tx-error.ts
@@ -1,0 +1,40 @@
+/**
+ * Turn a thrown transaction error into the string we persist as
+ * `pending_onchain_actions.last_error`.
+ *
+ * Exists because of an upstream mismatch that silently destroys the most
+ * useful failures we get. `@solana/web3.js` 1.95+ changed
+ * `SendTransactionError` to a single-options-object constructor
+ * (`{ action, signature, transactionMessage, logs }`), but Anchor's
+ * `AnchorProvider.sendAndConfirm` still calls it positionally —
+ * `new SendTransactionError(err.message, logs)` (present in both 0.31.1 and
+ * 0.32.1). Destructuring a string yields `undefined` for every field, so the
+ * message builder falls to its `default:` branch and the instance carries the
+ * literal text below with the real program error, the signature and the logs
+ * all dropped on the floor.
+ *
+ * That branch is reached only when a transaction was BROADCAST and then failed
+ * during confirmation — exactly the case an operator most needs the logs for.
+ * Three of the stuck achievement rows in prod carry this sentinel as their
+ * whole `last_error`, which is what made them look like a queue dispatch bug
+ * rather than an ordinary on-chain rejection.
+ *
+ * Nothing can be recovered from such an instance (the fields were never
+ * assigned), so the best available fix is to stop the string from lying: name
+ * what actually happened and where the detail went.
+ */
+const WEB3JS_LOST_CONTEXT_SENTINEL = "Unknown action 'undefined'";
+
+export function describeTxError(err: unknown): string {
+  const message = err instanceof Error ? err.message : String(err);
+
+  if (message.trim() === WEB3JS_LOST_CONTEXT_SENTINEL) {
+    return (
+      "on-chain transaction failed after broadcast; program logs unavailable " +
+      "(Anchor built SendTransactionError positionally against web3.js's " +
+      "options-object constructor, discarding message/signature/logs)"
+    );
+  }
+
+  return message;
+}

--- a/apps/web/src/lib/solana/onchain-queue.ts
+++ b/apps/web/src/lib/solana/onchain-queue.ts
@@ -10,6 +10,7 @@ import type { Database } from "@/lib/supabase/types";
 import {
   creditQuestXpRows,
   creditXpAndSettle,
+  MAX_RETRIES,
 } from "@/lib/gamification/xp-queue-settlement";
 import {
   fetchAchievementReceipt,
@@ -25,6 +26,7 @@ import {
   sendSignedTransaction,
   TransactionNotBroadcastError,
 } from "./academy-program";
+import { describeTxError } from "./describe-tx-error";
 import { getProgramId } from "./pda";
 
 type OnchainActionType =
@@ -93,7 +95,7 @@ export async function retryPendingOnchainActions(
     .select("*")
     .eq("user_id", userId)
     .is("resolved_at", null)
-    .lt("retry_count", 5);
+    .lt("retry_count", MAX_RETRIES);
 
   if (fetchError || !rows || rows.length === 0) return;
 
@@ -638,14 +640,27 @@ export async function retryPendingOnchainActions(
         .update({ resolved_at: new Date().toISOString() })
         .eq("id", row.id);
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
+      // describeTxError, not err.message: Anchor destroys the message of any
+      // transaction that failed AFTER broadcast, leaving the useless literal
+      // "Unknown action 'undefined'" as the whole error (see the helper).
+      const message = describeTxError(err);
+      const nextRetryCount = (row.retry_count ?? 0) + 1;
       await adminClient
         .from("pending_onchain_actions")
         .update({
-          retry_count: (row.retry_count ?? 0) + 1,
+          retry_count: nextRetryCount,
           last_error: message,
         })
         .eq("id", row.id);
+
+      // At the cap the fetch filter stops selecting this row, so no later drain
+      // will ever see it again. Say so once, with the identity an operator needs
+      // to requeue it, instead of letting it disappear.
+      if (nextRetryCount >= MAX_RETRIES) {
+        console.error(
+          `[onchain-queue] row ${row.id} (${row.action_type} ${row.reference_id}, user ${userId}) exhausted its ${MAX_RETRIES}-attempt budget and will no longer be retried: ${message}`
+        );
+      }
     }
   }
 }


### PR DESCRIPTION
Two separate bugs kept 23 rows in `pending_onchain_actions` unresolved, the oldest since 2026-07-27.

**Nothing ever retried.** All three login routes called `retryPendingOnchainActions(userId).catch(...)` as a detached promise. The drain does RPC reads and on-chain sends that take seconds; the serverless instance freezes as soon as the response is sent, so no sweep ever got far enough to write anything back — which is why every stuck row still reads `retry_count = 0`. They now run inside `after()` from `next/server`, the same pattern `/api/quests/daily` already uses. The 5-attempt budget was a bare `5` in two fetch filters; it is now a shared `MAX_RETRIES`, and a row that exhausts it logs its identity instead of silently dropping out of every future query.

**The webhook manufactured the failures.** `checkAndAwardAchievements` decides what is un-earned from `user_achievements`, and that table is written by the `AchievementAwarded` webhook, which lands seconds after the award transaction. Two lesson completions inside that window both see the achievement as un-earned, so the second one re-awards it — the receipt PDA already exists, the CPI's `Allocate` fails with `custom program error: 0x0`, and we queue a "failure" for something fully delivered. It now reads the receipt first, exactly as the drainer does, and reconciles the DB from the chain. All 20 stuck achievement rows were on-chain *and* in `user_achievements` with a signature the whole time; no learner ever lost a badge.

**The `Unknown action 'undefined'` errors are not a dispatch bug.** That string comes from `@solana/web3.js`, whose `SendTransactionError` takes an options object since 1.95, while Anchor's `AnchorProvider.sendAndConfirm` still constructs it positionally (`new SendTransactionError(err.message, logs)` — both 0.31.1 and 0.32.1). Destructuring a string yields `undefined` for every field, so the message builder falls to its `default:` branch and the real error, signature and logs are all lost. It only fires for a transaction that was broadcast and then failed — the case an operator most needs logs for. Nothing is recoverable from such an instance, so `describeTxError` at least stops the recorded error from lying about what happened.

The 3 stuck `quest_xp_mint` rows are genuinely owed mints, not #1159 phantom claims: `last_error` is NULL and their `xp_transactions` rows carry no signature, so nothing was ever built or sent. #1159 is untouched — no `getSignatureStatus` reconciliation here, and no path that can rebuild a claimed row.

No migration.

### Requeueing the stuck rows after deploy

The 20 achievement rows are noise — they are already settled on-chain and in the DB. Resolve them rather than re-running them:

```sql
UPDATE pending_onchain_actions p
SET resolved_at = now()
WHERE p.resolved_at IS NULL
  AND p.action_type = 'achievement'
  AND EXISTS (
    SELECT 1 FROM user_achievements ua
    WHERE ua.user_id = p.user_id
      AND ua.achievement_id = p.reference_id
      AND ua.tx_signature IS NOT NULL
  );
```

The 3 `quest_xp_mint` rows need no SQL at all: they are already unresolved with `retry_count = 0`, so the next login by each of those three learners drains them. To not wait on that, the operator can hit any auth route for them; there is nothing to reset.
