### PR TITLE
feat(content): trim course-specific achievements to speedrunner only

### DIFF
--- a/apps/web/content.lock
+++ b/apps/web/content.lock
@@ -1,4 +1,4 @@
 {
   "repo": "solanabr/academy-courses",
-  "sha": "958e78779ab4d3a309c12a1ff8ae30887331e9ff"
+  "sha": "aff33b8d1129d6cf72aed92f39abb651a17d5cfc"
 }

--- a/apps/web/src/components/gamification/patch-look.ts
+++ b/apps/web/src/components/gamification/patch-look.ts
@@ -29,7 +29,6 @@ const PATCH_LOOKS: Record<string, PatchLook> = {
   "achievement-first-steps": { tier: 1, cat: "reward" },
   "achievement-early-adopter": { tier: 1, cat: "start" },
   "achievement-rust-rookie": { tier: 1, cat: "start" },
-  "achievement-course-completer": { tier: 2, cat: "course", glyph: "★" },
   "achievement-bug-hunter": { tier: 2, cat: "community", glyph: "!" },
   "achievement-monthly-master": { tier: 2, cat: "reward" },
   "achievement-week-warrior": { tier: 2, cat: "reward" },

--- a/apps/web/src/content/generated/achievements.json
+++ b/apps/web/src/content/generated/achievements.json
@@ -51,23 +51,6 @@
     "xpReward": 400
   },
   {
-    "_id": "achievement-course-completer",
-    "_type": "achievement",
-    "award": {
-      "course": "course-btc-to-sol-evolution",
-      "kind": "course-completed"
-    },
-    "category": "progress",
-    "description": "Complete an entire course",
-    "glyph": "✦",
-    "icon": "graduation-cap",
-    "maxSupply": 0,
-    "metadataUri": "https://superteam-academy.vercel.app/api/achievements/metadata?id=achievement-course-completer",
-    "name": "Course Completer",
-    "solTier": false,
-    "xpReward": 200
-  },
-  {
     "_id": "achievement-double-digits",
     "_type": "achievement",
     "award": {
@@ -99,59 +82,6 @@
     "name": "Early Adopter",
     "solTier": true,
     "xpReward": 1000
-  },
-  {
-    "_id": "achievement-evolution-explorer",
-    "_type": "achievement",
-    "award": {
-      "course": "course-btc-to-sol-evolution",
-      "gte": 5,
-      "kind": "lessons-completed-in-course"
-    },
-    "category": "progress",
-    "description": "Complete 5 lessons of From Bitcoin to Solana",
-    "glyph": "⅓",
-    "icon": "compass",
-    "maxSupply": 0,
-    "metadataUri": "https://superteam-academy.vercel.app/api/achievements/metadata?id=achievement-evolution-explorer",
-    "name": "Five Chapters In",
-    "solTier": false,
-    "xpReward": 50
-  },
-  {
-    "_id": "achievement-evolution-navigator",
-    "_type": "achievement",
-    "award": {
-      "course": "course-btc-to-sol-evolution",
-      "gte": 10,
-      "kind": "lessons-completed-in-course"
-    },
-    "category": "progress",
-    "description": "Complete 10 lessons of From Bitcoin to Solana",
-    "glyph": "⅔",
-    "icon": "compass",
-    "maxSupply": 0,
-    "metadataUri": "https://superteam-academy.vercel.app/api/achievements/metadata?id=achievement-evolution-navigator",
-    "name": "Two-Thirds There",
-    "solTier": false,
-    "xpReward": 80
-  },
-  {
-    "_id": "achievement-evolution-scholar",
-    "_type": "achievement",
-    "award": {
-      "course": "course-btc-to-sol-evolution",
-      "kind": "course-completed"
-    },
-    "category": "progress",
-    "description": "Complete From Bitcoin to Solana",
-    "glyph": "✦",
-    "icon": "graduation-cap",
-    "maxSupply": 0,
-    "metadataUri": "https://superteam-academy.vercel.app/api/achievements/metadata?id=achievement-evolution-scholar",
-    "name": "Evolution Scholar",
-    "solTier": false,
-    "xpReward": 150
   },
   {
     "_id": "achievement-first-steps",
@@ -290,40 +220,6 @@
     "name": "Monthly Master",
     "solTier": false,
     "xpReward": 200
-  },
-  {
-    "_id": "achievement-panorama",
-    "_type": "achievement",
-    "award": {
-      "course": "course-visao-geral-solana",
-      "kind": "course-completed"
-    },
-    "category": "progress",
-    "description": "Complete Visão Geral do Solana",
-    "glyph": "◎",
-    "icon": "compass",
-    "maxSupply": 0,
-    "metadataUri": "https://superteam-academy.vercel.app/api/achievements/metadata?id=achievement-panorama",
-    "name": "Visão Geral",
-    "solTier": false,
-    "xpReward": 60
-  },
-  {
-    "_id": "achievement-pilula-taken",
-    "_type": "achievement",
-    "award": {
-      "course": "course-pilula-solana-superteam",
-      "kind": "course-completed"
-    },
-    "category": "progress",
-    "description": "Complete Pílula Solana & Superteam",
-    "glyph": "◆",
-    "icon": "graduation-cap",
-    "maxSupply": 0,
-    "metadataUri": "https://superteam-academy.vercel.app/api/achievements/metadata?id=achievement-pilula-taken",
-    "name": "Pílula Tomada",
-    "solTier": false,
-    "xpReward": 30
   },
   {
     "_id": "achievement-speedrunner",

--- a/apps/web/src/content/generated/meta.json
+++ b/apps/web/src/content/generated/meta.json
@@ -1,11 +1,11 @@
 {
-  "compiledAt": "2026-08-24T13:54:33Z",
+  "compiledAt": "2026-08-24T17:59:35Z",
   "counts": {
-    "achievements": 24,
+    "achievements": 18,
     "courses": 4,
     "learningPaths": 1,
     "lessons": 23,
     "quests": 5
   },
-  "sha": "958e78779ab4d3a309c12a1ff8ae30887331e9ff"
+  "sha": "aff33b8d1129d6cf72aed92f39abb651a17d5cfc"
 }

--- a/apps/web/src/lib/content/__tests__/fixtures/golden/achievements-raw.json
+++ b/apps/web/src/lib/content/__tests__/fixtures/golden/achievements-raw.json
@@ -39,25 +39,6 @@
       "xpReward": 400
     },
     {
-      "_id": "achievement-course-completer",
-      "award": {
-        "course": "course-btc-to-sol-evolution",
-        "days": null,
-        "gte": null,
-        "kind": "course-completed",
-        "lte": null,
-        "path": null,
-        "stat": null
-      },
-      "category": "progress",
-      "description": "Complete an entire course",
-      "glyph": "✦",
-      "icon": "graduation-cap",
-      "name": "Course Completer",
-      "solTier": false,
-      "xpReward": 200
-    },
-    {
       "_id": "achievement-early-adopter",
       "award": {
         "course": null,
@@ -172,63 +153,6 @@
       "xpReward": 80
     },
     {
-      "_id": "achievement-evolution-explorer",
-      "award": {
-        "course": "course-btc-to-sol-evolution",
-        "days": null,
-        "gte": 5,
-        "kind": "lessons-completed-in-course",
-        "lte": null,
-        "path": null,
-        "stat": null
-      },
-      "category": "progress",
-      "description": "Complete 5 lessons of From Bitcoin to Solana",
-      "glyph": "⅓",
-      "icon": "compass",
-      "name": "Five Chapters In",
-      "solTier": false,
-      "xpReward": 50
-    },
-    {
-      "_id": "achievement-evolution-navigator",
-      "award": {
-        "course": "course-btc-to-sol-evolution",
-        "days": null,
-        "gte": 10,
-        "kind": "lessons-completed-in-course",
-        "lte": null,
-        "path": null,
-        "stat": null
-      },
-      "category": "progress",
-      "description": "Complete 10 lessons of From Bitcoin to Solana",
-      "glyph": "⅔",
-      "icon": "compass",
-      "name": "Two-Thirds There",
-      "solTier": false,
-      "xpReward": 80
-    },
-    {
-      "_id": "achievement-evolution-scholar",
-      "award": {
-        "course": "course-btc-to-sol-evolution",
-        "days": null,
-        "gte": null,
-        "kind": "course-completed",
-        "lte": null,
-        "path": null,
-        "stat": null
-      },
-      "category": "progress",
-      "description": "Complete From Bitcoin to Solana",
-      "glyph": "✦",
-      "icon": "graduation-cap",
-      "name": "Evolution Scholar",
-      "solTier": false,
-      "xpReward": 150
-    },
-    {
       "_id": "achievement-first-steps-path",
       "award": {
         "course": null,
@@ -339,44 +263,6 @@
       "glyph": "↪",
       "icon": "message-square",
       "name": "Helping Hand",
-      "solTier": false,
-      "xpReward": 30
-    },
-    {
-      "_id": "achievement-panorama",
-      "award": {
-        "course": "course-visao-geral-solana",
-        "days": null,
-        "gte": null,
-        "kind": "course-completed",
-        "lte": null,
-        "path": null,
-        "stat": null
-      },
-      "category": "progress",
-      "description": "Complete Visão Geral do Solana",
-      "glyph": "◎",
-      "icon": "compass",
-      "name": "Visão Geral",
-      "solTier": false,
-      "xpReward": 60
-    },
-    {
-      "_id": "achievement-pilula-taken",
-      "award": {
-        "course": "course-pilula-solana-superteam",
-        "days": null,
-        "gte": null,
-        "kind": "course-completed",
-        "lte": null,
-        "path": null,
-        "stat": null
-      },
-      "category": "progress",
-      "description": "Complete Pílula Solana & Superteam",
-      "glyph": "◆",
-      "icon": "graduation-cap",
-      "name": "Pílula Tomada",
       "solTier": false,
       "xpReward": 30
     },
@@ -497,25 +383,6 @@
       "xpReward": 400
     },
     {
-      "_id": "achievement-course-completer",
-      "award": {
-        "course": "course-btc-to-sol-evolution",
-        "days": null,
-        "gte": null,
-        "kind": "course-completed",
-        "lte": null,
-        "path": null,
-        "stat": null
-      },
-      "category": "progress",
-      "description": "Complete an entire course",
-      "glyph": "✦",
-      "icon": "graduation-cap",
-      "name": "Course Completer",
-      "solTier": false,
-      "xpReward": 200
-    },
-    {
       "_id": "achievement-early-adopter",
       "award": {
         "course": null,
@@ -630,63 +497,6 @@
       "xpReward": 80
     },
     {
-      "_id": "achievement-evolution-explorer",
-      "award": {
-        "course": "course-btc-to-sol-evolution",
-        "days": null,
-        "gte": 5,
-        "kind": "lessons-completed-in-course",
-        "lte": null,
-        "path": null,
-        "stat": null
-      },
-      "category": "progress",
-      "description": "Complete 5 lessons of From Bitcoin to Solana",
-      "glyph": "⅓",
-      "icon": "compass",
-      "name": "Five Chapters In",
-      "solTier": false,
-      "xpReward": 50
-    },
-    {
-      "_id": "achievement-evolution-navigator",
-      "award": {
-        "course": "course-btc-to-sol-evolution",
-        "days": null,
-        "gte": 10,
-        "kind": "lessons-completed-in-course",
-        "lte": null,
-        "path": null,
-        "stat": null
-      },
-      "category": "progress",
-      "description": "Complete 10 lessons of From Bitcoin to Solana",
-      "glyph": "⅔",
-      "icon": "compass",
-      "name": "Two-Thirds There",
-      "solTier": false,
-      "xpReward": 80
-    },
-    {
-      "_id": "achievement-evolution-scholar",
-      "award": {
-        "course": "course-btc-to-sol-evolution",
-        "days": null,
-        "gte": null,
-        "kind": "course-completed",
-        "lte": null,
-        "path": null,
-        "stat": null
-      },
-      "category": "progress",
-      "description": "Complete From Bitcoin to Solana",
-      "glyph": "✦",
-      "icon": "graduation-cap",
-      "name": "Evolution Scholar",
-      "solTier": false,
-      "xpReward": 150
-    },
-    {
       "_id": "achievement-first-steps-path",
       "award": {
         "course": null,
@@ -797,44 +607,6 @@
       "glyph": "↪",
       "icon": "message-square",
       "name": "Helping Hand",
-      "solTier": false,
-      "xpReward": 30
-    },
-    {
-      "_id": "achievement-panorama",
-      "award": {
-        "course": "course-visao-geral-solana",
-        "days": null,
-        "gte": null,
-        "kind": "course-completed",
-        "lte": null,
-        "path": null,
-        "stat": null
-      },
-      "category": "progress",
-      "description": "Complete Visão Geral do Solana",
-      "glyph": "◎",
-      "icon": "compass",
-      "name": "Visão Geral",
-      "solTier": false,
-      "xpReward": 60
-    },
-    {
-      "_id": "achievement-pilula-taken",
-      "award": {
-        "course": "course-pilula-solana-superteam",
-        "days": null,
-        "gte": null,
-        "kind": "course-completed",
-        "lte": null,
-        "path": null,
-        "stat": null
-      },
-      "category": "progress",
-      "description": "Complete Pílula Solana & Superteam",
-      "glyph": "◆",
-      "icon": "graduation-cap",
-      "name": "Pílula Tomada",
       "solTier": false,
       "xpReward": 30
     },

--- a/apps/web/src/lib/content/__tests__/project.golden.test.ts
+++ b/apps/web/src/lib/content/__tests__/project.golden.test.ts
@@ -200,6 +200,14 @@ vi.mock("server-only", () => ({}));
 //    ACTIVE set, so `quest-challenge` (active: false now) DROPS out of it,
 //    and complete-lesson 25 -> 20 / lesson-batch 3 -> 2 targets at 50 -> 40 /
 //    login-streak 40 -> 50 land in the remaining four.
+//  - course-badge trim (bump to academy-courses @aff33b8d, academy-courses
+//    #42): owner ruling — no course-specific achievements except speedrunner.
+//    achievements 24 -> 18: pilula-taken, panorama, evolution-explorer,
+//    evolution-navigator, evolution-scholar and the legacy course-completer
+//    (which duplicated evolution-scholar's trigger) all deleted; the fixture
+//    drops the same six from both arrays. Nothing else in the bundle moved.
+//    The award-shape assertion moves course-completer -> speedrunner, now the
+//    bundle's only `course-completed` doc.
 const deps = { lessonsById };
 
 function bundleCourse(id: string): CourseDoc {
@@ -362,18 +370,18 @@ describe("projectAchievement — mapAchievement over the bundle", () => {
     }
   });
 
-  it("award is validated + stripped; course-completer = course-completed", () => {
-    // Was anchor-expert until the alpha wave parked it; course-completer is now
-    // the bundle's only `course-completed` award, retargeted to the flagship.
-    const completer = projectAchievement(
-      achievementsById.get("achievement-course-completer")!
+  it("award is validated + stripped; speedrunner = course-completed", () => {
+    // Was anchor-expert, then course-completer; the trim wave deleted every
+    // course-specific badge except speedrunner, so it now carries the bundle's
+    // only `course-completed` award.
+    const speedrunner = projectAchievement(
+      achievementsById.get("achievement-speedrunner")!
     );
-    expect(completer.award).toEqual({
+    expect(speedrunner.award).toEqual({
       kind: "course-completed",
-      course: "course-btc-to-sol-evolution",
+      course: "course-solana-speedrun",
     });
-    expect(completer.glyph).toBe("✦");
-    expect(completer.solTier).toBe(false);
+    expect(speedrunner.solTier).toBe(false);
   });
 
   it("early-adopter is manual — it no longer auto-fires on signup", () => {


### PR DESCRIPTION
Activates academy-courses#42 (lock bump to aff33b8d). Owner ruling: badges shouldn't multiply per course — drops pilula-taken, panorama, the three evolution badges, and the legacy course-completer (which duplicated evolution-scholar's trigger). 24 → 18; zero learners ever unlocked any of the six. Goldens trimmed to match; the award-shape assertion moves to speedrunner, now the bundle's only course-completed doc.