### PR TITLE
feat(content): activate the launch achievement ladder + quest repricing

### DIFF
--- a/apps/web/content.lock
+++ b/apps/web/content.lock
@@ -1,4 +1,4 @@
 {
   "repo": "solanabr/academy-courses",
-  "sha": "4a6e4c6f8ac1c19566a3de85a19012809b28b050"
+  "sha": "958e78779ab4d3a309c12a1ff8ae30887331e9ff"
 }

--- a/apps/web/src/content/generated/achievements.json
+++ b/apps/web/src/content/generated/achievements.json
@@ -1,5 +1,23 @@
 [
   {
+    "_id": "achievement-accepted",
+    "_type": "achievement",
+    "award": {
+      "gte": 1,
+      "kind": "community-stat",
+      "stat": "acceptedAnswers"
+    },
+    "category": "community",
+    "description": "Have one of your answers accepted",
+    "glyph": "✓",
+    "icon": "check-circle",
+    "maxSupply": 0,
+    "metadataUri": "https://superteam-academy.vercel.app/api/achievements/metadata?id=achievement-accepted",
+    "name": "Accepted Answer",
+    "solTier": false,
+    "xpReward": 75
+  },
+  {
     "_id": "achievement-bug-hunter",
     "_type": "achievement",
     "award": {
@@ -30,7 +48,7 @@
     "metadataUri": "https://superteam-academy.vercel.app/api/achievements/metadata?id=achievement-consistency-king",
     "name": "Consistency King",
     "solTier": true,
-    "xpReward": 500
+    "xpReward": 400
   },
   {
     "_id": "achievement-course-completer",
@@ -50,11 +68,27 @@
     "xpReward": 200
   },
   {
+    "_id": "achievement-double-digits",
+    "_type": "achievement",
+    "award": {
+      "gte": 10,
+      "kind": "lessons-completed"
+    },
+    "category": "progress",
+    "description": "Complete 10 lessons",
+    "glyph": "10",
+    "icon": "rocket",
+    "maxSupply": 0,
+    "metadataUri": "https://superteam-academy.vercel.app/api/achievements/metadata?id=achievement-double-digits",
+    "name": "Double Digits",
+    "solTier": false,
+    "xpReward": 80
+  },
+  {
     "_id": "achievement-early-adopter",
     "_type": "achievement",
     "award": {
-      "kind": "user-number",
-      "lte": 100
+      "kind": "manual"
     },
     "category": "special",
     "description": "Join the platform during the first month",
@@ -65,6 +99,59 @@
     "name": "Early Adopter",
     "solTier": true,
     "xpReward": 1000
+  },
+  {
+    "_id": "achievement-evolution-explorer",
+    "_type": "achievement",
+    "award": {
+      "course": "course-btc-to-sol-evolution",
+      "gte": 5,
+      "kind": "lessons-completed-in-course"
+    },
+    "category": "progress",
+    "description": "Complete 5 lessons of From Bitcoin to Solana",
+    "glyph": "⅓",
+    "icon": "compass",
+    "maxSupply": 0,
+    "metadataUri": "https://superteam-academy.vercel.app/api/achievements/metadata?id=achievement-evolution-explorer",
+    "name": "Five Chapters In",
+    "solTier": false,
+    "xpReward": 50
+  },
+  {
+    "_id": "achievement-evolution-navigator",
+    "_type": "achievement",
+    "award": {
+      "course": "course-btc-to-sol-evolution",
+      "gte": 10,
+      "kind": "lessons-completed-in-course"
+    },
+    "category": "progress",
+    "description": "Complete 10 lessons of From Bitcoin to Solana",
+    "glyph": "⅔",
+    "icon": "compass",
+    "maxSupply": 0,
+    "metadataUri": "https://superteam-academy.vercel.app/api/achievements/metadata?id=achievement-evolution-navigator",
+    "name": "Two-Thirds There",
+    "solTier": false,
+    "xpReward": 80
+  },
+  {
+    "_id": "achievement-evolution-scholar",
+    "_type": "achievement",
+    "award": {
+      "course": "course-btc-to-sol-evolution",
+      "kind": "course-completed"
+    },
+    "category": "progress",
+    "description": "Complete From Bitcoin to Solana",
+    "glyph": "✦",
+    "icon": "graduation-cap",
+    "maxSupply": 0,
+    "metadataUri": "https://superteam-academy.vercel.app/api/achievements/metadata?id=achievement-evolution-scholar",
+    "name": "Evolution Scholar",
+    "solTier": false,
+    "xpReward": 150
   },
   {
     "_id": "achievement-first-steps",
@@ -81,7 +168,111 @@
     "metadataUri": "https://superteam-academy.vercel.app/api/achievements/metadata?id=achievement-first-steps",
     "name": "First Steps",
     "solTier": false,
+    "xpReward": 25
+  },
+  {
+    "_id": "achievement-first-steps-path",
+    "_type": "achievement",
+    "award": {
+      "kind": "path-completed",
+      "path": "path-first-steps"
+    },
+    "category": "progress",
+    "description": "Complete every course in the First Steps path",
+    "glyph": "✧",
+    "icon": "graduation-cap",
+    "maxSupply": 0,
+    "metadataUri": "https://superteam-academy.vercel.app/api/achievements/metadata?id=achievement-first-steps-path",
+    "name": "First Steps Complete",
+    "solTier": true,
+    "xpReward": 200
+  },
+  {
+    "_id": "achievement-first-word",
+    "_type": "achievement",
+    "award": {
+      "gte": 1,
+      "kind": "community-stat",
+      "stat": "totalThreads"
+    },
+    "category": "community",
+    "description": "Start your first forum thread",
+    "glyph": "✎",
+    "icon": "message-circle",
+    "maxSupply": 0,
+    "metadataUri": "https://superteam-academy.vercel.app/api/achievements/metadata?id=achievement-first-word",
+    "name": "First Word",
+    "solTier": false,
+    "xpReward": 30
+  },
+  {
+    "_id": "achievement-fortnight",
+    "_type": "achievement",
+    "award": {
+      "days": 14,
+      "kind": "streak"
+    },
+    "category": "streaks",
+    "description": "Maintain a 14-day learning streak",
+    "glyph": "14",
+    "icon": "flame",
+    "maxSupply": 0,
+    "metadataUri": "https://superteam-academy.vercel.app/api/achievements/metadata?id=achievement-fortnight",
+    "name": "Fortnight",
+    "solTier": false,
+    "xpReward": 125
+  },
+  {
+    "_id": "achievement-getting-traction",
+    "_type": "achievement",
+    "award": {
+      "gte": 5,
+      "kind": "lessons-completed"
+    },
+    "category": "progress",
+    "description": "Complete 5 lessons",
+    "glyph": "05",
+    "icon": "rocket",
+    "maxSupply": 0,
+    "metadataUri": "https://superteam-academy.vercel.app/api/achievements/metadata?id=achievement-getting-traction",
+    "name": "Getting Traction",
+    "solTier": false,
     "xpReward": 50
+  },
+  {
+    "_id": "achievement-half-century",
+    "_type": "achievement",
+    "award": {
+      "gte": 50,
+      "kind": "lessons-completed"
+    },
+    "category": "progress",
+    "description": "Complete 50 lessons",
+    "glyph": "50",
+    "icon": "crown",
+    "maxSupply": 0,
+    "metadataUri": "https://superteam-academy.vercel.app/api/achievements/metadata?id=achievement-half-century",
+    "name": "Half Century",
+    "solTier": true,
+    "xpReward": 250
+  },
+  {
+    "_id": "achievement-helping-hand",
+    "_type": "achievement",
+    "award": {
+      "gte": 1,
+      "kind": "community-stat",
+      "stat": "totalAnswers"
+    },
+    "category": "community",
+    "description": "Post your first answer in the forum",
+    "glyph": "↪",
+    "icon": "message-square",
+    "maxSupply": 0,
+    "metadataUri": "https://superteam-academy.vercel.app/api/achievements/metadata?id=achievement-helping-hand",
+    "name": "Helping Hand",
+    "solTier": false,
+    "xpReward": 30
   },
   {
     "_id": "achievement-monthly-master",
@@ -98,7 +289,109 @@
     "metadataUri": "https://superteam-academy.vercel.app/api/achievements/metadata?id=achievement-monthly-master",
     "name": "Monthly Master",
     "solTier": false,
-    "xpReward": 300
+    "xpReward": 200
+  },
+  {
+    "_id": "achievement-panorama",
+    "_type": "achievement",
+    "award": {
+      "course": "course-visao-geral-solana",
+      "kind": "course-completed"
+    },
+    "category": "progress",
+    "description": "Complete Visão Geral do Solana",
+    "glyph": "◎",
+    "icon": "compass",
+    "maxSupply": 0,
+    "metadataUri": "https://superteam-academy.vercel.app/api/achievements/metadata?id=achievement-panorama",
+    "name": "Visão Geral",
+    "solTier": false,
+    "xpReward": 60
+  },
+  {
+    "_id": "achievement-pilula-taken",
+    "_type": "achievement",
+    "award": {
+      "course": "course-pilula-solana-superteam",
+      "kind": "course-completed"
+    },
+    "category": "progress",
+    "description": "Complete Pílula Solana & Superteam",
+    "glyph": "◆",
+    "icon": "graduation-cap",
+    "maxSupply": 0,
+    "metadataUri": "https://superteam-academy.vercel.app/api/achievements/metadata?id=achievement-pilula-taken",
+    "name": "Pílula Tomada",
+    "solTier": false,
+    "xpReward": 30
+  },
+  {
+    "_id": "achievement-speedrunner",
+    "_type": "achievement",
+    "award": {
+      "course": "course-solana-speedrun",
+      "kind": "course-completed"
+    },
+    "category": "progress",
+    "description": "Complete the Solana Speedrun course",
+    "glyph": "»",
+    "icon": "flame",
+    "maxSupply": 0,
+    "metadataUri": "https://superteam-academy.vercel.app/api/achievements/metadata?id=achievement-speedrunner",
+    "name": "Speedrunner",
+    "solTier": false,
+    "xpReward": 75
+  },
+  {
+    "_id": "achievement-three-day-spark",
+    "_type": "achievement",
+    "award": {
+      "days": 3,
+      "kind": "streak"
+    },
+    "category": "streaks",
+    "description": "Maintain a 3-day learning streak",
+    "glyph": "3×",
+    "icon": "flame",
+    "maxSupply": 0,
+    "metadataUri": "https://superteam-academy.vercel.app/api/achievements/metadata?id=achievement-three-day-spark",
+    "name": "Three-Day Spark",
+    "solTier": false,
+    "xpReward": 40
+  },
+  {
+    "_id": "achievement-twenty-five",
+    "_type": "achievement",
+    "award": {
+      "gte": 25,
+      "kind": "lessons-completed"
+    },
+    "category": "progress",
+    "description": "Complete 25 lessons",
+    "glyph": "25",
+    "icon": "trophy",
+    "maxSupply": 0,
+    "metadataUri": "https://superteam-academy.vercel.app/api/achievements/metadata?id=achievement-twenty-five",
+    "name": "Twenty-Five",
+    "solTier": false,
+    "xpReward": 150
+  },
+  {
+    "_id": "achievement-warmed-up",
+    "_type": "achievement",
+    "award": {
+      "gte": 3,
+      "kind": "lessons-completed"
+    },
+    "category": "progress",
+    "description": "Complete 3 lessons",
+    "glyph": "03",
+    "icon": "footprints",
+    "maxSupply": 0,
+    "metadataUri": "https://superteam-academy.vercel.app/api/achievements/metadata?id=achievement-warmed-up",
+    "name": "Warmed Up",
+    "solTier": false,
+    "xpReward": 40
   },
   {
     "_id": "achievement-week-warrior",
@@ -115,6 +408,6 @@
     "metadataUri": "https://superteam-academy.vercel.app/api/achievements/metadata?id=achievement-week-warrior",
     "name": "Week Warrior",
     "solTier": false,
-    "xpReward": 100
+    "xpReward": 75
   }
 ]

--- a/apps/web/src/content/generated/meta.json
+++ b/apps/web/src/content/generated/meta.json
@@ -1,11 +1,11 @@
 {
-  "compiledAt": "2026-08-24T13:22:34Z",
+  "compiledAt": "2026-08-24T13:54:33Z",
   "counts": {
-    "achievements": 7,
+    "achievements": 24,
     "courses": 4,
     "learningPaths": 1,
     "lessons": 23,
     "quests": 5
   },
-  "sha": "4a6e4c6f8ac1c19566a3de85a19012809b28b050"
+  "sha": "958e78779ab4d3a309c12a1ff8ae30887331e9ff"
 }

--- a/apps/web/src/content/generated/quests.json
+++ b/apps/web/src/content/generated/quests.json
@@ -2,7 +2,7 @@
   {
     "_id": "quest-challenge",
     "_type": "quest",
-    "active": true,
+    "active": false,
     "description": "Pass a challenge lesson",
     "icon": "Code",
     "name": "Complete a Challenge",
@@ -21,7 +21,7 @@
     "resetType": "daily",
     "targetValue": 1,
     "type": "lesson",
-    "xpReward": 25
+    "xpReward": 20
   },
   {
     "_id": "quest-complete-module",
@@ -39,13 +39,13 @@
     "_id": "quest-lesson-batch",
     "_type": "quest",
     "active": true,
-    "description": "Finish 3 lessons in a single day",
+    "description": "Finish 2 lessons in a single day",
     "icon": "Lightning",
-    "name": "Complete 3 Lessons",
+    "name": "Complete 2 Lessons",
     "resetType": "daily",
-    "targetValue": 3,
+    "targetValue": 2,
     "type": "lesson_batch",
-    "xpReward": 50
+    "xpReward": 40
   },
   {
     "_id": "quest-login-streak",
@@ -57,6 +57,6 @@
     "resetType": "multi_day",
     "targetValue": 3,
     "type": "login_streak",
-    "xpReward": 40
+    "xpReward": 50
   }
 ]

