### PR TITLE
feat(catalog): community-style filter rails + ink status chips

### DIFF
--- a/apps/web/src/app/[locale]/(marketing)/landing-client.tsx
+++ b/apps/web/src/app/[locale]/(marketing)/landing-client.tsx
@@ -423,8 +423,14 @@ export function LandingPageClient({
 
       <div className="flex-1">
         {/* ── Hero — the stage reacts to the cursor (parallax halo + tilt) ── */}
+        {/* The hero owns the first screen: the viewport minus the fixed
+            header's band. `min-h` and not `h`, and `dvh` and not `vh` — a
+            short laptop viewport has to be able to scroll rather than clip,
+            and mobile browser chrome must not push the section past the fold.
+            The content centres in whatever space that leaves instead of
+            gaining dead padding at the bottom. */}
         <section
-          className="relative overflow-hidden"
+          className="relative flex min-h-[calc(100dvh-var(--header-h))] items-center overflow-hidden"
           onMouseMove={handleHeroMove}
           onMouseLeave={resetHeroParallax}
         >
@@ -440,7 +446,7 @@ export function LandingPageClient({
             />
           </div>
 
-          <div className="container px-4 pb-10 pt-8 sm:pb-12 sm:pt-10 md:pb-14 md:pt-14">
+          <div className="container w-full px-4 pb-10 pt-8 sm:pb-12 sm:pt-10 md:pb-14 md:pt-14">
             <div className="mx-auto grid max-w-6xl items-center gap-12 md:grid-cols-2 md:gap-16">
               <div>
                 <div

--- a/apps/web/src/app/[locale]/(platform)/courses/courses-client.tsx
+++ b/apps/web/src/app/[locale]/(platform)/courses/courses-client.tsx
@@ -191,7 +191,7 @@ export function CourseCatalogClient({
                 placeholder={tCommon("search") + "..."}
                 value={searchQuery}
                 onChange={(e) => setSearchQuery(e.target.value)}
-                className="h-9 w-full rounded-[var(--r-md)] border-[2.5px] border-border bg-card pl-9 pr-4 text-sm text-text shadow-[var(--shadow-sm)] outline-none transition-[border-color] duration-150 placeholder:text-text-3 focus:border-primary"
+                className="h-full min-h-9 w-full rounded-[var(--r-md)] border-[2.5px] border-border bg-card pl-9 pr-4 text-sm text-text shadow-[var(--shadow-sm)] outline-none transition-[border-color] duration-150 placeholder:text-text-3 focus:border-primary"
                 aria-label={tCommon("search")}
               />
               {searchQuery && (

--- a/apps/web/src/app/[locale]/(platform)/courses/courses-client.tsx
+++ b/apps/web/src/app/[locale]/(platform)/courses/courses-client.tsx
@@ -8,11 +8,16 @@ import { SegmentedControl } from "@/components/ui/segmented-control";
 import { CourseCard } from "@/components/course/course-card";
 import { type PathCourseProgress } from "@/components/course/learning-path-section";
 import { PathsView } from "@/components/course/paths-view";
+import {
+  buildStatusMap,
+  filterCatalogCourses,
+  type CourseStatus,
+  type Difficulty,
+  type StatusFilter,
+} from "@/lib/courses/catalog-filter";
 import { useSegmentState } from "@/lib/onboarding/use-segment-state";
 import { createClient } from "@/lib/supabase/client";
 
-type Difficulty = "beginner" | "intermediate" | "advanced";
-type CourseStatus = "enrolled" | "completed";
 type ActiveTab = "all" | "paths";
 
 interface CourseCatalogClientProps {
@@ -27,6 +32,19 @@ const ALL_DIFFICULTIES: (Difficulty | "all")[] = [
   "advanced",
 ];
 
+const ALL_STATUSES: (StatusFilter | "all")[] = [
+  "all",
+  "enrolled",
+  "not-enrolled",
+  "completed",
+];
+
+const STATUS_LABEL_KEY = {
+  enrolled: "enrolled",
+  "not-enrolled": "notEnrolled",
+  completed: "completed",
+} as const satisfies Record<StatusFilter, string>;
+
 function useCourseProgress(courses: Course[]) {
   const [statuses, setStatuses] = useState<Map<string, CourseStatus>>(
     new Map()
@@ -34,6 +52,9 @@ function useCourseProgress(courses: Course[]) {
   const [progress, setProgress] = useState<Map<string, PathCourseProgress>>(
     new Map()
   );
+  // Drives whether the status rail exists at all — an anonymous visitor has no
+  // enrollment state to filter on, so the rail would be three dead options.
+  const [isSignedIn, setIsSignedIn] = useState(false);
 
   useEffect(() => {
     async function fetchData() {
@@ -42,6 +63,7 @@ function useCourseProgress(courses: Course[]) {
         data: { session },
       } = await supabase.auth.getSession();
       if (!session?.user) return;
+      setIsSignedIn(true);
 
       const [
         { data: enrollments },
@@ -50,7 +72,7 @@ function useCourseProgress(courses: Course[]) {
       ] = await Promise.all([
         supabase
           .from("enrollments")
-          .select("course_id")
+          .select("course_id, completed_at")
           .eq("user_id", session.user.id),
         supabase
           .from("certificates")
@@ -62,7 +84,10 @@ function useCourseProgress(courses: Course[]) {
           .eq("user_id", session.user.id),
       ]);
 
-      const statusMap = new Map<string, CourseStatus>();
+      const statusMap = buildStatusMap(
+        enrollments ?? [],
+        (certificates ?? []).map((row) => row.course_id)
+      );
       const progressMap = new Map<string, PathCourseProgress>();
 
       // Count completed lessons per course
@@ -74,13 +99,6 @@ function useCourseProgress(courses: Course[]) {
             (completedByCourse.get(row.course_id) ?? 0) + 1
           );
         }
-      }
-
-      for (const row of enrollments ?? []) {
-        statusMap.set(row.course_id, "enrolled");
-      }
-      for (const row of certificates ?? []) {
-        statusMap.set(row.course_id, "completed");
       }
 
       // Build progress entries enriched with total lesson counts
@@ -108,7 +126,7 @@ function useCourseProgress(courses: Course[]) {
     fetchData();
   }, [courses]);
 
-  return { statuses, progress };
+  return { statuses, progress, isSignedIn };
 }
 
 export function CourseCatalogClient({
@@ -122,20 +140,17 @@ export function CourseCatalogClient({
   const [activeDifficulty, setActiveDifficulty] = useState<Difficulty | null>(
     null
   );
-  const { statuses, progress } = useCourseProgress(courses);
+  const [activeStatus, setActiveStatus] = useState<StatusFilter | null>(null);
+  const { statuses, progress, isSignedIn } = useCourseProgress(courses);
   // Segment/goal from the /start intake (LX-A3): drives the path-page modality
   // and the goal framing line. Absent for learners who never ran the intake.
   const { segment, goal } = useSegmentState();
 
-  const filteredCourses = courses.filter((course) => {
-    const matchesSearch =
-      !searchQuery ||
-      course.title.toLowerCase().includes(searchQuery.toLowerCase()) ||
-      course.description.toLowerCase().includes(searchQuery.toLowerCase());
-    const matchesDifficulty =
-      !activeDifficulty || course.difficulty === activeDifficulty;
-    return matchesSearch && matchesDifficulty;
-  });
+  const filteredCourses = filterCatalogCourses(
+    courses,
+    { searchQuery, difficulty: activeDifficulty, status: activeStatus },
+    statuses
+  );
 
   return (
     <div className="space-y-6">
@@ -165,7 +180,7 @@ export function CourseCatalogClient({
       {/* ════════ TAB 1: ALL COURSES ════════ */}
       {activeTab === "all" && (
         <div className="space-y-3">
-          {/* Row 1: Search + Difficulty pills */}
+          {/* Row 1: search + the difficulty and status rails */}
           <div className="filter-row">
             <div className="relative w-full max-w-[400px] flex-1 sm:min-w-[200px]">
               <MagnifyingGlass
@@ -192,11 +207,10 @@ export function CourseCatalogClient({
               )}
             </div>
 
-            {/* The difficulty row is a segmented control like the community
-                filters — "All" is just the null option, so picking a segment
-                replaces the old click-the-active-one-to-clear behaviour. */}
+            {/* Two rails side by side, the community idiom (owner, 24-08):
+                segments grouped inside one bordered track, one track per axis.
+                "All" is the null option on each, and the axes compose. */}
             <SegmentedControl
-              variant="pills"
               ariaLabel={t("difficulty")}
               options={ALL_DIFFICULTIES.map((diff) => ({
                 value: diff === "all" ? null : (diff as Difficulty),
@@ -205,6 +219,24 @@ export function CourseCatalogClient({
               value={activeDifficulty}
               onChange={setActiveDifficulty}
             />
+
+            {/* Status is the learner's own relationship to a course, so it has
+                nothing to say to an anonymous visitor — the rail is absent
+                rather than disabled. */}
+            {isSignedIn && (
+              <SegmentedControl
+                ariaLabel={t("status")}
+                options={ALL_STATUSES.map((status) => ({
+                  value: status === "all" ? null : (status as StatusFilter),
+                  label:
+                    status === "all"
+                      ? tCommon("all")
+                      : t(STATUS_LABEL_KEY[status as StatusFilter]),
+                }))}
+                value={activeStatus}
+                onChange={setActiveStatus}
+              />
+            )}
           </div>
 
           {/* Course Grid */}

--- a/apps/web/src/app/[locale]/(platform)/courses/courses-client.tsx
+++ b/apps/web/src/app/[locale]/(platform)/courses/courses-client.tsx
@@ -161,21 +161,19 @@ export function CourseCatalogClient({
         <p className="mt-1 text-text-3">{t("catalogSubtitle")}</p>
       </div>
 
-      {/* Tabs */}
-      <div className="catalog-tabs">
-        <button
-          className={`catalog-tab ${activeTab === "all" ? "active" : ""}`}
-          onClick={() => setActiveTab("all")}
-        >
-          {t("allCourses")}
-        </button>
-        <button
-          className={`catalog-tab ${activeTab === "paths" ? "active" : ""}`}
-          onClick={() => setActiveTab("paths")}
-        >
-          {t("learningPaths")}
-        </button>
-      </div>
+      {/* All Courses / Learning Paths is a segmented choice like any other, so
+          it wears the same rail as the filters below it rather than its own
+          underline-tab idiom (owner, 24-08). */}
+      <SegmentedControl
+        ariaLabel={t("view")}
+        options={[
+          { value: "all" as ActiveTab, label: t("allCourses") },
+          { value: "paths" as ActiveTab, label: t("learningPaths") },
+        ]}
+        value={activeTab}
+        onChange={setActiveTab}
+        className="w-fit"
+      />
 
       {/* ════════ TAB 1: ALL COURSES ════════ */}
       {activeTab === "all" && (

--- a/apps/web/src/app/[locale]/layout.tsx
+++ b/apps/web/src/app/[locale]/layout.tsx
@@ -57,7 +57,7 @@ export default async function LocaleLayout(props: LocaleLayoutProps) {
           <AnalyticsProvider>
             <div className="grid-bg flex min-h-screen flex-col bg-[var(--bg)]">
               <Header />
-              <main id="main-content" className="flex-1 pt-[60px]">
+              <main id="main-content" className="flex-1 pt-[var(--header-h)]">
                 {children}
               </main>
               <MobileBottomNav />

--- a/apps/web/src/components/auth/user-menu.tsx
+++ b/apps/web/src/components/auth/user-menu.tsx
@@ -12,7 +12,7 @@ import {
   ShieldStar,
   SignOut,
   Trophy,
-  UserCircle,
+  User,
 } from "@phosphor-icons/react";
 import { useAmbientWallet } from "@/lib/solana/ambient-wallet-store";
 import {
@@ -181,7 +181,7 @@ export function UserMenu({
             href={`/${locale}/profile`}
             className="flex items-center gap-2 font-display text-[13px] font-semibold"
           >
-            <UserCircle size={16} weight="bold" />
+            <User size={16} weight="bold" />
             {tCommon("profile")}
           </Link>
         </DropdownMenuItem>

--- a/apps/web/src/components/auth/user-menu.tsx
+++ b/apps/web/src/components/auth/user-menu.tsx
@@ -181,7 +181,7 @@ export function UserMenu({
             href={`/${locale}/profile`}
             className="flex items-center gap-2 font-display text-[13px] font-semibold"
           >
-            <UserCircle size={14} weight="bold" />
+            <UserCircle size={16} weight="bold" />
             {tCommon("profile")}
           </Link>
         </DropdownMenuItem>
@@ -190,7 +190,7 @@ export function UserMenu({
             href={`/${locale}/certificates`}
             className="flex items-center gap-2 font-display text-[13px] font-semibold"
           >
-            <Certificate size={14} weight="bold" />
+            <Certificate size={16} weight="bold" />
             {tCommon("certificates")}
           </Link>
         </DropdownMenuItem>
@@ -199,7 +199,7 @@ export function UserMenu({
             href={`/${locale}/leaderboard?board=referrals`}
             className="flex items-center gap-2 font-display text-[13px] font-semibold"
           >
-            <Gift size={14} weight="bold" />
+            <Gift size={16} weight="bold" />
             {tGam("referrals")}
           </Link>
         </DropdownMenuItem>
@@ -210,7 +210,7 @@ export function UserMenu({
             href={`/${locale}/leaderboard`}
             className="flex items-center gap-2 font-display text-[13px] font-semibold"
           >
-            <Trophy size={14} weight="bold" />
+            <Trophy size={16} weight="bold" />
             {tNav("leaderboard")}
           </Link>
         </DropdownMenuItem>
@@ -219,7 +219,7 @@ export function UserMenu({
             href={`/${locale}/settings`}
             className="flex items-center gap-2 font-display text-[13px] font-semibold"
           >
-            <GearSix size={14} weight="bold" />
+            <GearSix size={16} weight="bold" />
             {tCommon("settings")}
           </Link>
         </DropdownMenuItem>
@@ -229,7 +229,7 @@ export function UserMenu({
               href={`/${locale}/admin`}
               className="flex items-center gap-2 font-display text-[13px] font-semibold"
             >
-              <ShieldStar size={14} weight="bold" />
+              <ShieldStar size={16} weight="bold" />
               {tNav("admin")}
             </Link>
           </DropdownMenuItem>
@@ -239,7 +239,7 @@ export function UserMenu({
           onClick={handleSignOut}
           className="flex items-center gap-2 font-display text-[13px] font-semibold"
         >
-          <SignOut size={14} weight="bold" />
+          <SignOut size={16} weight="bold" />
           {tCommon("signOut")}
         </DropdownMenuItem>
       </DropdownMenuContent>

--- a/apps/web/src/components/course/course-card.tsx
+++ b/apps/web/src/components/course/course-card.tsx
@@ -2,8 +2,9 @@
 
 import Link from "next/link";
 import Image from "next/image";
-import { CheckCircle } from "@phosphor-icons/react";
+import { Check } from "@phosphor-icons/react";
 import { useTranslations, useLocale } from "next-intl";
+import { StatusChip } from "@/components/course/status-chip";
 
 interface CourseCardProps {
   slug: string;
@@ -63,23 +64,24 @@ export function CourseCard({
           </h3>
         )}
         {status === "completed" && (
-          <span
-            className="course-card-status completed"
+          <StatusChip
+            tone="earned"
+            className="course-card-status"
             aria-label={t("completed")}
           >
-            <CheckCircle size={11} weight="fill" aria-hidden="true" />
+            <Check size={11} weight="bold" aria-hidden="true" />
             {t("completed")}
-          </span>
+          </StatusChip>
         )}
         {status === "enrolled" &&
           completedLessons !== undefined &&
           lessonCount !== undefined && (
-            <span
-              className="course-card-status enrolled"
+            <StatusChip
+              className="course-card-status"
               aria-label={`${completedLessons}/${lessonCount} ${t("lessons")}`}
             >
               {completedLessons}/{lessonCount} {t("lessons")}
-            </span>
+            </StatusChip>
           )}
       </div>
 

--- a/apps/web/src/components/course/learning-path-section.tsx
+++ b/apps/web/src/components/course/learning-path-section.tsx
@@ -6,12 +6,16 @@ import Link from "next/link";
 import {
   CaretDoubleRight,
   CaretDown,
+  Check,
+  Lightning,
   Lock,
-  CheckCircle,
 } from "@phosphor-icons/react";
 import type { LearningPath } from "@superteam-lms/types";
 import type { PathGuidanceModality } from "@/lib/courses/learner-segment";
 import { cn } from "@/lib/utils";
+import { ProgressBar } from "@/components/course/progress-bar";
+import { StatusChip } from "@/components/course/status-chip";
+import { buttonVariants } from "@/components/ui/button";
 
 export interface PathCourseProgress {
   courseId: string;
@@ -67,11 +71,6 @@ export function LearningPathSection({
 
   const totalXpPossible = courses.reduce((sum, c) => sum + c.xpReward, 0);
 
-  const progressPercent =
-    totalLessonsTotal > 0
-      ? Math.round((completedLessonsTotal / totalLessonsTotal) * 100)
-      : 0;
-
   const totalHours = courses.reduce((s, c) => s + c.duration, 0);
 
   // Sequential gate: course N is "ahead" if course N-1 is not completed.
@@ -122,13 +121,16 @@ export function LearningPathSection({
           />
         </div>
 
-        {/* Progress bar — full width hero element */}
-        <div className="path-bar-track">
-          <div
-            className="path-bar-fill"
-            style={{ width: `${progressPercent}%` }}
-          />
-        </div>
+        {/* Progress bar — the shared ink construction. Lessons are discrete and
+            the footer counts them, so the bar counts them too: one cell per
+            lesson, falling back to a smooth fill on its own past SEGMENT_CAP
+            where ticks stop being countable. */}
+        <ProgressBar
+          value={completedLessonsTotal}
+          max={totalLessonsTotal}
+          segmented
+          aria-label={`${completedLessonsTotal}/${totalLessonsTotal} ${t("lessons")}`}
+        />
 
         {/* Row 2: Stats */}
         <div className="path-header-foot">
@@ -141,8 +143,11 @@ export function LearningPathSection({
           <span>
             {totalHours} {t("hours")}
           </span>
+          {/* The dashboard's XP idiom: drawn lightning + amber display face,
+              not an emoji and not a tinted pill. */}
           <span className="path-foot-xp">
-            {"\u26A1"} {totalXpEarned.toLocaleString()} /{" "}
+            <Lightning size={12} weight="fill" aria-hidden="true" />
+            {totalXpEarned.toLocaleString()} /{" "}
             {totalXpPossible.toLocaleString()}
           </span>
         </div>
@@ -158,10 +163,6 @@ export function LearningPathSection({
             modality === "guided-skip" && ahead && idx === firstAheadIdx;
           const isComplete = p?.isCompleted ?? false;
           const isActive = (p?.isEnrolled && !p?.isCompleted) ?? false;
-          const percent =
-            p && p.totalLessons > 0
-              ? Math.round((p.completedLessons / p.totalLessons) * 100)
-              : 0;
           const lessonCount =
             course.modules?.reduce(
               (sum, m) => sum + (m.lessons?.length ?? 0),
@@ -185,24 +186,49 @@ export function LearningPathSection({
                 <div className="path-step-top">
                   <h4 className="path-step-title">{course.title}</h4>
                   {isComplete && (
-                    <span className="path-step-badge done">
-                      <CheckCircle size={11} weight="fill" /> {t("completed")}
-                    </span>
+                    <StatusChip tone="earned" size="sm">
+                      <Check size={11} weight="bold" aria-hidden="true" />
+                      {t("completed")}
+                    </StatusChip>
                   )}
                   {isActive && (
                     <>
-                      <span className="path-step-badge active">
+                      <StatusChip
+                        size="sm"
+                        aria-label={`${completedLessons}/${lessonCount} ${t("lessons")}`}
+                      >
                         {completedLessons}/{lessonCount}
-                      </span>
-                      <span className="path-step-continue">
+                      </StatusChip>
+                      {/* The row's card IS the link, so the affordances inside
+                          it are spans wearing the Button's classes — a nested
+                          <button> inside an <a> is invalid markup. */}
+                      <span
+                        className={cn(
+                          buttonVariants({ variant: "primary", size: "sm" }),
+                          "path-step-continue"
+                        )}
+                      >
                         {t("continue")}
-                        <CaretDoubleRight size={11} weight="bold" />
+                        <CaretDoubleRight
+                          size={11}
+                          weight="bold"
+                          aria-hidden="true"
+                        />
                       </span>
                     </>
                   )}
                   {skipAhead && (
-                    <span className="path-step-badge skip">
-                      <CaretDoubleRight size={11} weight="bold" />{" "}
+                    <span
+                      className={cn(
+                        buttonVariants({ variant: "secondary", size: "sm" }),
+                        "path-step-skip"
+                      )}
+                    >
+                      <CaretDoubleRight
+                        size={11}
+                        weight="bold"
+                        aria-hidden="true"
+                      />{" "}
                       {t("skipAhead")}
                     </span>
                   )}
@@ -227,17 +253,21 @@ export function LearningPathSection({
                   <span>{t(course.difficulty)}</span>
                   <span>·</span>
                   <span className="path-step-meta-xp">
-                    {"\u26A1"} {course.xpReward}
+                    <Lightning size={11} weight="fill" aria-hidden="true" />
+                    {course.xpReward}
                   </span>
                 </div>
-                {/* Slim progress bar — only for active */}
+                {/* Slim progress bar — only for active. The same construction
+                    as the path bar above it, one step down in height. */}
                 {isActive && (
-                  <div className="path-step-progress">
-                    <div
-                      className="path-step-fill"
-                      style={{ width: `${percent}%` }}
-                    />
-                  </div>
+                  <ProgressBar
+                    value={completedLessons}
+                    max={lessonCount}
+                    segmented
+                    size="slim"
+                    className="mt-1.5"
+                    aria-label={`${completedLessons}/${lessonCount} ${t("lessons")}`}
+                  />
                 )}
               </div>
             </div>
@@ -247,7 +277,7 @@ export function LearningPathSection({
             <div key={course._id} className={`path-step ${stepStatus}`}>
               <div className="path-step-node" aria-hidden="true">
                 {isComplete ? (
-                  <CheckCircle size={16} weight="fill" />
+                  <Check size={16} weight="bold" />
                 ) : locked ? (
                   <Lock size={14} weight="duotone" />
                 ) : (

--- a/apps/web/src/components/course/status-chip.tsx
+++ b/apps/web/src/components/course/status-chip.tsx
@@ -1,0 +1,51 @@
+import type { ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+/**
+ * The learner-status chip — "10/15 LESSONS", "COMPLETED", and their siblings
+ * wherever a course's state is stamped on a surface.
+ *
+ * ONE component rather than two matching stylesheets: the catalog card's
+ * banner and the learning-path timeline row had grown their own translucent
+ * pills (`.course-card-status`, `.path-step-badge`) and drifted apart twice.
+ * They are the same statement about the same course, so they are now the same
+ * object — a `.chip` sized for a label: solid fill, literal ink outline, hard
+ * lift, bold caps.
+ *
+ * The ink is the literal dark one on BOTH grounds, like the glyph chips and
+ * the avatar rings: the card variant is drawn on arbitrary cover art, so there
+ * is no themed ground for a flipping line to agree with.
+ */
+export type StatusChipTone = "neutral" | "earned";
+
+export function StatusChip({
+  tone = "neutral",
+  size = "md",
+  className,
+  children,
+  "aria-label": ariaLabel,
+}: {
+  /**
+   * `earned` is a positive, finished state (COMPLETED) and takes the primary
+   * pair — the same green as a pressed segment and a primary button, so it is
+   * the light theme's dark green and the dark theme's mint. `neutral` is
+   * informational (a lesson count) and stays the cream plate.
+   */
+  tone?: StatusChipTone;
+  /** `sm` is the timeline row; `md` is the card banner. */
+  size?: "sm" | "md";
+  className?: string;
+  children: ReactNode;
+  "aria-label"?: string;
+}) {
+  return (
+    <span
+      className={cn("status-chip", className)}
+      data-tone={tone}
+      data-size={size}
+      aria-label={ariaLabel}
+    >
+      {children}
+    </span>
+  );
+}

--- a/apps/web/src/components/ui/segmented-control.tsx
+++ b/apps/web/src/components/ui/segmented-control.tsx
@@ -16,7 +16,13 @@ import { cn } from "@/lib/utils";
  *
  * Silhouette is a real difference rather than a cosmetic one, so it stays a
  * prop: `track` groups segments inside one bordered rail (community), `pills`
- * leaves them free-standing and round (catalog).
+ * leaves them free-standing and round.
+ *
+ * `pills` currently has NO consumer — the catalog was its only one and moved
+ * to `track` on the owner's 24-08 ruling, so both of its filter rails read as
+ * the community's grouped rails. It stays because it is the shape half of the
+ * control's API, exercised by the tests, and deleting it would make the next
+ * free-standing row reinvent it.
  *
  * Options are addressed by INDEX, not by value, because the "All" option is
  * legitimately `null`/`undefined` on both consumers and would otherwise need a

--- a/apps/web/src/lib/courses/__tests__/catalog-filter.test.ts
+++ b/apps/web/src/lib/courses/__tests__/catalog-filter.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildStatusMap,
+  filterCatalogCourses,
+  matchesStatus,
+  type CatalogCourse,
+  type CourseStatus,
+} from "../catalog-filter";
+
+const courses: CatalogCourse[] = [
+  {
+    _id: "c-intro",
+    title: "Solana Intro",
+    description: "Start here",
+    difficulty: "beginner",
+  },
+  {
+    _id: "c-anchor",
+    title: "Anchor Programs",
+    description: "Write a program",
+    difficulty: "intermediate",
+  },
+  {
+    _id: "c-defi",
+    title: "DeFi Deep Dive",
+    description: "Advanced Solana DeFi",
+    difficulty: "advanced",
+  },
+];
+
+const statuses = buildStatusMap(
+  [
+    { course_id: "c-intro", completed_at: "2026-08-01T00:00:00Z" },
+    { course_id: "c-anchor", completed_at: null },
+  ],
+  []
+);
+
+const ids = (rows: CatalogCourse[]) => rows.map((c) => c._id);
+const noFilters = {
+  searchQuery: "",
+  difficulty: null,
+  status: null,
+} as const;
+
+describe("buildStatusMap", () => {
+  it("classifies enrolled, completed and not-enrolled", () => {
+    expect(statuses.get("c-intro")).toBe("completed");
+    expect(statuses.get("c-anchor")).toBe("enrolled");
+    expect(statuses.get("c-defi")).toBeUndefined();
+  });
+
+  it("treats a minted certificate as completion even without completed_at", () => {
+    const map = buildStatusMap(
+      [{ course_id: "c-anchor", completed_at: null }],
+      ["c-anchor"]
+    );
+    expect(map.get("c-anchor")).toBe("completed");
+  });
+
+  it("is empty for an anonymous visitor", () => {
+    expect(buildStatusMap([], []).size).toBe(0);
+  });
+});
+
+describe("matchesStatus", () => {
+  const cases: [
+    CourseStatus | undefined,
+    "enrolled" | "not-enrolled" | "completed",
+    boolean,
+  ][] = [
+    ["enrolled", "enrolled", true],
+    ["completed", "enrolled", false],
+    [undefined, "enrolled", false],
+    [undefined, "not-enrolled", true],
+    ["enrolled", "not-enrolled", false],
+    ["completed", "completed", true],
+    ["enrolled", "completed", false],
+  ];
+
+  it.each(cases)("status %s under filter %s → %s", (status, filter, want) => {
+    expect(matchesStatus(status, filter)).toBe(want);
+  });
+
+  it("passes everything when the rail is on All", () => {
+    expect(matchesStatus(undefined, null)).toBe(true);
+    expect(matchesStatus("completed", null)).toBe(true);
+  });
+});
+
+describe("filterCatalogCourses", () => {
+  it("returns everything with no filter active", () => {
+    expect(ids(filterCatalogCourses(courses, noFilters, statuses))).toEqual([
+      "c-intro",
+      "c-anchor",
+      "c-defi",
+    ]);
+  });
+
+  it("ANDs difficulty with status", () => {
+    expect(
+      ids(
+        filterCatalogCourses(
+          courses,
+          { ...noFilters, difficulty: "intermediate", status: "enrolled" },
+          statuses
+        )
+      )
+    ).toEqual(["c-anchor"]);
+
+    expect(
+      filterCatalogCourses(
+        courses,
+        { ...noFilters, difficulty: "beginner", status: "enrolled" },
+        statuses
+      )
+    ).toHaveLength(0);
+  });
+
+  it("ANDs search with both rails", () => {
+    expect(
+      ids(
+        filterCatalogCourses(
+          courses,
+          {
+            searchQuery: "deep dive",
+            difficulty: "advanced",
+            status: "not-enrolled",
+          },
+          statuses
+        )
+      )
+    ).toEqual(["c-defi"]);
+
+    expect(
+      filterCatalogCourses(
+        courses,
+        { searchQuery: "anchor", difficulty: "advanced", status: null },
+        statuses
+      )
+    ).toHaveLength(0);
+  });
+
+  it("matches search against the description too, case-insensitively", () => {
+    expect(
+      ids(
+        filterCatalogCourses(
+          courses,
+          { ...noFilters, searchQuery: "  WRITE a Program " },
+          statuses
+        )
+      )
+    ).toEqual(["c-anchor"]);
+  });
+
+  it("shows every course as not-enrolled when there is no session", () => {
+    expect(
+      ids(
+        filterCatalogCourses(
+          courses,
+          { ...noFilters, status: "not-enrolled" },
+          new Map()
+        )
+      )
+    ).toEqual(["c-intro", "c-anchor", "c-defi"]);
+  });
+});

--- a/apps/web/src/lib/courses/catalog-filter.ts
+++ b/apps/web/src/lib/courses/catalog-filter.ts
@@ -1,0 +1,87 @@
+/**
+ * Catalog filtering — the search box, the difficulty rail and the status rail
+ * resolved in one place so the composition rule (AND across every active axis)
+ * is testable without mounting the page.
+ *
+ * "Status" is the signed-in learner's relationship to a course, which the
+ * catalog already reads client-side: an `enrollments` row means enrolled, a
+ * `completed_at` on that row (written by the on-chain finalize webhook) or a
+ * minted certificate means completed. Both completion signals count — a
+ * learner holding a credential is finished whether or not the webhook landed.
+ */
+
+export type Difficulty = "beginner" | "intermediate" | "advanced";
+
+/** What the card shows. `undefined` = the learner has no relationship. */
+export type CourseStatus = "enrolled" | "completed";
+
+/** The status rail's options. `null` is its "All". */
+export type StatusFilter = "enrolled" | "not-enrolled" | "completed";
+
+export interface EnrollmentRow {
+  course_id: string;
+  completed_at: string | null;
+}
+
+export interface CatalogCourse {
+  _id: string;
+  title: string;
+  description: string;
+  difficulty: Difficulty;
+}
+
+/**
+ * Course id → status, from the two session-scoped reads the catalog already
+ * makes. Courses absent from the map are "not enrolled".
+ */
+export function buildStatusMap(
+  enrollments: readonly EnrollmentRow[],
+  certificateCourseIds: readonly string[]
+): Map<string, CourseStatus> {
+  const statuses = new Map<string, CourseStatus>();
+  for (const row of enrollments) {
+    statuses.set(row.course_id, row.completed_at ? "completed" : "enrolled");
+  }
+  for (const courseId of certificateCourseIds) {
+    statuses.set(courseId, "completed");
+  }
+  return statuses;
+}
+
+export function matchesStatus(
+  status: CourseStatus | undefined,
+  filter: StatusFilter | null
+): boolean {
+  if (!filter) return true;
+  if (filter === "not-enrolled") return status === undefined;
+  return status === filter;
+}
+
+export function matchesSearch(course: CatalogCourse, query: string): boolean {
+  const q = query.trim().toLowerCase();
+  if (!q) return true;
+  return (
+    course.title.toLowerCase().includes(q) ||
+    course.description.toLowerCase().includes(q)
+  );
+}
+
+export interface CatalogFilters {
+  searchQuery: string;
+  difficulty: Difficulty | null;
+  status: StatusFilter | null;
+}
+
+/** Every active axis must match — the rails compose, they do not replace. */
+export function filterCatalogCourses<T extends CatalogCourse>(
+  courses: readonly T[],
+  filters: CatalogFilters,
+  statuses: ReadonlyMap<string, CourseStatus>
+): T[] {
+  return courses.filter(
+    (course) =>
+      matchesSearch(course, filters.searchQuery) &&
+      (!filters.difficulty || course.difficulty === filters.difficulty) &&
+      matchesStatus(statuses.get(course._id), filters.status)
+  );
+}

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -212,6 +212,8 @@
     "modules": "modules",
     "enrolled": "Enrolled",
     "completed": "Completed",
+    "status": "Status",
+    "notEnrolled": "Not enrolled",
     "inProgress": "In Progress",
     "continueCourse": "Continue Learning",
     "enrollNow": "Enroll Now",

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -214,6 +214,7 @@
     "completed": "Completed",
     "status": "Status",
     "notEnrolled": "Not enrolled",
+    "view": "View",
     "inProgress": "In Progress",
     "continueCourse": "Continue Learning",
     "enrollNow": "Enroll Now",

--- a/apps/web/src/messages/es.json
+++ b/apps/web/src/messages/es.json
@@ -214,6 +214,7 @@
     "completed": "Completado",
     "status": "Estado",
     "notEnrolled": "No inscrito",
+    "view": "Vista",
     "inProgress": "En Progreso",
     "continueCourse": "Continuar Aprendiendo",
     "enrollNow": "Inscribirse",

--- a/apps/web/src/messages/es.json
+++ b/apps/web/src/messages/es.json
@@ -212,6 +212,8 @@
     "modules": "módulos",
     "enrolled": "Inscrito",
     "completed": "Completado",
+    "status": "Estado",
+    "notEnrolled": "No inscrito",
     "inProgress": "En Progreso",
     "continueCourse": "Continuar Aprendiendo",
     "enrollNow": "Inscribirse",

--- a/apps/web/src/messages/pt-BR.json
+++ b/apps/web/src/messages/pt-BR.json
@@ -214,6 +214,7 @@
     "completed": "Concluído",
     "status": "Status",
     "notEnrolled": "Não matriculado",
+    "view": "Exibição",
     "inProgress": "Em Andamento",
     "continueCourse": "Continuar Aprendendo",
     "enrollNow": "Matricular-se",

--- a/apps/web/src/messages/pt-BR.json
+++ b/apps/web/src/messages/pt-BR.json
@@ -212,6 +212,8 @@
     "modules": "módulos",
     "enrolled": "Matriculado",
     "completed": "Concluído",
+    "status": "Status",
+    "notEnrolled": "Não matriculado",
     "inProgress": "Em Andamento",
     "continueCourse": "Continuar Aprendendo",
     "enrollNow": "Matricular-se",

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -2441,14 +2441,15 @@
      card colour and then sat on top of arbitrary cover art — over a light
      photo the old enrolled chip was near-invisible.
 
-     The ink is the LITERAL dark one on BOTH grounds, like the chips, the
+     The OUTLINE is the literal dark ink on BOTH grounds, like the chips, the
      avatar rings and the filled buttons: this badge is drawn on a photograph,
      not on a themed surface, so there is no ground for a flipping line to
-     agree with. Fills are literals for the same reason, which also means the
-     chip looks identical in light and dark — deliberate.
+     agree with, and a cream ring would disappear into a light banner.
 
-     Contrast is carried by the fill, not the art: #19231b on mint (#2ecc8e)
-     is 8.6:1 and on cream (#fafaf7) 16.6:1, so both hold over any banner. */
+     Contrast is carried by the fill, never by the art underneath — the neutral
+     chip is #19231b on cream (#fafaf7), 16.6:1, and the earned one inherits
+     the primary pair below. Both hold over a photo and over the Forge banner's
+     flat orange. */
   .course-card-status {
     position: absolute;
     top: 10px;
@@ -2471,10 +2472,14 @@
     font-variant-numeric: tabular-nums;
     white-space: nowrap;
   }
-  /* Earned: the mint the `course` patch category already uses for a finished
-     course, so a completed card and a course patch read as the same event. */
+  /* Earned. Colour comes from the primary tokens — the same pair `.pressed-key`
+     and the primary Button read — so a COMPLETED chip and a selected "All" key
+     are the same green on the same page: the light theme's dark green under a
+     white label, the dark theme's mint. A literal mint was tried first (owner,
+     24-08) and read as a foreign brightness beside the light-theme rails. */
   .course-card-status.completed {
-    background: var(--ink-green);
+    background: var(--primary);
+    color: var(--primary-fg);
   }
   /* In progress is informational, not an award — the neutral cream plate. */
   .course-card-status.enrolled {

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -2434,7 +2434,21 @@
     color: var(--text-3);
   }
 
-  /* Status badge — corner pill */
+  /* ── Status chip — the corner badge on a card banner ──────────
+     The `.chip` construction, sized for a label instead of a glyph: solid
+     fill, literal ink outline, hard offset shadow, caps label. It replaces a
+     translucent `color-mix(… , var(--card))` pill that inherited the theme's
+     card colour and then sat on top of arbitrary cover art — over a light
+     photo the old enrolled chip was near-invisible.
+
+     The ink is the LITERAL dark one on BOTH grounds, like the chips, the
+     avatar rings and the filled buttons: this badge is drawn on a photograph,
+     not on a themed surface, so there is no ground for a flipping line to
+     agree with. Fills are literals for the same reason, which also means the
+     chip looks identical in light and dark — deliberate.
+
+     Contrast is carried by the fill, not the art: #19231b on mint (#2ecc8e)
+     is 8.6:1 and on cream (#fafaf7) 16.6:1, so both hold over any banner. */
   .course-card-status {
     position: absolute;
     top: 10px;
@@ -2444,28 +2458,27 @@
     align-items: center;
     gap: 4px;
     width: fit-content;
-    padding: 3px 10px;
-    border-radius: 999px;
-    border: 2px solid currentColor;
-    /* Brand guide pill spec: Nunito 700 · caps · 11px · +0.4px · tabular */
+    padding: 3px 9px 4px;
+    border-radius: 7px;
+    border: 1.5px solid var(--ink-dark);
+    box-shadow: 0 1.5px 0 0 var(--ink-dark);
+    color: var(--ink-dark);
     font-family: var(--font-display, var(--font-d));
     font-size: 11px;
-    font-weight: 700;
+    font-weight: 800;
     text-transform: uppercase;
     letter-spacing: 0.4px;
     font-variant-numeric: tabular-nums;
     white-space: nowrap;
   }
-  /* Solid card-colored fill — these sit on top of the (dark) cover image */
+  /* Earned: the mint the `course` patch category already uses for a finished
+     course, so a completed card and a course patch read as the same event. */
   .course-card-status.completed {
-    color: var(--success, #22c55e);
-    border-color: color-mix(in srgb, var(--success, #22c55e) 35%, transparent);
-    background: color-mix(in srgb, var(--success, #22c55e) 10%, var(--card));
+    background: var(--ink-green);
   }
+  /* In progress is informational, not an award — the neutral cream plate. */
   .course-card-status.enrolled {
-    color: var(--primary);
-    border-color: color-mix(in srgb, var(--primary) 35%, transparent);
-    background: color-mix(in srgb, var(--primary) 10%, var(--card));
+    background: var(--ink-cream);
   }
 }
 

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -2915,6 +2915,20 @@ a.path-step-card:active {
   letter-spacing: 0.4px;
   font-size: 11px;
 }
+/* A deliberate path-context exception to the "mint retired on dark buttons"
+   rule (owner call, 24-08). Everything around this button on a timeline row is
+   mint on dark — the COMPLETED chip, the segmented bars, the ✓ disc — and the
+   deep-green button was the only thing in the group speaking a different
+   green. Scoped to this row only: `.btn-ink--primary` is untouched, so every
+   other primary button in the app keeps the dark spec. White on mint is the
+   accepted tradeoff here, the same one the chip already makes. */
+[data-theme="dark"] .path-step-continue.btn-ink--primary {
+  background: var(--primary);
+  color: var(--primary-fg);
+}
+[data-theme="dark"] .path-step-continue.btn-ink--primary:hover:not(:disabled) {
+  background: var(--primary-hover, var(--primary));
+}
 .path-step-skip {
   flex-shrink: 0;
   text-transform: uppercase;

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -145,6 +145,12 @@
     --r-xl: 22px;
     --r-full: 999px;
 
+    /* The fixed header's reserved band — the offset `main` pads by and the
+       amount a full-viewport section has to subtract. One token so a header
+       resize cannot leave the landing hero overflowing by exactly its own
+       chrome. The bar itself is 56px; the extra 4px is the gap under it. */
+    --header-h: 60px;
+
     /* ── Shadows ── */
     --shadow: 0 1px 3px rgba(0, 0, 0, 0.06), 0 2px 0 0 rgba(0, 0, 0, 0.06);
     --shadow-hover: 0 4px 0 0 rgba(0, 0, 0, 0.08);

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -4304,9 +4304,7 @@ a.stat-receipt:active {
   display: none;
   align-items: center;
   gap: 2px;
-  /* Extra room at the bottom for the active item's 3px lift, which would
-     otherwise land flush against the bar's inner edge. */
-  padding: 3px 3px 6px;
+  padding: 3px;
   border-radius: 9999px;
   background: var(--card-glass-blur);
   border: 1px solid var(--border);
@@ -4344,12 +4342,7 @@ a.stat-receipt:active {
   display: flex;
   align-items: center;
   gap: 7px;
-  /* The transparent border is carried by EVERY item, active or not, so the
-     active one's ink outline costs no layout and nothing shifts as the current
-     page changes. Padding is reduced by the border width to keep the bar the
-     height it was. */
-  padding: 3px 11px;
-  border: 2px solid transparent;
+  padding: 5px 13px;
   border-radius: 9999px;
   font-size: 13px;
   font-weight: 600;
@@ -4363,17 +4356,19 @@ a.stat-receipt:active {
   color: var(--text-2);
   background: var(--card-hover);
 }
-/* Active — the ink lift on the tint (owner, option B, 24-08). The tint fill
-   and the label colour are unchanged; what is new is the chip family's
-   construction on top of them: a literal dark ink outline on BOTH grounds and
-   a hard offset shadow, so the current page reads as a raised object rather
-   than as a coloured glow. The two soft glow shadows this replaces (one per
-   theme) were the last light-source effect in the header. */
 .nav-link.active {
   color: var(--primary);
   background: var(--primary-dim);
-  border-color: var(--ink-dark);
-  box-shadow: 0 3px 0 0 var(--ink-dark);
+  box-shadow:
+    0 0 12px rgba(46, 204, 142, 0.12),
+    inset 0 1px 0 rgba(46, 204, 142, 0.08);
+}
+
+/* Light mode adjustments */
+:root .nav-link.active {
+  box-shadow:
+    0 0 8px rgba(10, 112, 85, 0.1),
+    inset 0 1px 0 rgba(10, 112, 85, 0.06);
 }
 
 /* ═══════════════════════════════════════════════════════════════

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -2434,35 +2434,34 @@
     color: var(--text-3);
   }
 
-  /* ── Status chip — the corner badge on a card banner ──────────
-     The `.chip` construction, sized for a label instead of a glyph: solid
-     fill, literal ink outline, hard offset shadow, caps label. It replaces a
-     translucent `color-mix(… , var(--card))` pill that inherited the theme's
-     card colour and then sat on top of arbitrary cover art — over a light
-     photo the old enrolled chip was near-invisible.
+  /* ── Status chip — `StatusChip`, the one learner-status stamp ──
+     The `.chip` construction sized for a label instead of a glyph: solid fill,
+     literal ink outline, hard offset shadow, caps label. It replaces two
+     separate translucent pills — the card banner's and the path timeline's —
+     that each did `color-mix(…, var(--card))`, inherited the theme's card
+     colour, and then sat on top of arbitrary cover art. Over a light photo the
+     old enrolled pill was near-invisible.
 
-     The OUTLINE is the literal dark ink on BOTH grounds, like the chips, the
-     avatar rings and the filled buttons: this badge is drawn on a photograph,
-     not on a themed surface, so there is no ground for a flipping line to
-     agree with, and a cream ring would disappear into a light banner.
+     The OUTLINE is the literal dark ink on BOTH grounds, like the glyph chips,
+     the avatar rings and the filled buttons: the card variant is drawn on a
+     photograph, not on a themed surface, so there is no ground for a flipping
+     line to agree with, and a cream ring would vanish into a light banner.
 
-     Contrast is carried by the fill, never by the art underneath — the neutral
-     chip is #19231b on cream (#fafaf7), 16.6:1, and the earned one inherits
-     the primary pair below. Both hold over a photo and over the Forge banner's
-     flat orange. */
-  .course-card-status {
-    position: absolute;
-    top: 10px;
-    right: 10px;
-    z-index: 2;
+     Contrast is carried by the fill, never by the art underneath: the neutral
+     chip is #19231b on cream (#fafaf7), 16.6:1, and the earned one is the
+     primary pair (white on #0a7055 light, on #2ecc8e dark). Both hold over a
+     photo and over the Forge banner's flat orange. */
+  .status-chip {
     display: inline-flex;
     align-items: center;
     gap: 4px;
     width: fit-content;
+    flex-shrink: 0;
     padding: 3px 9px 4px;
     border-radius: 7px;
     border: 1.5px solid var(--ink-dark);
     box-shadow: 0 1.5px 0 0 var(--ink-dark);
+    background: var(--ink-cream);
     color: var(--ink-dark);
     font-family: var(--font-display, var(--font-d));
     font-size: 11px;
@@ -2472,18 +2471,28 @@
     font-variant-numeric: tabular-nums;
     white-space: nowrap;
   }
+  /* The compact step of the same chip — timeline rows, not card banners. */
+  .status-chip[data-size="sm"] {
+    padding: 2px 8px 3px;
+    border-radius: 6px;
+    font-size: 10px;
+  }
   /* Earned. Colour comes from the primary tokens — the same pair `.pressed-key`
      and the primary Button read — so a COMPLETED chip and a selected "All" key
      are the same green on the same page: the light theme's dark green under a
      white label, the dark theme's mint. A literal mint was tried first (owner,
      24-08) and read as a foreign brightness beside the light-theme rails. */
-  .course-card-status.completed {
+  .status-chip[data-tone="earned"] {
     background: var(--primary);
     color: var(--primary-fg);
   }
-  /* In progress is informational, not an award — the neutral cream plate. */
-  .course-card-status.enrolled {
-    background: var(--ink-cream);
+
+  /* Placement only — the chip itself is `.status-chip`. */
+  .course-card-status {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    z-index: 2;
   }
 }
 
@@ -2491,35 +2500,11 @@
    COURSE CATALOG — tabs, path filter pills, learning path sections
 ═══════════════════════════════════════════════════════════════ */
 
-/* ── Catalog tabs ── */
-.catalog-tabs {
-  display: flex;
-  gap: 4px;
-  overflow-x: auto;
-}
-.catalog-tab {
-  font-family: var(--font-display, var(--font-d));
-  font-weight: 800;
-  font-size: 14px;
-  padding: 12px 20px;
-  min-height: 44px;
-  border: none;
-  background: none;
-  color: var(--text-3);
-  cursor: pointer;
-  border-bottom: 3px solid transparent;
-  transition: all 0.15s;
-  white-space: nowrap;
-}
-.catalog-tab:hover {
-  color: var(--text);
-}
-.catalog-tab.active {
-  color: var(--primary);
-  border-bottom-color: var(--primary);
-}
+/* The All Courses / Learning Paths switcher was an underline-tab family here
+   (`.catalog-tabs` / `.catalog-tab`). It is a segmented choice, so it now uses
+   the shared `SegmentedControl` track like the filter rails under it. */
 
-/* ── Filter row layout (search + pills on same row) ── */
+/* ── Filter row layout (search + rails on the same row) ── */
 .filter-row {
   display: flex;
   align-items: center;
@@ -2655,16 +2640,20 @@
   }
 }
 
+/* The path's kind ("FOUNDATION") — informational, so it takes the neutral ink
+   chip the course cards use: cream plate, literal ink outline, hard lift. */
 .path-tag {
   font-family: var(--font-mono, var(--font-m));
-  font-weight: 600;
+  font-weight: 700;
   font-size: 10px;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  padding: 3px 10px;
-  border-radius: 99px;
-  border: 1.5px solid var(--border);
-  color: var(--text-3);
+  padding: 2px 8px 3px;
+  border-radius: 6px;
+  border: 1.5px solid var(--ink-dark);
+  box-shadow: 0 1.5px 0 0 var(--ink-dark);
+  background: var(--ink-cream);
+  color: var(--ink-dark);
 }
 
 .path-chevron {
@@ -2676,7 +2665,7 @@
   transform: rotate(180deg);
 }
 
-/* The path bar itself is the progress standard — see `.path-bar-track` in the
+/* The path bar is the shared `ProgressBar` — see `.seg-track` in the
    progress-bar block next to `.dash-xp-track`. */
 
 /* Row 2: Stats footer */
@@ -2697,13 +2686,21 @@
   font-size: 14px;
   line-height: 1;
 }
+/* The XP counter is the dashboard's `.dq-reward` idiom — drawn lightning plus
+   an amber display face. It was an emoji floating on the row; the amber accent
+   survives, the bare emoji does not. */
 .path-foot-xp {
   margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
   font-family: var(--font-display, var(--font-d));
   font-weight: 800;
   font-size: 13px;
   color: var(--xp);
   letter-spacing: -0.3px;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
 }
 
 /* ═══════════════════════════════════════════════
@@ -2752,7 +2749,10 @@
   position: relative;
 }
 
-/* ── Node circle (bigger, bolder) ── */
+/* ── Step disc — the round `.chip` at 36px ──────────────────────
+   Flat fill, literal ink outline, hard offset lift, mono mark. A step is the
+   same kind of object as a glyph chip or a patch, so it is drawn the same way
+   rather than as a soft circle with a tinted border. */
 .path-step-node {
   width: 36px;
   height: 36px;
@@ -2763,39 +2763,51 @@
   font-family: var(--font-mono, var(--font-m));
   font-weight: 700;
   font-size: 13px;
-  color: var(--text-3);
-  background: var(--card);
-  border: 2.5px solid var(--border);
+  color: var(--ink-dark);
+  background: var(--ink-cream);
+  border: 2px solid var(--ink-dark);
+  box-shadow: 0 2px 0 0 var(--ink-dark);
   position: relative;
   z-index: 2;
   align-self: start;
   margin-top: 16px;
-  transition: all 0.25s ease;
+  transition:
+    background 0.25s ease,
+    color 0.25s ease;
 }
 
-/* State: done — universal green */
+/* Done — the same earned green as the COMPLETED chip, from the primary pair. */
 .path-step.done .path-step-node {
-  background: var(--success, #22c55e);
-  color: #fff;
-  border-color: transparent;
+  background: var(--primary);
+  color: var(--primary-fg);
 }
 
-/* State: active — pulsing XP glow */
+/* Active — the amber XP accent, the one place on this rail that pulses. The
+   glow is layered ON TOP of the disc's own hard lift, which stays. */
 .path-step.active .path-step-node {
   background: var(--xp);
-  color: #1a1a1a;
-  border-color: var(--xp);
   font-weight: 800;
-  box-shadow: 0 0 0 5px color-mix(in srgb, var(--xp) 22%, transparent);
   animation: node-pulse 2.5s ease-in-out infinite;
 }
 @keyframes node-pulse {
   0%,
   100% {
-    box-shadow: 0 0 0 5px color-mix(in srgb, var(--xp) 22%, transparent);
+    box-shadow:
+      0 2px 0 0 var(--ink-dark),
+      0 0 0 5px color-mix(in srgb, var(--xp) 22%, transparent);
   }
   50% {
-    box-shadow: 0 0 0 10px color-mix(in srgb, var(--xp) 8%, transparent);
+    box-shadow:
+      0 2px 0 0 var(--ink-dark),
+      0 0 0 10px color-mix(in srgb, var(--xp) 8%, transparent);
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .path-step.active .path-step-node {
+    animation: none;
+    box-shadow:
+      0 2px 0 0 var(--ink-dark),
+      0 0 0 5px color-mix(in srgb, var(--xp) 22%, transparent);
   }
 }
 
@@ -2889,56 +2901,25 @@ a.path-step-card:active {
   text-overflow: ellipsis;
 }
 
-/* Status badges — compact */
-.path-step-badge {
-  flex-shrink: 0;
-  display: inline-flex;
-  align-items: center;
-  gap: 3px;
-  /* Brand guide pill spec: Nunito 700 · caps · +0.4px · tabular */
-  font-family: var(--font-display, var(--font-d));
-  font-size: 10px;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.4px;
-  font-variant-numeric: tabular-nums;
-  border-radius: 99px;
-  padding: 2px 8px;
-  border: 1.5px solid;
-  white-space: nowrap;
-}
-.path-step-badge.done {
-  color: var(--success, #22c55e);
-  border-color: color-mix(in srgb, var(--success, #22c55e) 30%, transparent);
-  background: color-mix(in srgb, var(--success, #22c55e) 8%, transparent);
-}
-.path-step-badge.active {
-  color: var(--primary);
-  border-color: color-mix(in srgb, var(--primary) 30%, transparent);
-  background: color-mix(in srgb, var(--primary) 8%, transparent);
-}
+/* The row's COMPLETED and lesson-count badges are `StatusChip` at `size="sm"`
+   — literally the component the catalog cards use, not a matching copy. The
+   old `.path-step-badge` family lived here and drifted from the card twice. */
 
-/* Continue chip — the one filled action on the timeline (active row only) */
+/* Continue — the one filled action on the timeline (active row only). It is
+   the Button primitive's classes on a span, so it cannot drift from a real
+   primary button; only the row placement lives here. */
 .path-step-continue {
   flex-shrink: 0;
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
   margin-left: auto;
-  padding: 4px 12px;
-  border-radius: 99px;
-  background: var(--primary);
-  color: #fff;
-  font-family: var(--font-display, var(--font-d));
-  font-size: 11px;
-  font-weight: 800;
   text-transform: uppercase;
   letter-spacing: 0.4px;
-  white-space: nowrap;
-  transition: background 0.15s ease;
+  font-size: 11px;
 }
-a.path-step-card:hover .path-step-continue {
-  background: var(--primary-hover, var(--primary));
+.path-step-skip {
+  flex-shrink: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+  font-size: 10px;
 }
 
 .path-step-lock {
@@ -2956,37 +2937,15 @@ a.path-step-card:hover .path-step-continue {
   flex-wrap: wrap;
 }
 .path-step-meta-xp {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
   color: var(--xp);
   font-weight: 700;
 }
 
-/* Slim progress bar — active step only */
-.path-step-progress {
-  height: 3px;
-  background: var(--subtle);
-  border-radius: 99px;
-  overflow: hidden;
-  margin-top: 6px;
-}
-.path-step-fill {
-  height: 100%;
-  border-radius: 99px;
-  position: relative;
-  overflow: hidden;
-  transition: width 0.6s cubic-bezier(0.22, 1, 0.36, 1);
-}
-.path-step-fill::after {
-  content: "";
-  position: absolute;
-  inset: 0;
-  background: linear-gradient(
-    90deg,
-    transparent 0%,
-    rgba(255, 255, 255, 0.35) 50%,
-    transparent 100%
-  );
-  animation: shimmer 2.2s ease-in-out infinite;
-}
+/* The active row's own bar is `ProgressBar size="slim"` — the shared ink
+   construction, not a 3px tinted line with a shimmer sweep. */
 
 /* ── Staggered reveal ── */
 .path-section.open .path-step {
@@ -3019,22 +2978,6 @@ a.path-step-card:hover .path-step-continue {
     opacity: 1;
     transform: translateY(0);
   }
-}
-
-/* Step progress bar — universal primary color */
-.path-step-fill {
-  background: var(--primary);
-}
-
-/* ── Skip-ahead badge (LX-A7 guided-skip modality) ── */
-.path-step-badge.skip {
-  color: var(--text-3);
-  border-color: var(--border);
-  background: var(--subtle);
-}
-a.path-step-card:hover .path-step-badge.skip {
-  color: var(--text);
-  border-color: var(--border-hover);
 }
 
 /* ═══ PATHS VIEW — guidance row + start-here card (LX-A7) ═══ */
@@ -4518,15 +4461,13 @@ a.stat-receipt:active {
    once, on every construction that uses them, so a value can never drift
    between the XP bar, the segmented lesson bars and the path bar. */
 .dash-xp-track,
-.seg-track,
-.path-bar-track {
+.seg-track {
   --xpbar-ink: #19231b;
   --xpbar-track: rgba(25, 35, 27, 0.12);
   --xpbar-fill: #2ecc8e;
 }
 [data-theme="dark"] .dash-xp-track,
-[data-theme="dark"] .seg-track,
-[data-theme="dark"] .path-bar-track {
+[data-theme="dark"] .seg-track {
   --xpbar-ink: var(--ink-line);
   /* The unfilled remainder of the bar is a fill; keep it bright-derived. Mint
      stays the FILLED portion — the spec retires mint as a button fill only. */
@@ -4600,26 +4541,10 @@ a.stat-receipt:active {
   }
 }
 
-/* ── Learning-path bar — smooth, never segmented: a path spans whole courses,
-   so ticks would read as lessons and mislead. ── */
-.path-bar-track {
-  width: 100%;
-  height: 10px;
-  background: var(--xpbar-track);
-  border: 2px solid var(--xpbar-ink);
-  border-radius: var(--r-full);
-  overflow: hidden;
-}
-.path-bar-fill {
-  height: 100%;
-  background: var(--xpbar-fill);
-  transition: width 1s cubic-bezier(0.4, 0, 0.2, 1);
-}
-@media (prefers-reduced-motion: reduce) {
-  .path-bar-fill {
-    transition: none;
-  }
-}
+/* The learning-path header bar was its own smooth `.path-bar-track` here. It
+   is now the shared `ProgressBar`: the path footer counts lessons, so the bar
+   counts them too, and `SEGMENT_CAP` decides ticks vs. smooth fill instead of
+   this file. */
 .dash-ach {
   padding: 18px 16px;
   display: flex;

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -1075,10 +1075,19 @@
     display: flex;
     gap: 4px;
     overflow-x: auto;
+    /* The track scrolls when it is narrower than its segments, but it must not
+       reserve a scrollbar gutter for the possibility: on a classic-scrollbar
+       platform that gutter made every rail 17px taller than the segments
+       inside it — the catalog's rails measured 56px around 35px tabs, and no
+       neighbouring control could line up with them. */
+    scrollbar-width: none;
     padding: 2px;
     border: 1px solid var(--quiet-line);
     border-radius: var(--r-md);
     background: var(--surface);
+  }
+  .segctl-track::-webkit-scrollbar {
+    display: none;
   }
   .segctl-pills {
     display: flex;
@@ -2504,12 +2513,20 @@
    (`.catalog-tabs` / `.catalog-tab`). It is a segmented choice, so it now uses
    the shared `SegmentedControl` track like the filter rails under it. */
 
-/* ── Filter row layout (search + rails on the same row) ── */
+/* ── Filter row layout (search + rails on the same row) ──
+   One control strip: the search field and the rails read as the same height,
+   which they get by stretching to the line rather than by anyone hardcoding
+   the other's metrics. The rails also refuse to shrink — as flex items with a
+   `flex-1` input beside them they were being crushed to a few pixels wide and
+   scrolling internally; wrapping to the next line is the correct answer. */
 .filter-row {
   display: flex;
-  align-items: center;
+  align-items: stretch;
   gap: 10px;
   flex-wrap: wrap;
+}
+.filter-row .segctl-track {
+  flex-shrink: 0;
 }
 
 /* ── Learning Path sections — premium redesign ── */

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -4298,7 +4298,9 @@ a.stat-receipt:active {
   display: none;
   align-items: center;
   gap: 2px;
-  padding: 3px;
+  /* Extra room at the bottom for the active item's 3px lift, which would
+     otherwise land flush against the bar's inner edge. */
+  padding: 3px 3px 6px;
   border-radius: 9999px;
   background: var(--card-glass-blur);
   border: 1px solid var(--border);
@@ -4336,7 +4338,12 @@ a.stat-receipt:active {
   display: flex;
   align-items: center;
   gap: 7px;
-  padding: 5px 13px;
+  /* The transparent border is carried by EVERY item, active or not, so the
+     active one's ink outline costs no layout and nothing shifts as the current
+     page changes. Padding is reduced by the border width to keep the bar the
+     height it was. */
+  padding: 3px 11px;
+  border: 2px solid transparent;
   border-radius: 9999px;
   font-size: 13px;
   font-weight: 600;
@@ -4350,19 +4357,17 @@ a.stat-receipt:active {
   color: var(--text-2);
   background: var(--card-hover);
 }
+/* Active — the ink lift on the tint (owner, option B, 24-08). The tint fill
+   and the label colour are unchanged; what is new is the chip family's
+   construction on top of them: a literal dark ink outline on BOTH grounds and
+   a hard offset shadow, so the current page reads as a raised object rather
+   than as a coloured glow. The two soft glow shadows this replaces (one per
+   theme) were the last light-source effect in the header. */
 .nav-link.active {
   color: var(--primary);
   background: var(--primary-dim);
-  box-shadow:
-    0 0 12px rgba(46, 204, 142, 0.12),
-    inset 0 1px 0 rgba(46, 204, 142, 0.08);
-}
-
-/* Light mode adjustments */
-:root .nav-link.active {
-  box-shadow:
-    0 0 8px rgba(10, 112, 85, 0.1),
-    inset 0 1px 0 rgba(10, 112, 85, 0.06);
+  border-color: var(--ink-dark);
+  box-shadow: 0 3px 0 0 var(--ink-dark);
 }
 
 /* ═══════════════════════════════════════════════════════════════


### PR DESCRIPTION
The catalog's difficulty filter was a row of free-standing pills. It becomes the community's grouped rail, and a second rail joins it for the learner's own enrollment state — All / Enrolled / Not enrolled / Completed, composing with difficulty and the search box. Anonymous visitors don't get the status rail at all; it has nothing to say to them. Enrollment state comes from the read the catalog already makes, plus `completed_at` on the same rows.

The status chips that sit on card banners were translucent pills mixed from `var(--card)`, so on a light cover image they nearly vanished. They now use the `.chip` construction — solid fill, literal ink outline, hard lift — as one `StatusChip` component shared with the learning-path rows, which had grown their own copy and drifted from it twice.

While the owner was live-testing this he asked for the rest of the tab, so the same pass covers the Learning Paths view (the switcher becomes a rail, the progress bars become the shared `ProgressBar`, the tags/badges/step discs join the chip family, CONTINUE and SKIP AHEAD wear the Button's own classes), the header nav's active state, and the landing hero's height. Each is its own commit.

One deliberate exception is recorded in the CSS: on dark, the path row's CONTINUE takes the mint primary rather than the deep green every other primary button uses, because everything around it on that row is mint. `.btn-ink--primary` is untouched.

Filter composition and the enrolled/completed/not-enrolled classification are unit-tested. Full web suite green: 345 files, 3414 tests.