--- a/apps/web/src/lib/content/__tests__/fixtures/golden/achievements-raw.json
+++ b/apps/web/src/lib/content/__tests__/fixtures/golden/achievements-raw.json
@@ -36,7 +36,7 @@
       "icon": "trophy",
       "name": "Consistency King",
       "solTier": true,
-      "xpReward": 500
+      "xpReward": 400
     },
     {
       "_id": "achievement-course-completer",
@@ -63,8 +63,8 @@
         "course": null,
         "days": null,
         "gte": null,
-        "kind": "user-number",
-        "lte": 100,
+        "kind": "manual",
+        "lte": null,
         "path": null,
         "stat": null
       },
@@ -93,7 +93,7 @@
       "icon": "footprints",
       "name": "First Steps",
       "solTier": false,
-      "xpReward": 50
+      "xpReward": 25
     },
     {
       "_id": "achievement-monthly-master",
@@ -112,7 +112,7 @@
       "icon": "crown",
       "name": "Monthly Master",
       "solTier": false,
-      "xpReward": 300
+      "xpReward": 200
     },
     {
       "_id": "achievement-week-warrior",
@@ -131,7 +131,330 @@
       "icon": "flame",
       "name": "Week Warrior",
       "solTier": false,
-      "xpReward": 100
+      "xpReward": 75
+    },
+    {
+      "_id": "achievement-accepted",
+      "award": {
+        "course": null,
+        "days": null,
+        "gte": 1,
+        "kind": "community-stat",
+        "lte": null,
+        "path": null,
+        "stat": "acceptedAnswers"
+      },
+      "category": "community",
+      "description": "Have one of your answers accepted",
+      "glyph": "✓",
+      "icon": "check-circle",
+      "name": "Accepted Answer",
+      "solTier": false,
+      "xpReward": 75
+    },
+    {
+      "_id": "achievement-double-digits",
+      "award": {
+        "course": null,
+        "days": null,
+        "gte": 10,
+        "kind": "lessons-completed",
+        "lte": null,
+        "path": null,
+        "stat": null
+      },
+      "category": "progress",
+      "description": "Complete 10 lessons",
+      "glyph": "10",
+      "icon": "rocket",
+      "name": "Double Digits",
+      "solTier": false,
+      "xpReward": 80
+    },
+    {
+      "_id": "achievement-evolution-explorer",
+      "award": {
+        "course": "course-btc-to-sol-evolution",
+        "days": null,
+        "gte": 5,
+        "kind": "lessons-completed-in-course",
+        "lte": null,
+        "path": null,
+        "stat": null
+      },
+      "category": "progress",
+      "description": "Complete 5 lessons of From Bitcoin to Solana",
+      "glyph": "⅓",
+      "icon": "compass",
+      "name": "Five Chapters In",
+      "solTier": false,
+      "xpReward": 50
+    },
+    {
+      "_id": "achievement-evolution-navigator",
+      "award": {
+        "course": "course-btc-to-sol-evolution",
+        "days": null,
+        "gte": 10,
+        "kind": "lessons-completed-in-course",
+        "lte": null,
+        "path": null,
+        "stat": null
+      },
+      "category": "progress",
+      "description": "Complete 10 lessons of From Bitcoin to Solana",
+      "glyph": "⅔",
+      "icon": "compass",
+      "name": "Two-Thirds There",
+      "solTier": false,
+      "xpReward": 80
+    },
+    {
+      "_id": "achievement-evolution-scholar",
+      "award": {
+        "course": "course-btc-to-sol-evolution",
+        "days": null,
+        "gte": null,
+        "kind": "course-completed",
+        "lte": null,
+        "path": null,
+        "stat": null
+      },
+      "category": "progress",
+      "description": "Complete From Bitcoin to Solana",
+      "glyph": "✦",
+      "icon": "graduation-cap",
+      "name": "Evolution Scholar",
+      "solTier": false,
+      "xpReward": 150
+    },
+    {
+      "_id": "achievement-first-steps-path",
+      "award": {
+        "course": null,
+        "days": null,
+        "gte": null,
+        "kind": "path-completed",
+        "lte": null,
+        "path": "path-first-steps",
+        "stat": null
+      },
+      "category": "progress",
+      "description": "Complete every course in the First Steps path",
+      "glyph": "✧",
+      "icon": "graduation-cap",
+      "name": "First Steps Complete",
+      "solTier": true,
+      "xpReward": 200
+    },
+    {
+      "_id": "achievement-first-word",
+      "award": {
+        "course": null,
+        "days": null,
+        "gte": 1,
+        "kind": "community-stat",
+        "lte": null,
+        "path": null,
+        "stat": "totalThreads"
+      },
+      "category": "community",
+      "description": "Start your first forum thread",
+      "glyph": "✎",
+      "icon": "message-circle",
+      "name": "First Word",
+      "solTier": false,
+      "xpReward": 30
+    },
+    {
+      "_id": "achievement-fortnight",
+      "award": {
+        "course": null,
+        "days": 14,
+        "gte": null,
+        "kind": "streak",
+        "lte": null,
+        "path": null,
+        "stat": null
+      },
+      "category": "streaks",
+      "description": "Maintain a 14-day learning streak",
+      "glyph": "14",
+      "icon": "flame",
+      "name": "Fortnight",
+      "solTier": false,
+      "xpReward": 125
+    },
+    {
+      "_id": "achievement-getting-traction",
+      "award": {
+        "course": null,
+        "days": null,
+        "gte": 5,
+        "kind": "lessons-completed",
+        "lte": null,
+        "path": null,
+        "stat": null
+      },
+      "category": "progress",
+      "description": "Complete 5 lessons",
+      "glyph": "05",
+      "icon": "rocket",
+      "name": "Getting Traction",
+      "solTier": false,
+      "xpReward": 50
+    },
+    {
+      "_id": "achievement-half-century",
+      "award": {
+        "course": null,
+        "days": null,
+        "gte": 50,
+        "kind": "lessons-completed",
+        "lte": null,
+        "path": null,
+        "stat": null
+      },
+      "category": "progress",
+      "description": "Complete 50 lessons",
+      "glyph": "50",
+      "icon": "crown",
+      "name": "Half Century",
+      "solTier": true,
+      "xpReward": 250
+    },
+    {
+      "_id": "achievement-helping-hand",
+      "award": {
+        "course": null,
+        "days": null,
+        "gte": 1,
+        "kind": "community-stat",
+        "lte": null,
+        "path": null,
+        "stat": "totalAnswers"
+      },
+      "category": "community",
+      "description": "Post your first answer in the forum",
+      "glyph": "↪",
+      "icon": "message-square",
+      "name": "Helping Hand",
+      "solTier": false,
+      "xpReward": 30
+    },
+    {
+      "_id": "achievement-panorama",
+      "award": {
+        "course": "course-visao-geral-solana",
+        "days": null,
+        "gte": null,
+        "kind": "course-completed",
+        "lte": null,
+        "path": null,
+        "stat": null
+      },
+      "category": "progress",
+      "description": "Complete Visão Geral do Solana",
+      "glyph": "◎",
+      "icon": "compass",
+      "name": "Visão Geral",
+      "solTier": false,
+      "xpReward": 60
+    },
+    {
+      "_id": "achievement-pilula-taken",
+      "award": {
+        "course": "course-pilula-solana-superteam",
+        "days": null,
+        "gte": null,
+        "kind": "course-completed",
+        "lte": null,
+        "path": null,
+        "stat": null
+      },
+      "category": "progress",
+      "description": "Complete Pílula Solana & Superteam",
+      "glyph": "◆",
+      "icon": "graduation-cap",
+      "name": "Pílula Tomada",
+      "solTier": false,
+      "xpReward": 30
+    },
+    {
+      "_id": "achievement-speedrunner",
+      "award": {
+        "course": "course-solana-speedrun",
+        "days": null,
+        "gte": null,
+        "kind": "course-completed",
+        "lte": null,
+        "path": null,
+        "stat": null
+      },
+      "category": "progress",
+      "description": "Complete the Solana Speedrun course",
+      "glyph": "»",
+      "icon": "flame",
+      "name": "Speedrunner",
+      "solTier": false,
+      "xpReward": 75
+    },
+    {
+      "_id": "achievement-three-day-spark",
+      "award": {
+        "course": null,
+        "days": 3,
+        "gte": null,
+        "kind": "streak",
+        "lte": null,
+        "path": null,
+        "stat": null
+      },
+      "category": "streaks",
+      "description": "Maintain a 3-day learning streak",
+      "glyph": "3×",
+      "icon": "flame",
+      "name": "Three-Day Spark",
+      "solTier": false,
+      "xpReward": 40
+    },
+    {
+      "_id": "achievement-twenty-five",
+      "award": {
+        "course": null,
+        "days": null,
+        "gte": 25,
+        "kind": "lessons-completed",
+        "lte": null,
+        "path": null,
+        "stat": null
+      },
+      "category": "progress",
+      "description": "Complete 25 lessons",
+      "glyph": "25",
+      "icon": "trophy",
+      "name": "Twenty-Five",
+      "solTier": false,
+      "xpReward": 150
+    },
+    {
+      "_id": "achievement-warmed-up",
+      "award": {
+        "course": null,
+        "days": null,
+        "gte": 3,
+        "kind": "lessons-completed",
+        "lte": null,
+        "path": null,
+        "stat": null
+      },
+      "category": "progress",
+      "description": "Complete 3 lessons",
+      "glyph": "03",
+      "icon": "footprints",
+      "name": "Warmed Up",
+      "solTier": false,
+      "xpReward": 40
     }
   ],
   "deployed": [
@@ -171,7 +494,7 @@
       "icon": "trophy",
       "name": "Consistency King",
       "solTier": true,
-      "xpReward": 500
+      "xpReward": 400
     },
     {
       "_id": "achievement-course-completer",
@@ -198,8 +521,8 @@
         "course": null,
         "days": null,
         "gte": null,
-        "kind": "user-number",
-        "lte": 100,
+        "kind": "manual",
+        "lte": null,
         "path": null,
         "stat": null
       },
@@ -228,7 +551,7 @@
       "icon": "footprints",
       "name": "First Steps",
       "solTier": false,
-      "xpReward": 50
+      "xpReward": 25
     },
     {
       "_id": "achievement-monthly-master",
@@ -247,7 +570,7 @@
       "icon": "crown",
       "name": "Monthly Master",
       "solTier": false,
-      "xpReward": 300
+      "xpReward": 200
     },
     {
       "_id": "achievement-week-warrior",
@@ -266,7 +589,330 @@
       "icon": "flame",
       "name": "Week Warrior",
       "solTier": false,
-      "xpReward": 100
+      "xpReward": 75
+    },
+    {
+      "_id": "achievement-accepted",
+      "award": {
+        "course": null,
+        "days": null,
+        "gte": 1,
+        "kind": "community-stat",
+        "lte": null,
+        "path": null,
+        "stat": "acceptedAnswers"
+      },
+      "category": "community",
+      "description": "Have one of your answers accepted",
+      "glyph": "✓",
+      "icon": "check-circle",
+      "name": "Accepted Answer",
+      "solTier": false,
+      "xpReward": 75
+    },
+    {
+      "_id": "achievement-double-digits",
+      "award": {
+        "course": null,
+        "days": null,
+        "gte": 10,
+        "kind": "lessons-completed",
+        "lte": null,
+        "path": null,
+        "stat": null
+      },
+      "category": "progress",
+      "description": "Complete 10 lessons",
+      "glyph": "10",
+      "icon": "rocket",
+      "name": "Double Digits",
+      "solTier": false,
+      "xpReward": 80
+    },
+    {
+      "_id": "achievement-evolution-explorer",
+      "award": {
+        "course": "course-btc-to-sol-evolution",
+        "days": null,
+        "gte": 5,
+        "kind": "lessons-completed-in-course",
+        "lte": null,
+        "path": null,
+        "stat": null
+      },
+      "category": "progress",
+      "description": "Complete 5 lessons of From Bitcoin to Solana",
+      "glyph": "⅓",
+      "icon": "compass",
+      "name": "Five Chapters In",
+      "solTier": false,
+      "xpReward": 50
+    },
+    {
+      "_id": "achievement-evolution-navigator",
+      "award": {
+        "course": "course-btc-to-sol-evolution",
+        "days": null,
+        "gte": 10,
+        "kind": "lessons-completed-in-course",
+        "lte": null,
+        "path": null,
+        "stat": null
+      },
+      "category": "progress",
+      "description": "Complete 10 lessons of From Bitcoin to Solana",
+      "glyph": "⅔",
+      "icon": "compass",
+      "name": "Two-Thirds There",
+      "solTier": false,
+      "xpReward": 80
+    },
+    {
+      "_id": "achievement-evolution-scholar",
+      "award": {
+        "course": "course-btc-to-sol-evolution",
+        "days": null,
+        "gte": null,
+        "kind": "course-completed",
+        "lte": null,
+        "path": null,
+        "stat": null
+      },
+      "category": "progress",
+      "description": "Complete From Bitcoin to Solana",
+      "glyph": "✦",
+      "icon": "graduation-cap",
+      "name": "Evolution Scholar",
+      "solTier": false,
+      "xpReward": 150
+    },
+    {
+      "_id": "achievement-first-steps-path",
+      "award": {
+        "course": null,
+        "days": null,
+        "gte": null,
+        "kind": "path-completed",
+        "lte": null,
+        "path": "path-first-steps",
+        "stat": null
+      },
+      "category": "progress",
+      "description": "Complete every course in the First Steps path",
+      "glyph": "✧",
+      "icon": "graduation-cap",
+      "name": "First Steps Complete",
+      "solTier": true,
+      "xpReward": 200
+    },
+    {
+      "_id": "achievement-first-word",
+      "award": {
+        "course": null,
+        "days": null,
+        "gte": 1,
+        "kind": "community-stat",
+        "lte": null,
+        "path": null,
+        "stat": "totalThreads"
+      },
+      "category": "community",
+      "description": "Start your first forum thread",
+      "glyph": "✎",
+      "icon": "message-circle",
+      "name": "First Word",
+      "solTier": false,
+      "xpReward": 30
+    },
+    {
+      "_id": "achievement-fortnight",
+      "award": {
+        "course": null,
+        "days": 14,
+        "gte": null,
+        "kind": "streak",
+        "lte": null,
+        "path": null,
+        "stat": null
+      },
+      "category": "streaks",
+      "description": "Maintain a 14-day learning streak",
+      "glyph": "14",
+      "icon": "flame",
+      "name": "Fortnight",
+      "solTier": false,
+      "xpReward": 125
+    },
+    {
+      "_id": "achievement-getting-traction",
+      "award": {
+        "course": null,
+        "days": null,
+        "gte": 5,
+        "kind": "lessons-completed",
+        "lte": null,
+        "path": null,
+        "stat": null
+      },
+      "category": "progress",
+      "description": "Complete 5 lessons",
+      "glyph": "05",
+      "icon": "rocket",
+      "name": "Getting Traction",
+      "solTier": false,
+      "xpReward": 50
+    },
+    {
+      "_id": "achievement-half-century",
+      "award": {
+        "course": null,
+        "days": null,
+        "gte": 50,
+        "kind": "lessons-completed",
+        "lte": null,
+        "path": null,
+        "stat": null
+      },
+      "category": "progress",
+      "description": "Complete 50 lessons",
+      "glyph": "50",
+      "icon": "crown",
+      "name": "Half Century",
+      "solTier": true,
+      "xpReward": 250
+    },
+    {
+      "_id": "achievement-helping-hand",
+      "award": {
+        "course": null,
+        "days": null,
+        "gte": 1,
+        "kind": "community-stat",
+        "lte": null,
+        "path": null,
+        "stat": "totalAnswers"
+      },
+      "category": "community",
+      "description": "Post your first answer in the forum",
+      "glyph": "↪",
+      "icon": "message-square",
+      "name": "Helping Hand",
+      "solTier": false,
+      "xpReward": 30
+    },
+    {
+      "_id": "achievement-panorama",
+      "award": {
+        "course": "course-visao-geral-solana",
+        "days": null,
+        "gte": null,
+        "kind": "course-completed",
+        "lte": null,
+        "path": null,
+        "stat": null
+      },
+      "category": "progress",
+      "description": "Complete Visão Geral do Solana",
+      "glyph": "◎",
+      "icon": "compass",
+      "name": "Visão Geral",
+      "solTier": false,
+      "xpReward": 60
+    },
+    {
+      "_id": "achievement-pilula-taken",
+      "award": {
+        "course": "course-pilula-solana-superteam",
+        "days": null,
+        "gte": null,
+        "kind": "course-completed",
+        "lte": null,
+        "path": null,
+        "stat": null
+      },
+      "category": "progress",
+      "description": "Complete Pílula Solana & Superteam",
+      "glyph": "◆",
+      "icon": "graduation-cap",
+      "name": "Pílula Tomada",
+      "solTier": false,
+      "xpReward": 30
+    },
+    {
+      "_id": "achievement-speedrunner",
+      "award": {
+        "course": "course-solana-speedrun",
+        "days": null,
+        "gte": null,
+        "kind": "course-completed",
+        "lte": null,
+        "path": null,
+        "stat": null
+      },
+      "category": "progress",
+      "description": "Complete the Solana Speedrun course",
+      "glyph": "»",
+      "icon": "flame",
+      "name": "Speedrunner",
+      "solTier": false,
+      "xpReward": 75
+    },
+    {
+      "_id": "achievement-three-day-spark",
+      "award": {
+        "course": null,
+        "days": 3,
+        "gte": null,
+        "kind": "streak",
+        "lte": null,
+        "path": null,
+        "stat": null
+      },
+      "category": "streaks",
+      "description": "Maintain a 3-day learning streak",
+      "glyph": "3×",
+      "icon": "flame",
+      "name": "Three-Day Spark",
+      "solTier": false,
+      "xpReward": 40
+    },
+    {
+      "_id": "achievement-twenty-five",
+      "award": {
+        "course": null,
+        "days": null,
+        "gte": 25,
+        "kind": "lessons-completed",
+        "lte": null,
+        "path": null,
+        "stat": null
+      },
+      "category": "progress",
+      "description": "Complete 25 lessons",
+      "glyph": "25",
+      "icon": "trophy",
+      "name": "Twenty-Five",
+      "solTier": false,
+      "xpReward": 150
+    },
+    {
+      "_id": "achievement-warmed-up",
+      "award": {
+        "course": null,
+        "days": null,
+        "gte": 3,
+        "kind": "lessons-completed",
+        "lte": null,
+        "path": null,
+        "stat": null
+      },
+      "category": "progress",
+      "description": "Complete 3 lessons",
+      "glyph": "03",
+      "icon": "footprints",
+      "name": "Warmed Up",
+      "solTier": false,
+      "xpReward": 40
     }
   ]
 }

--- a/apps/web/src/lib/content/__tests__/fixtures/golden/quests-raw.json
+++ b/apps/web/src/lib/content/__tests__/fixtures/golden/quests-raw.json
@@ -82,16 +82,6 @@
   ],
   "quests": [
     {
-      "_id": "quest-challenge",
-      "description": "Pass a challenge lesson",
-      "icon": "Code",
-      "name": "Complete a Challenge",
-      "resetType": "daily",
-      "targetValue": 1,
-      "type": "challenge",
-      "xpReward": 35
-    },
-    {
       "_id": "quest-complete-lesson",
       "description": "Finish any lesson today",
       "icon": "BookOpen",
@@ -99,7 +89,7 @@
       "resetType": "daily",
       "targetValue": 1,
       "type": "lesson",
-      "xpReward": 25
+      "xpReward": 20
     },
     {
       "_id": "quest-complete-module",
@@ -113,13 +103,13 @@
     },
     {
       "_id": "quest-lesson-batch",
-      "description": "Finish 3 lessons in a single day",
+      "description": "Finish 2 lessons in a single day",
       "icon": "Lightning",
-      "name": "Complete 3 Lessons",
+      "name": "Complete 2 Lessons",
       "resetType": "daily",
-      "targetValue": 3,
+      "targetValue": 2,
       "type": "lesson_batch",
-      "xpReward": 50
+      "xpReward": 40
     },
     {
       "_id": "quest-login-streak",
@@ -129,7 +119,7 @@
       "resetType": "multi_day",
       "targetValue": 3,
       "type": "login_streak",
-      "xpReward": 40
+      "xpReward": 50
     }
   ]
 }

--- a/apps/web/src/lib/content/__tests__/project.golden.test.ts
+++ b/apps/web/src/lib/content/__tests__/project.golden.test.ts
@@ -179,13 +179,27 @@ vi.mock("server-only", () => ({}));
 //    single-module course (`course-visao-geral-solana`, 3 lessons, module
 //    `origens-e-historia`) authored under its OWN creator wallet
 //    (`Em8D6Xyu…`), which is why the creator assertion is now a per-course
-//    map instead of one constant. The same bump sets `creatorRewardXp: 30` on
-//    the two Kaue courses — invisible here, `projectCourse` never projected
+//    map instead of one constant. The same bump carries `creatorRewardXp: 30`
+//    on the two Kaue courses — invisible here, `projectCourse` never projected
 //    that field — and the upstream images arrive pre-compressed, so no asset
 //    url moves. New content again = golden is the projected bundle:
 //    courses.json and lessons.json gained the projector-generated docs and
 //    quests-raw.json's moduleLessonMap gained the one-module entry. Every
 //    pre-existing doc is byte-unchanged.
+//  - gamification ladder (bump to academy-courses @958e7877, academy-courses
+//    #41): an achievements+quests-ONLY wave — no course, lesson, path or slot
+//    moved, so courses/lessons/paths/summaries/course-by-slug and quests-raw's
+//    derived fields are all byte-unchanged. achievements 7 -> 24: 17 new docs
+//    (streak/lessons-completed ladders, the three per-course badges, the
+//    first-steps path badge, three community-stat badges) plus 4 repricings
+//    (first-steps 50 -> 25, week-warrior 100 -> 75, monthly-master 300 -> 200,
+//    consistency-king 500 -> 400) and `achievement-early-adopter` flipping
+//    `user-number lte:100` -> `manual`, so it no longer auto-fires on signup.
+//    The fixture stays the exact both-directions cover, regenerated into the
+//    raw capture's null-filled award shape. quests-raw's `quests` array is the
+//    ACTIVE set, so `quest-challenge` (active: false now) DROPS out of it,
+//    and complete-lesson 25 -> 20 / lesson-batch 3 -> 2 targets at 50 -> 40 /
+//    login-streak 40 -> 50 land in the remaining four.
 const deps = { lessonsById };
 
 function bundleCourse(id: string): CourseDoc {
@@ -360,6 +374,18 @@ describe("projectAchievement — mapAchievement over the bundle", () => {
     });
     expect(completer.glyph).toBe("✦");
     expect(completer.solTier).toBe(false);
+  });
+
+  it("early-adopter is manual — it no longer auto-fires on signup", () => {
+    // The ladder wave retired the `user-number lte:100` rule. Asserted
+    // positively because the regression is silent: a doc that drifted back to
+    // an auto rule would hand every early signup 500 XP on day one, and a
+    // byte-identical comparison against a golden regenerated from that same
+    // doc could never catch it.
+    const early = projectAchievement(
+      achievementsById.get("achievement-early-adopter")!
+    );
+    expect(early.award).toEqual({ kind: "manual" });
   });
 });
 

--- a/apps/web/src/lib/gamification/__tests__/community-achievement-deploy-gate.test.ts
+++ b/apps/web/src/lib/gamification/__tests__/community-achievement-deploy-gate.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/supabase/admin", () => ({ createAdminClient: () => ({}) }));
+vi.mock("@/lib/content/queries", () => ({
+  getDeployedAchievements: vi.fn(),
+  getAllCourseLessonCounts: vi.fn().mockResolvedValue([]),
+  getLearningPathsForAdmin: vi.fn().mockResolvedValue([]),
+}));
+vi.mock("@/lib/content/deployments", () => ({
+  getActiveDeployments: vi.fn().mockResolvedValue(new Map()),
+  isSynced: vi.fn().mockReturnValue(true),
+}));
+
+import { getDeployedAchievements } from "@/lib/content/queries";
+import type { DeployedAchievement } from "@/lib/content/queries";
+import { checkCommunityAchievements } from "../achievements";
+
+const firstWord: DeployedAchievement = {
+  id: "achievement-first-word",
+  name: "First Word",
+  description: "",
+  icon: "message-circle",
+  glyph: "Fw",
+  solTier: false,
+  category: "community",
+  xpReward: 30,
+  award: { kind: "community-stat", stat: "totalThreads", gte: 1 },
+};
+
+/** Chainable admin stub: any query resolves to the row provided per table. */
+function adminStub(rows: Record<string, unknown>) {
+  const rpc = vi.fn().mockResolvedValue({ data: null, error: null });
+  const from = (table: string) => {
+    const result = { data: rows[table] ?? null, error: null };
+    const builder: Record<string, unknown> = {};
+    for (const m of ["select", "eq", "lte", "single"]) {
+      builder[m] = () => builder;
+    }
+    (builder as { then: unknown }).then = (
+      resolve: (v: typeof result) => unknown
+    ) => Promise.resolve(resolve(result));
+    return builder;
+  };
+  return { admin: { from, rpc }, rpc };
+}
+
+const qualifyingRows = {
+  user_xp: { current_streak: 0 },
+  user_progress: [],
+  enrollments: [],
+  community_stats: {
+    total_threads: 1,
+    total_answers: 0,
+    accepted_answers: 0,
+    total_community_xp: 0,
+  },
+  profiles: { created_at: "2026-08-01T00:00:00Z" },
+  user_achievements: [],
+};
+
+beforeEach(() => {
+  vi.mocked(getDeployedAchievements).mockReset();
+});
+
+describe("checkCommunityAchievements — deployed-only gate", () => {
+  // An un-deployed doc unlocking here would write a user_achievements row with
+  // no tx/asset and permanently block the real on-chain award (review on the
+  // ladder-activation PR). The community path must see DEPLOYED docs only.
+  it("does not unlock a qualifying achievement that has no on-chain deploy", async () => {
+    vi.mocked(getDeployedAchievements).mockResolvedValue([]);
+    const { admin, rpc } = adminStub(qualifyingRows);
+
+    await checkCommunityAchievements(
+      admin as unknown as Parameters<typeof checkCommunityAchievements>[0],
+      "user-1"
+    );
+
+    expect(getDeployedAchievements).toHaveBeenCalled();
+    expect(rpc).not.toHaveBeenCalled();
+  });
+
+  it("unlocks the same achievement once it is deployed", async () => {
+    vi.mocked(getDeployedAchievements).mockResolvedValue([firstWord]);
+    const { admin, rpc } = adminStub(qualifyingRows);
+
+    await checkCommunityAchievements(
+      admin as unknown as Parameters<typeof checkCommunityAchievements>[0],
+      "user-1"
+    );
+
+    expect(rpc).toHaveBeenCalledWith("unlock_achievement", {
+      p_user_id: "user-1",
+      p_achievement_id: "achievement-first-word",
+    });
+  });
+});

--- a/apps/web/src/lib/gamification/achievements.ts
+++ b/apps/web/src/lib/gamification/achievements.ts
@@ -8,8 +8,8 @@ import {
 import { createAdminClient } from "@/lib/supabase/admin";
 import { getActiveDeployments, isSynced } from "@/lib/content/deployments";
 import {
-  getAllAchievements,
   getAllCourseLessonCounts,
+  getDeployedAchievements,
   getLearningPathsForAdmin,
 } from "@/lib/content/queries";
 
@@ -221,8 +221,11 @@ export async function checkCommunityAchievements(
   admin: AdminClient,
   userId: string
 ): Promise<void> {
+  // Deployed-only, like the webhook award path: an un-deployed achievement
+  // unlocking here would write a user_achievements row with no tx/asset and
+  // permanently block the real on-chain award once the PDA exists.
   const [allAchievements, state, { data: unlocked }] = await Promise.all([
-    getAllAchievements(),
+    getDeployedAchievements(),
     buildUserState(admin, userId),
     admin
       .from("user_achievements")


### PR DESCRIPTION
Bumps `content.lock` to academy-courses@958e7877 (academy-courses#41). Achievements go 7 → 24 and the four live quests get repriced; no course, lesson, path or slot moves, so the course/lesson/path goldens are byte-unchanged.

Two behavioral notes:

Every one of the 17 new achievement docs needs an admin on-chain sync (deploy) before Helius can award it — the content bump alone does nothing for learners.

`achievement-early-adopter` flips from `user-number lte:100` to `manual`, so it no longer auto-fires on signup. Day one now yields one badge (first-steps, 25 XP) plus the lesson quest (20) and the lesson itself (20), instead of the old early-signup windfall. `quest-challenge` goes inactive and drops out of the active set.

Goldens regenerated through the real projectors; full web suite green (3396 tests).