### PR TITLE
docs: bring the README and docs/ back to reality

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,365 +1,218 @@
-<div align="center">
-  <h1>Superteam Academy</h1>
-  <p><strong>A Solana-native learning platform with on-chain credentials.</strong></p>
-  <p>Soulbound XP tokens, NFT certificates, interactive coding challenges, and gamified progression — all on Solana.</p>
-  <p>Built by <a href="https://superteam.fun">Superteam Brazil</a></p>
+# Superteam Academy
 
-  <p>
-    <a href="#overview">Overview</a> &bull;
-    <a href="#tech-stack">Tech Stack</a> &bull;
-    <a href="#local-development">Local Development</a> &bull;
-    <a href="#environment-variables">Environment Variables</a> &bull;
-    <a href="#deployment">Deployment</a> &bull;
-    <a href="#documentation">Documentation</a>
-  </p>
+A Solana-native learning platform. Learners enroll in courses, complete lessons,
+and earn credentials that live on-chain: soulbound XP as Token-2022, course
+certificates as Metaplex Core NFTs. Built by [Superteam Brazil](https://superteam.fun).
 
-  <p>
-    <img src="https://img.shields.io/badge/Solana-Devnet-9945FF?logo=solana" alt="Solana" />
-    <img src="https://img.shields.io/badge/Token--2022-Soulbound_XP-14F195" alt="Token-2022" />
-    <img src="https://img.shields.io/badge/Metaplex_Core-NFT_Credentials-E42575" alt="Metaplex Core" />
-    <img src="https://img.shields.io/badge/Next.js-14-black?logo=next.js" alt="Next.js 14" />
-    <img src="https://img.shields.io/badge/Anchor-0.31+-DEA584?logo=rust" alt="Anchor" />
-    <img src="https://img.shields.io/badge/TypeScript-Strict-3178C6?logo=typescript" alt="TypeScript" />
-    <img src="https://img.shields.io/badge/License-MIT-green.svg" alt="MIT License" />
-  </p>
-</div>
+Open source, MIT. Currently running on **devnet**.
 
----
+## How it fits together
 
-## Overview
+Four moving parts, each with a clear job:
 
-Superteam Academy is an open-source learning management system built on Solana. Learners enroll in courses, complete lessons to earn soulbound XP tokens, receive NFT certificates on course completion, and collect achievements — all with on-chain verification.
+| Part                 | What it is                                        | Where                                                                     |
+| -------------------- | ------------------------------------------------- | ------------------------------------------------------------------------- |
+| **Web app**          | Next.js 15 App Router on Vercel                   | `apps/web/`                                                               |
+| **On-chain program** | Pinocchio (Rust), 18 instructions, 6 PDA types    | `onchain-academy/`                                                        |
+| **Database**         | Supabase Postgres — 36 tables, RLS on all of them | `supabase/`                                                               |
+| **Course content**   | A committed bundle, compiled from a separate repo | [`solanabr/academy-courses`](https://github.com/solanabr/academy-courses) |
 
-### Feature Highlights
+On-chain state is the source of truth for XP balances, lesson completion (a
+bitmap in the Enrollment PDA), and credentials. Supabase mirrors it for fast
+queries, streaks, and leaderboards; mirror writes are non-fatal and rebuildable.
 
-**On-Chain Credentials**
+**There is no CMS.** Content is authored in git, compiled ahead of time by
+`compile-content.ts`, and committed to this repo as typed JSON pinned to one
+`academy-courses` commit (`apps/web/content.lock`). Nothing fetches content at
+runtime, and no credential in the app can mutate it — publishing is a pull
+request.
 
-- **Soulbound XP tokens** via Token-2022 (NonTransferable + PermanentDelegate) — cannot be transferred or self-burned
-- **NFT certificates** via Metaplex Core, auto-minted on course completion and frozen to the learner's wallet (PermanentFreezeDelegate)
-- **On-chain lesson tracking** using a bitmap stored in the Enrollment PDA — each bit represents a lesson
+## What learners get
 
-**Interactive Learning**
+- **Soulbound XP** — Token-2022 with NonTransferable + PermanentDelegate. Minted
+  by CPI on lesson completion; cannot be transferred or self-burned.
+- **Credential NFTs** — Metaplex Core, frozen to the learner's wallet via
+  PermanentFreezeDelegate, one collection per course track.
+- **Interactive lessons** — a lesson is an ordered `blocks[]` page builder:
+  prose, video, Monaco code challenges, quizzes, reflections, and Solana widgets
+  (devnet airdrop, IDL program explorer, deployed-program card).
+- **Rust/Anchor compilation** — `buildable` challenges and in-browser program
+  deploys go through a Rust/Axum build server on Cloud Run.
+- **AI lesson assistant** — Gemini-backed, with per-day spend caps enforced by a
+  Postgres ledger.
+- **Gamification** — 18 achievements (a course-agnostic ladder plus one course
+  badge), 5 daily/multi-day quests, streaks, leagues, referrals, and a
+  leaderboard. Level is `floor(sqrt(totalXP / 100))`.
+- **Community forum** — threads, answers, voting, accepted answers, flags, and
+  XP for participation with a daily cap.
+- **Three languages** — English, Portuguese (pt-BR), Spanish.
 
-- Code challenges with an in-browser Monaco Editor (JS/TS syntax highlighting, automated test cases)
-- Rust/Anchor program compilation via a sandboxed build server
-- Content lessons with rich markdown rendering
-- Program deployment and interaction directly from lesson pages
-
-**Gamification**
-
-- XP rewards for lesson completions (10-100 XP based on difficulty)
-- Level progression: `Level = floor(sqrt(totalXP / 100))`
-- Daily streaks tracking consecutive learning days
-- Achievements across 5 categories (Progress, Streaks, Skills, Community, Special), with unlock rules declared in content
-- Celebration popups for level-ups, achievements, and certificate minting
-
-**Community Forum**
-
-- Discussion threads with category browsing and full-text search
-- Answers with upvoting/downvoting and accepted answer marking
-- Content flagging for moderation
-- Community XP rewards for participation
-
-**Daily Quests**
-
-- Rotating daily objectives (complete a lesson, earn XP, etc.)
-- Bonus XP for first daily completion and streak bonuses
-
-**Platform**
-
-- i18n: English, Portuguese (pt-BR), Spanish
-- Dark/light mode with Solana-branded gradient theme
-- Wallet auth (SIWS) supporting Phantom, Solflare, and Backpack
-- Google OAuth + GitHub OAuth for low-friction onboarding
-- Admin panel for deploying courses and achievements on-chain
-- Live leaderboard with weekly, monthly, and all-time XP rankings
-- In-browser program deployment with wallet-signed transactions
-
-## Tech Stack
-
-| Layer            | Technology                                                            |
-| ---------------- | --------------------------------------------------------------------- |
-| Frontend         | Next.js 14 (App Router), React 18, Tailwind CSS, shadcn/ui + Radix UI |
-| Content          | Committed bundle compiled from the `academy-courses` git repo         |
-| Database / Auth  | Supabase (Postgres, RLS, Auth)                                        |
-| On-Chain Program | Solana, Pinocchio 0.11 (Rust, `cargo build-sbf`)                      |
-| XP Tokens        | Token-2022 (NonTransferable + PermanentDelegate)                      |
-| Credential NFTs  | Metaplex Core (soulbound via PermanentFreezeDelegate)                 |
-| i18n             | next-intl (EN, PT-BR, ES)                                             |
-| Auth             | SIWS (Sign In With Solana) + Google OAuth + GitHub OAuth              |
-| Code Editor      | Monaco Editor                                                         |
-| Build Server     | Rust/Axum on GCP Cloud Run                                            |
-| Analytics        | GA4, PostHog, Sentry (all optional)                                   |
-| RPC              | Helius (DAS API for credential queries + leaderboard)                 |
-| Monorepo         | Turborepo + pnpm 9                                                    |
-| Deployment       | Vercel (web) + GCP Cloud Run (build server)                           |
-
-## Screenshots
-
-|                  Dashboard                  |                  Code Challenge                  |                   Certificate                   |
-| :-----------------------------------------: | :----------------------------------------------: | :---------------------------------------------: |
-| ![Dashboard](apps/web/public/dashboard.png) | ![Code Challenge](apps/web/public/challenge.png) | ![Certificate](apps/web/public/certificate.png) |
-
-## Local Development
+## Getting it running
 
 ### Prerequisites
 
-- [Node.js](https://nodejs.org) >= 18
-- [pnpm](https://pnpm.io) >= 9
-- A [Supabase](https://supabase.com) account (free tier works)
-- A Solana wallet ([Phantom](https://phantom.app) recommended)
+- Node.js >= 18 and pnpm 10 (the repo pins `packageManager`)
+- A Supabase project (free tier is fine)
+- For on-chain work: Rust, the Solana CLI, and `cargo build-sbf`. No Anchor CLI —
+  the program is Pinocchio.
 
-For on-chain program development, you also need:
-
-- [Rust](https://rustup.rs) >= 1.82
-- [Solana CLI](https://docs.solanalabs.com/cli/install) >= 1.18
-- [Anchor CLI](https://www.anchor-lang.com/docs/installation) >= 0.31
-
-### Quick Setup
+### Quickstart
 
 ```bash
-# 1. Clone and install
-git clone https://github.com/superteam-brazil/superteam-academy.git
+git clone https://github.com/solanabr/superteam-academy.git
 cd superteam-academy
 pnpm install
 
-# 2. Configure environment
+# Environment: copy the template and fill in real values.
 cp .env.example apps/web/.env.local
-# Replace every placeholder with a real value — .env.example holds illustrative
-# defaults, not working credentials. Minimum to boot (see Environment Variables):
-# NEXT_PUBLIC_SUPABASE_URL, NEXT_PUBLIC_SUPABASE_ANON_KEY, SUPABASE_SERVICE_ROLE_KEY,
-# NEXT_PUBLIC_SOLANA_RPC_URL, SOLANA_RPC_URL.
 
-# 3. Set up the database (migrations are the source of truth)
-# Create a Supabase project, install the Supabase CLI, then link and push:
-#   supabase link --project-ref <your-project-ref>
-#   supabase db push        # applies supabase/migrations/ in order
-# supabase/schema.sql is a generated snapshot for reference — do not run it directly.
+# Database: migrations are the source of truth.
+supabase link --project-ref <your-project-ref>
+supabase db push
 
-# 4. Content — nothing to import.
-# Course content is a COMMITTED bundle (apps/web/src/content/generated/), compiled
-# from solanabr/academy-courses at the SHA pinned in apps/web/content.lock.
-# It is already in the repo. To recompile it after a pin bump:
-#   pnpm --filter web compile-content
-
-# 5. Start the dev server
 pnpm dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000).
+Open <http://localhost:3000>.
 
-**Minimum variables for basic dev** (no on-chain features): `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_ROLE_KEY`, `NEXT_PUBLIC_SOLANA_RPC_URL`, `SOLANA_RPC_URL`.
+The minimum to boot is `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`,
+`SUPABASE_SERVICE_ROLE_KEY`, `NEXT_PUBLIC_SOLANA_RPC_URL`, and `SOLANA_RPC_URL`.
+On-chain features additionally need `NEXT_PUBLIC_PROGRAM_ID`,
+`NEXT_PUBLIC_XP_MINT_ADDRESS`, `PROGRAM_AUTHORITY_SECRET`, and
+`BACKEND_SIGNER_SECRET` — see [docs/DEPLOY-PROGRAM.md](docs/DEPLOY-PROGRAM.md).
 
-> **Courses won't appear until they're deployed on-chain.** Visibility is gated on
-> the Supabase `onchain_deployments` table (`status = "synced"` and active), which
-> starts empty on a fresh project. Deploy courses from `/en/admin/deploy` — see
-> [docs/ADMIN.md](docs/ADMIN.md).
+The **authoritative, annotated env-var list** — every variable, what it does, and
+what happens when it is unset — is the `## Environment Variables` block in
+[`apps/web/CLAUDE.md`](apps/web/CLAUDE.md). `.env.example` is the copyable
+template; treat CLAUDE.md as the explanation.
 
-**Full on-chain features** require: `NEXT_PUBLIC_PROGRAM_ID`, `NEXT_PUBLIC_XP_MINT_ADDRESS`, `PROGRAM_AUTHORITY_SECRET`, `BACKEND_SIGNER_SECRET`. See [Program Deployment](docs/DEPLOY-PROGRAM.md) for the deploy and initialize workflow.
+> **Nothing shows up on a fresh project.** Course visibility is gated on the
+> Supabase `onchain_deployments` table (`status = "synced"` and active), which
+> starts empty. Deploy courses from `/en/admin` — see [docs/ADMIN.md](docs/ADMIN.md).
 
-### Development Commands
+Course content is already in the repo (`apps/web/src/content/generated/`) — there
+is nothing to import. To rebuild it after bumping the pin:
+`pnpm --filter web compile-content`.
+
+### Commands
 
 ```bash
-pnpm dev          # Start Next.js dev server
-pnpm build        # Production build
+pnpm dev          # Next.js dev server
+pnpm build        # production build (Turborepo)
 pnpm lint         # ESLint
-pnpm typecheck    # TypeScript type checking
-pnpm format       # Prettier formatting
+pnpm typecheck    # tsc
+pnpm format       # Prettier
 ```
 
-## Project Structure
+## Repository map
 
 ```
 superteam-academy/
 ├── apps/
-│   ├── web/                    # Next.js 14 application
-│   │   ├── src/app/            #   App Router pages ([locale] route groups)
-│   │   │   ├── [locale]/
-│   │   │   │   ├── (marketing)/  # Landing page
-│   │   │   │   ├── (platform)/   # Authenticated routes (dashboard, courses, etc.)
-│   │   │   │   └── admin/        # Admin panel
-│   │   │   └── api/              # API routes (auth, lessons, achievements, etc.)
-│   │   ├── src/components/     #   UI components (auth, editor, gamification, layout)
-│   │   ├── src/lib/            #   Utilities (supabase, content, github, solana, analytics)
-│   │   ├── src/content/generated/  # COMMITTED content bundle (do not hand-edit)
-│   │   ├── content.lock        #   The academy-courses commit the bundle is pinned to
-│   │   ├── scripts/            #   compile-content.ts (repo → committed bundle)
-│   │   └── src/messages/       #   i18n translation files (en, pt-BR, es)
-│   └── build-server/           # Rust/Axum build server (GCP Cloud Run)
-├── onchain-academy/            # Pinocchio program workspace (Solana)
-│   ├── programs/               #   On-chain program source (Rust)
-│   └── tests/                  #   Integration + unit tests
+│   ├── web/                      Next.js 15 app
+│   │   ├── src/app/[locale]/     pages — (marketing), (platform), admin
+│   │   ├── src/app/api/          72 API routes
+│   │   ├── src/lib/              content, solana, auth, gamification, ai, helius…
+│   │   ├── src/content/generated/  COMMITTED content bundle — never hand-edit
+│   │   ├── src/messages/         en / pt-BR / es
+│   │   └── content.lock          the academy-courses commit the bundle is pinned to
+│   └── build-server/             Rust/Axum program compiler (Cloud Run)
+├── onchain-academy/              Pinocchio program workspace + IDL + tests
 ├── packages/
-│   ├── types/                  # Shared TypeScript interfaces
-│   ├── content-schema/         # Zod schemas for the content standard
-│   ├── content-lint/           # Content linter (runs in academy-courses CI)
-│   ├── challenge-executor/     # Sandboxed challenge runner (QuickJS)
-│   ├── deploy/                 # Browser-based Solana program deployment library
-│   └── config/                 # Shared ESLint, TS, Tailwind configs
-├── supabase/                   # Database schema + migrations
-├── scripts/                    # Helper scripts (init-program, update-program-id)
-├── wallets/                    # Keypairs (gitignored)
-└── docs/                       # Documentation
+│   ├── types/                    shared TypeScript interfaces
+│   ├── content-schema/           Zod schemas for the content standard
+│   ├── content-lint/             content linter — runs in academy-courses CI
+│   ├── challenge-executor/       sandboxed challenge runner (QuickJS)
+│   ├── deploy/                   browser-side Solana program deployment
+│   └── config/                   shared ESLint / TS / Tailwind configs
+├── supabase/                     migrations (source of truth) + schema snapshot
+├── scripts/                      operator scripts
+└── docs/                         the guides below
 ```
 
-Course **content** lives in a separate repo:
-[`solanabr/academy-courses`](https://github.com/solanabr/academy-courses).
+## Signing in
 
-## Environment Variables
+Three ways in, all of which end at a **server-set Supabase cookie session** —
+nothing mints a session client-side:
 
-Copy `.env.example` to `apps/web/.env.local` and fill in values.
+- **SIWS with an external wallet** — the wallet signs a nonce; `/api/auth/wallet`
+  verifies it. Always available; the guaranteed path.
+- **Dynamic embedded wallets** — Google handshake and embedded-wallet ownership
+  proven by Dynamic, exchanged at `/api/auth/dynamic`. Optional: unset
+  `NEXT_PUBLIC_DYNAMIC_ENVIRONMENT_ID` and it is simply off.
+- **Supabase OAuth (Google / GitHub)** — the fallback and kill switch, via
+  `/api/auth/callback`.
 
-### Supabase (Required)
+The full map, including the post-login rituals every rail must share, is
+[docs/AUTH-FLOWS.md](docs/AUTH-FLOWS.md).
 
-| Variable                        | Scope  | Description                                                         |
-| ------------------------------- | ------ | ------------------------------------------------------------------- |
-| `NEXT_PUBLIC_SUPABASE_URL`      | Client | Supabase project URL                                                |
-| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | Client | Public anon key (safe for browser)                                  |
-| `SUPABASE_SERVICE_ROLE_KEY`     | Server | Service role key for admin operations. **Never expose to browser.** |
+## On-chain program
 
-### Content
+Built with Pinocchio 0.11 (`#![no_std]`, `cargo build-sbf`). The Anchor
+implementation it was ported from has been deleted — there is no `Anchor.toml`
+and no Anchor CLI in the toolchain. The committed IDL at
+`onchain-academy/idl/onchain_academy.json` is still Anchor IDL format, because
+that is the wire contract every client decodes against.
 
-**No variables required.** Course content is a committed bundle — there is no CMS
-and no content-write credential. `GITHUB_TOKEN` (below) is optional, read-only, and
-only used to poll the content repo's HEAD/CI state for the admin Publish screen.
+- **18 instructions**, dispatched on the 8-byte `sha256("global:<name>")`
+  sighash: initialize, config, course CRUD, enroll, complete lesson, finalize,
+  credentials, minter roles, XP rewards, achievements.
+- **6 PDA types**: Config, Course, Enrollment, MinterRole, AchievementType,
+  AchievementReceipt.
+- 37 program errors (6000+) and 18 events, emitted byte-identically to Anchor's
+  `emit!` so existing indexers keep working.
 
-### Solana (Required for on-chain features)
+The program id is baked at compile time in two flavors. The default build carries
+the upstream id `7NeJaSRyb4Wxay3Tcd9bdpD7T3GWYUQSFyrhG8SgwE8V` (what the IDL
+declares); `--features fresh-id` carries
+`Dsro2Cd9Mhgk8L71imh3LLPwYU5PU8hvBY5HEcPrcx5u`, the self-owned devnet instance
+that is actually deployed and initialized. Clients read the id from
+`NEXT_PUBLIC_PROGRAM_ID` and throw if it is unset.
 
-| Variable                      | Scope  | Description                                                                                       |
-| ----------------------------- | ------ | ------------------------------------------------------------------------------------------------- |
-| `NEXT_PUBLIC_SOLANA_RPC_URL`  | Client | Browser RPC endpoint. Must carry **no** privileged key (default: `https://api.devnet.solana.com`) |
-| `SOLANA_RPC_URL`              | Server | Server RPC endpoint — **this** is the one that may carry the Helius key. Required at boot.        |
-| `NEXT_PUBLIC_SOLANA_NETWORK`  | Client | Network name (`devnet`)                                                                           |
-| `NEXT_PUBLIC_PROGRAM_ID`      | Client | Program ID from `solana program deploy`                                                           |
-| `NEXT_PUBLIC_XP_MINT_ADDRESS` | Client | XP mint pubkey from `initialize` output                                                           |
+Byte-level layouts, validation order, and every invariant:
+[docs/SPEC.md](docs/SPEC.md). Deploying your own instance:
+[docs/DEPLOY-PROGRAM.md](docs/DEPLOY-PROGRAM.md).
 
-### Admin / Signing (Required for the admin console and on-chain operations)
+## Admin console
 
-| Variable                   | Scope  | Description                                                                                                                                |
-| -------------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| `PROGRAM_AUTHORITY_SECRET` | Server | JSON array of authority keypair bytes (64 elements). The keypair that signed `initialize`.                                                 |
-| `BACKEND_SIGNER_SECRET`    | Server | JSON array of backend signer keypair bytes. On devnet, same as `PROGRAM_AUTHORITY_SECRET`.                                                 |
-| `XP_MINT_AUTHORITY_SECRET` | Server | JSON array of XP mint authority keypair bytes. Signs XP token mints; omit to disable XP minting.                                           |
-| `ADMIN_SECRET`             | Server | Admin console secret (min 32 chars, random) — also the HMAC key signing the `admin_session` cookie                                         |
-| `GITHUB_TOKEN`             | Server | Fine-grained **read** token for `solanabr/academy-courses`. Powers the admin Publish screen. Unset → those routes 503. **No write scope.** |
+`/{locale}/admin`, four screens: **Courses** (publish pin, on-chain deploy,
+supporting content), **Moderation**, **Insights**, **Status**.
 
-### Build Server (Optional -- for code compilation features)
-
-| Variable               | Scope  | Description                                                                      |
-| ---------------------- | ------ | -------------------------------------------------------------------------------- |
-| `BUILD_SERVER_URL`     | Server | Cloud Run service URL                                                            |
-| `BUILD_SERVER_API_KEY` | Server | API key for `X-API-Key` header (same as `ACADEMY_API_KEY` on Cloud Run)          |
-| `RUST_PLAYGROUND_URL`  | Server | Upstream for `/api/rust/execute` (default: `https://play.rust-lang.org/execute`) |
-
-### AI Lesson Assistant (Optional)
-
-| Variable                 | Scope  | Description                                                                             |
-| ------------------------ | ------ | --------------------------------------------------------------------------------------- |
-| `GEMINI_API_KEY`         | Server | Google Gemini API key for the in-lesson AI assistant (`/api/ai/*`). Omit to disable it. |
-| `AI_PARTNER_SEAL_SECRET` | Server | Key sealing the comprehension-check token. Falls back to `SUPABASE_SERVICE_ROLE_KEY`.   |
-
-### Credentials & Moderation (Optional)
-
-| Variable                  | Scope  | Description                                                                                                          |
-| ------------------------- | ------ | -------------------------------------------------------------------------------------------------------------------- |
-| `ARWEAVE_UPLOADER_SECRET` | Server | Solana keypair funding Irys uploads that pin credential metadata to Arweave. Unset → falls back to the metadata API. |
-| `MODERATION_WEBHOOK_URL`  | Server | Slack/Discord-compatible webhook pinged on the first flag of a post.                                                 |
-| `HELIUS_API_KEY`          | Server | Helius DAS API + webhook management                                                                                  |
-| `HELIUS_WEBHOOK_SECRET`   | Server | Verifies Helius webhook signatures                                                                                   |
-
-### Analytics (Optional -- platform works without these)
-
-| Variable                         | Scope  | Description                                                |
-| -------------------------------- | ------ | ---------------------------------------------------------- |
-| `NEXT_PUBLIC_GA4_MEASUREMENT_ID` | Client | Google Analytics 4 measurement ID                          |
-| `NEXT_PUBLIC_POSTHOG_KEY`        | Client | PostHog project key                                        |
-| `NEXT_PUBLIC_POSTHOG_HOST`       | Client | PostHog instance URL (default: `https://us.i.posthog.com`) |
-| `NEXT_PUBLIC_SENTRY_DSN`         | Client | Sentry error tracking DSN (public/safe to expose)          |
-
-### App URL
-
-| Variable              | Scope  | Description                                                                        |
-| --------------------- | ------ | ---------------------------------------------------------------------------------- |
-| `NEXT_PUBLIC_APP_URL` | Client | Base URL for sitemap, OG tags, NFT metadata URI (default: `http://localhost:3000`) |
-
-## Deployment
-
-Superteam Academy deploys as a Vercel-hosted Next.js app backed by Supabase (Postgres + Auth) and a Solana on-chain program. Content ships inside the build — there is no CMS to deploy.
-
-- **[Production Deployment Guide](docs/DEPLOYMENT.md)** -- Full instructions for Vercel, Supabase, the content bundle, Google OAuth, GCP Cloud Run (build server), analytics, custom domains, and post-deployment checklist.
-- **[Program Deployment Guide](docs/DEPLOY-PROGRAM.md)** -- On-chain program build, deploy, and initialize workflow (keypair generation, Pinocchio build via `cargo build-sbf`, devnet deploy, XP mint creation).
-
-## On-Chain Program
-
-**Program**: Superteam Academy (`onchain_academy`)
-**Network**: Solana Devnet
-**Program ID**: `7NeJaSRyb4Wxay3Tcd9bdpD7T3GWYUQSFyrhG8SgwE8V`
-
-The program manages the full learning lifecycle on-chain:
-
-- **18 instructions**: initialize, update config, create/update/close course, enroll, complete lesson, finalize course, close enrollment, issue/upgrade credential, register/update/revoke minter, reward XP, create/deactivate achievement type, award achievement
-- **6 PDA account types**: Config, Course, Enrollment, MinterRole, AchievementType, AchievementReceipt
-- **XP minting**: Token-2022 soulbound tokens minted on lesson completion
-- **Credential issuance**: Metaplex Core NFTs minted on course completion
-
-For deployment instructions, see [docs/DEPLOY-PROGRAM.md](docs/DEPLOY-PROGRAM.md).
-For system architecture, see [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
-
-## Admin Console
-
-**URL**: `/{locale}/admin` (e.g., `/en/admin`)
-**Auth**: Enter the `ADMIN_SECRET` value — this mints an HMAC-signed `admin_session` cookie
-
-Four screens:
-
-- **Publish** (`/admin/publish`): shows the pinned content SHA vs `academy-courses` HEAD and hands you a prefilled PR link. Publishing is a **pull request** that bumps `content.lock` + commits the regenerated bundle — the console holds no write token and cannot mutate content.
-- **Deploy** (`/admin/deploy`): deploy courses and achievements on-chain (Course PDA + Metaplex Core collection), and deactivate/reactivate courses. Recorded in the Supabase `onchain_deployments` table, which **is** the learner-visibility gate.
-- **Moderation** (`/admin/moderation`): the pending community-flag queue.
-- **Status** (`/admin/status`): program liveness, authority match, deploy counts, and on-chain → Supabase resync.
-
-For details, see [docs/ADMIN.md](docs/ADMIN.md).
+Access is your ordinary Supabase session checked against an `admin_users`
+allowlist that only the service role can read. There is no admin password and no
+login form — signed-in non-admins get a 404. See [docs/ADMIN.md](docs/ADMIN.md).
 
 ## Documentation
 
-| Document                                     | Description                                               |
-| -------------------------------------------- | --------------------------------------------------------- |
-| [Architecture](docs/ARCHITECTURE.md)         | System design, account maps, data flows, content pipeline |
-| [Customization](docs/CUSTOMIZATION.md)       | Theming, i18n, gamification, and extending                |
-| [Admin Guide](docs/ADMIN.md)                 | The 4-screen console: publish, deploy, moderate, status   |
-| [Deployment](docs/DEPLOYMENT.md)             | Vercel, Supabase, content bundle, build server            |
-| [Program Deployment](docs/DEPLOY-PROGRAM.md) | On-chain program build, deploy, and initialize            |
-| [Developer Reference](CLAUDE.md)             | Full codebase conventions, security model, API routes     |
-
-## Known Limitations / Roadmap
-
-The on-chain program is feature-complete with 18 instructions covering the full learning lifecycle. The following items are scoped for future iterations:
-
-- **Track collection enforcement**: `track_collection` is validated server-side during credential issuance but is not yet enforced on-chain as an account constraint (future program upgrade).
-- **`perfect-score` achievement**: dropped, not deferred. Block results are transient by design, so there is no durable "passed on first try" signal to key it on.
-- **Build server**: Compilation features (`buildable` Rust challenges + program deployment) require a separately deployed Rust/Axum build server on GCP Cloud Run. See the [Deployment](#deployment) section for setup details.
-
-## Code Quality
-
-- TypeScript strict mode with zero `any` types
-- ESLint + Prettier enforced via Husky pre-commit hooks
-- Conventional commits: `feat:`, `fix:`, `docs:`, `chore:`, `refactor:`
-- All UI strings externalized via next-intl (never hardcoded)
-- Server components by default, client components only when needed
-- RLS enabled on all Supabase tables; sensitive functions restricted to `service_role`
+| Doc                                                   | What it covers                                           |
+| ----------------------------------------------------- | -------------------------------------------------------- |
+| [ARCHITECTURE.md](docs/ARCHITECTURE.md)               | System design, data flows, service interfaces, DB schema |
+| [AUTH-FLOWS.md](docs/AUTH-FLOWS.md)                   | Every way into a session, mapped from the code           |
+| [SPEC.md](docs/SPEC.md)                               | Authoritative on-chain program specification             |
+| [DEPLOYMENT.md](docs/DEPLOYMENT.md)                   | Vercel, Supabase, Cloud Run, cron, analytics             |
+| [DEPLOY-PROGRAM.md](docs/DEPLOY-PROGRAM.md)           | Build, deploy, and initialize the program on devnet      |
+| [ADMIN.md](docs/ADMIN.md)                             | The admin console, screen by screen                      |
+| [CUSTOMIZATION.md](docs/CUSTOMIZATION.md)             | Theming, i18n, extending content and gamification        |
+| [PINOCCHIO-MIGRATION.md](docs/PINOCCHIO-MIGRATION.md) | What changed in the Anchor → Pinocchio port              |
+| [DB-MIGRATION-LEDGER.md](docs/DB-MIGRATION-LEDGER.md) | Filename ↔ prod migration-ledger reconciliation          |
 
 ## Contributing
 
-1. Fork the repository
-2. Create a feature branch: `git checkout -b feat/your-feature`
-3. Commit using conventional commits: `git commit -m "feat: add quiz lesson type"`
-4. Push and open a pull request
+Branch, commit conventionally, open a PR:
+
+```bash
+git checkout -b feat/your-thing
+git commit -m "feat: add quiz lesson type"
+```
+
+House rules that CI actually enforces: TypeScript strict with no `any`, all UI
+strings through next-intl, server components by default, ESLint + Prettier on a
+pre-commit hook, and a byte-comparison of the committed content bundle against a
+fresh recompile.
 
 ## License
 
-MIT
+MIT.
 
-## Acknowledgments
-
-- [Superteam Brazil](https://superteam.fun) -- community and bounty program
-- [Solana Foundation](https://solana.org) -- blockchain infrastructure
-- Built with [Claude Code](https://claude.ai/claude-code) (Anthropic)
+Thanks to [Superteam Brazil](https://superteam.fun) and the
+[Solana Foundation](https://solana.org).

--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -39,7 +39,7 @@ Server components share one per-request claims read via `getAuthClaims()` (`lib/
 
 ### Achievements
 
-The curated set (currently 10) lives in `solanabr/academy-courses` under `achievements/` — git is the source of truth; do not enumerate them here.
+The curated set (currently 18 — the course-agnostic ladder, Speedrunner as the only course badge) lives in `solanabr/academy-courses` under `achievements/` — git is the source of truth; do not enumerate them here.
 
 **Unlock logic is declarative, not a per-achievement map.** Each achievement doc carries an `award` rule (a discriminated union of `AwardKind`); `lib/gamification/achievements.ts` holds `PREDICATES satisfies Record<AwardKind, Predicate>` — one predicate per _kind_, so adding a kind without a predicate is a compile error, and no course/path id is ever hardcoded. Adding an achievement means adding a content doc, not code.
 

--- a/docs/ADMIN.md
+++ b/docs/ADMIN.md
@@ -1,4 +1,4 @@
-> Last synced: 2026-07-12
+> Last synced: 2026-08-24
 
 # Admin Console Guide
 
@@ -13,31 +13,50 @@ repo and ships to the app as a **committed, compiled bundle**. The console holds
 **no content-write token** and cannot mutate content — publishing is a pull
 request. See [Publishing content](#1-publish--pin-the-content-bundle).
 
-## Accessing the console
+## Access
 
 The console lives at `/{locale}/admin` (e.g. `/en/admin`).
 
-**Authentication**: `/admin` renders a login form. Enter the value of
-`ADMIN_SECRET`. On success the server sets an **HMAC-signed `admin_session`
-cookie**, and `/admin` redirects to `/admin/courses` (the default screen).
+**There is no admin password and no login form.** Access is your ordinary
+Supabase session, checked against the `admin_users` allowlist table. Grant
+yourself access by inserting your `auth.users` id into `admin_users` — that table
+has RLS on with **zero policies** plus explicit REVOKEs, so only the service role
+can read or write it, and no `ADMIN_SECRET`-style shared credential exists.
 
-- The middleware bounces unauthenticated `/admin/*` sub-routes back to `/admin`.
-- Every `/api/admin/*` route authorizes on that **signed cookie plus a
-  same-origin check** (`requireAdminAuth`, `lib/admin/auth.ts`). There is no
-  `Authorization: Bearer <ADMIN_SECRET>` header path — the secret is only ever
-  submitted once, at login, and is never read in a page component (so it cannot
-  leak into a client payload).
+How it is enforced, in layers:
+
+- Middleware redirects a session-less `/admin` to the localized landing.
+- `requireAdmin()` (`lib/admin/auth.ts`) verifies the user server-side via
+  `supabase.auth.getUser()` — never a client-supplied id — then checks the
+  allowlist with the service-role client. It fails closed on everything: no
+  session, expired session, DB error, missing env.
+- Both `admin/layout.tsx` and `admin/page.tsx` call it and `notFound()` on
+  failure, so a signed-in non-admin gets a **404** and the panel's existence is
+  not revealed. A new admin sub-page that does its own server-side private fetch
+  must call `requireAdmin()` itself — Next renders segments in parallel, so the
+  layout's check does not gate a sibling's data fetch.
+- Every `/api/admin/*` route calls `requireAdminAuth()`, which adds a same-origin
+  CSRF check (`Sec-Fetch-Site`, falling back to `Origin`) on state-changing
+  methods and returns the acting admin's id for attribution.
+
+> The old `ADMIN_SECRET` / HMAC-`admin_session`-cookie system is **retired** and
+> can be deleted from your Vercel environment. One straggler: the operator script
+> `scripts/init-program.ts` still reads `ADMIN_SECRET` as a bearer token for its
+> admin API calls, and is therefore broken against the current routes.
 
 ## Required environment variables
 
+Admin **auth** needs no environment variable at all. These are what the admin
+_operations_ need:
+
 | Variable                    | Required for                                                                                                                                                                                         |
 | --------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `ADMIN_SECRET`              | Console login + the HMAC key that signs `admin_session`. Min 32 random chars. Unset → the console cannot be logged into and admin routes 401.                                                        |
+| `SUPABASE_SERVICE_ROLE_KEY` | The `admin_users` allowlist read, `onchain_deployments` writes, and the moderation queue. Without it every admin check fails closed.                                                                 |
 | `PROGRAM_AUTHORITY_SECRET`  | The `Config.authority` keypair. Signs `create_course`, `update_course`, `create_achievement_type` from the **Courses** screen.                                                                       |
 | `BACKEND_SIGNER_SECRET`     | The keypair registered in `Config.backend_signer`. Signs lesson/credential instructions from the learner-facing API routes.                                                                          |
 | `SOLANA_RPC_URL`            | Server-only RPC (may carry the Helius key). Required at boot — every admin screen reads chain state through it.                                                                                      |
-| `SUPABASE_SERVICE_ROLE_KEY` | Service-role writes to `onchain_deployments` (deploy status) and reads of the moderation queue.                                                                                                      |
 | `GITHUB_TOKEN`              | Fine-grained **read** token for `solanabr/academy-courses`. Powers the publish card's HEAD polling + CI-checks lookup. Unset → Publish shows "drift unavailable" (503); everything else still works. |
+| `RESEND_API_KEY`            | The course-announcement send. Unset ⇒ nothing is ever sent (fail-closed).                                                                                                                            |
 
 `GITHUB_TOKEN` is read-only by design. **No admin route holds a GitHub write
 token** — nothing in the app can push a commit or open a PR on your behalf.
@@ -52,6 +71,16 @@ token** — nothing in the app can push a commit or open a PR on your behalf.
 | **Moderation** | `/admin/moderation` | The pending community-flag queue (resolve / dismiss)                            |
 | **Insights**   | `/admin/insights`   | Platform-behaviour aggregates: AI-tutor usage, spend, lesson funnel             |
 | **Status**     | `/admin/status`     | Network, program liveness, authority match, deploy counts, on-chain → DB resync |
+
+Two admin capabilities have no nav entry of their own:
+
+- **Platform freeze** (`/api/admin/freeze`) — a global deploy-window kill switch.
+  While it is on, the `pending_onchain_actions` drain defers wholesale rather
+  than writing to a chain that is mid-migration. The freeze route is
+  deliberately not itself freeze-gated, so it can always be turned back off.
+- **Course recreate** (`/api/admin/courses/recreate`) — **destructive**: it
+  closes and recreates a Course PDA. Always run
+  `/api/admin/courses/recreate/preflight` (read-only) first.
 
 The nav rail is persistent (left rail on desktop, tabs on mobile). The
 **Moderation** tab carries a badge with the pending-flag count.
@@ -255,21 +284,22 @@ on-chain transaction. On-chain is the source of truth; the mirror is rebuildable
 
 ## Troubleshooting
 
-| Symptom                                       | Check                                                                                                                                    |
-| --------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| **"Unauthorized" / 401 on every admin route** | `ADMIN_SECRET` unset, or the `admin_session` cookie expired — log in again. Cross-origin requests are rejected by design.                |
-| **Publish card says "drift unavailable"**     | `GITHUB_TOKEN` unset or GitHub unreachable. The route 503s rather than crashing. Unauthenticated GitHub is 60 req/hr per IP.             |
-| **Course not visible to learners**            | Its `onchain_deployments` row must be `status = "synced"` and `is_active` not `false`. Deploy it from `/admin/courses`.                  |
-| **New lesson not showing up**                 | The bundle is pinned. Bump `content.lock` and recompile — merging content to `academy-courses` alone changes nothing in the app.         |
-| **"Transaction failed" on Deploy**            | Verify `PROGRAM_AUTHORITY_SECRET` is the real `Config.authority` (the Status screen's authority match tells you) and is funded with SOL. |
-| **CI fails with "Content bundle is stale"**   | You bumped `content.lock` without recompiling, or hand-edited the generated bundle. Run `pnpm --filter web compile-content` and commit.  |
+| Symptom                                     | Check                                                                                                                                     |
+| ------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| **404 on `/admin` while signed in**         | Your user id is not in `admin_users`. Insert it with the service role. A 404 rather than a 403 is deliberate.                             |
+| **401 on an admin API route**               | No Supabase session, or the request was cross-origin — both are rejected by design. `SUPABASE_SERVICE_ROLE_KEY` unset fails the same way. |
+| **Publish card says "drift unavailable"**   | `GITHUB_TOKEN` unset or GitHub unreachable. The route 503s rather than crashing. Unauthenticated GitHub is 60 req/hr per IP.              |
+| **Course not visible to learners**          | Its `onchain_deployments` row must be `status = "synced"` and `is_active` not `false`. Deploy it from `/admin/courses`.                   |
+| **New lesson not showing up**               | The bundle is pinned. Bump `content.lock` and recompile — merging content to `academy-courses` alone changes nothing in the app.          |
+| **"Transaction failed" on Deploy**          | Verify `PROGRAM_AUTHORITY_SECRET` is the real `Config.authority` (the Status screen's authority match tells you) and is funded with SOL.  |
+| **CI fails with "Content bundle is stale"** | You bumped `content.lock` without recompiling, or hand-edited the generated bundle. Run `pnpm --filter web compile-content` and commit.   |
 
 ---
 
 ## Security notes
 
-- `ADMIN_SECRET` must be at least 32 random characters and is never committed. It
-  is the HMAC key for the session cookie — rotating it invalidates all sessions.
+- Admin access is a row in `admin_users`, not a shared secret. Revoking someone
+  is a `DELETE`; there is no password to rotate and nothing to leak.
 - `PROGRAM_AUTHORITY_SECRET` and `BACKEND_SIGNER_SECRET` must never reach the
   browser. Every admin route and signer module is `import "server-only"`.
 - The `onchain_deployments` base table has **RLS on with no policies** —

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,203 +1,170 @@
-> Last synced: 2026-07-12
+> Last synced: 2026-08-24
 
-# Superteam Academy -- Architecture Reference
+# Architecture Reference
 
-System architecture, component structure, data flow, and service interfaces for Superteam Academy -- a Solana-native educational LMS.
+System architecture, data flows, and service interfaces for Superteam Academy.
 
-**There is no CMS.** Course content is authored in a git repo, compiled ahead of
-time, and **committed** to this repo as a typed bundle. Nothing fetches content at
-runtime. See [§3 Data Flow](#3-data-flow).
+Two invariants shape everything below:
+
+- **On-chain is the source of truth** for XP balances, lesson completion, and
+  credentials. Supabase mirrors them for fast queries; mirror writes are
+  non-fatal and rebuildable.
+- **There is no CMS.** Course content is authored in a git repo, compiled ahead
+  of time, and committed to this repo as typed JSON. Nothing fetches content at
+  runtime.
+
+Companion docs: [SPEC.md](./SPEC.md) is the authoritative on-chain program
+specification; [AUTH-FLOWS.md](./AUTH-FLOWS.md) is the authoritative map of
+sign-in. This document does not duplicate either — it says how they connect.
 
 ---
 
-## 1. System Architecture Overview
+## 1. The shape of the system
 
 ```
-┌──────────────────────────────────────────────────────────────────────┐
-│                        BROWSER (Client)                              │
-│                                                                      │
-│  React + Solana Wallet Adapter (Phantom, Solflare, Backpack)         │
-│  Monaco Editor (code challenges) · canvas-confetti (celebrations)    │
-└───────────┬─────────────────────────┬────────────────────────────────┘
-            │ fetch / POST            │ wallet signs (enroll, close)
-            │                         │
-┌───────────▼─────────────────────────▼────────────────────────────────┐
-│                    NEXT.JS 14 (App Router on Vercel)                  │
-│                                                                      │
-│  Server Components ── API Routes ── Middleware (auth + i18n)         │
-│                                                                      │
-│  ┌────────────────────────────────────────────────────────────────┐  │
-│  │  COMMITTED CONTENT BUNDLE  (src/content/generated/*.json)      │  │
-│  │  compiled from solanabr/academy-courses @ content.lock sha     │  │
-│  │  statically imported — no runtime content fetch, no CMS        │  │
-│  └────────────────────────────────────────────────────────────────┘  │
-│                                                                      │
-│  Holds: BACKEND_SIGNER_SECRET · PROGRAM_AUTHORITY_SECRET             │
-│         SUPABASE_SERVICE_ROLE_KEY · GITHUB_TOKEN (READ-ONLY)         │
-└──────────────┬──────────────┬──────────────┬─────────────────────────┘
-               │              │              │
-               ▼              ▼              ▼
-        ┌────────────┐  ┌───────────┐  ┌──────────────────────────────┐
-        │  Supabase  │  │  Solana   │  │  Build Server (Rust/Axum)    │
-        │  (DB+Auth) │  │ (Devnet)  │  │  on GCP Cloud Run            │
-        │            │  │           │  │  cargo-build-sbf --offline   │
-        │ user data  │  │ Token-2022│  └──────────────────────────────┘
-        │ +on-chain  │  │ Metaplex  │
-        │  status    │  │   Core    │
-        └────────────┘  └───────────┘
+┌─────────────────────────────────────────────────────────────────────┐
+│  BROWSER                                                            │
+│  React 18 · wallet-adapter (external wallets) · Dynamic (embedded)  │
+│  Monaco (code challenges) · QuickJS sandbox (challenge runner)      │
+└──────────┬──────────────────────────────┬───────────────────────────┘
+           │ fetch / POST                 │ wallet signs (enroll, close)
+┌──────────▼──────────────────────────────▼───────────────────────────┐
+│  NEXT.JS 15 App Router (Vercel)                                     │
+│  Server Components · 72 API routes · middleware (auth + i18n + CSP) │
+│                                                                     │
+│  ┌───────────────────────────────────────────────────────────────┐  │
+│  │ COMMITTED CONTENT BUNDLE  src/content/generated/*.json        │  │
+│  │ compiled from solanabr/academy-courses @ content.lock sha     │  │
+│  │ statically imported — no runtime fetch, no CMS                │  │
+│  └───────────────────────────────────────────────────────────────┘  │
+│                                                                     │
+│  Holds: BACKEND_SIGNER_SECRET · PROGRAM_AUTHORITY_SECRET            │
+│         SUPABASE_SERVICE_ROLE_KEY · GEMINI_API_KEY · RESEND_API_KEY │
+│         GITHUB_TOKEN (read-only)                                    │
+└────────┬─────────────┬─────────────┬────────────────┬───────────────┘
+         │             │             │                │
+         ▼             ▼             ▼                ▼
+   ┌──────────┐  ┌──────────┐  ┌────────────┐  ┌────────────────┐
+   │ Supabase │  │  Solana  │  │ Build svr  │  │ Gemini, Resend │
+   │  DB+Auth │  │  devnet  │  │ Cloud Run  │  │ Helius, Irys   │
+   │ 36 tables│  │Token-2022│  │ Rust/Axum  │  └────────────────┘
+   │  RLS on  │  │ MPL Core │  └────────────┘
+   └──────────┘  └──────────┘
+        ▲
+        │ Helius webhook → /api/webhooks/helius → DB credit
+        └── on-chain events replayed into the mirror
 ```
 
-Build-time only (not a runtime dependency):
+Build-time only, not a runtime dependency:
 
 ```
 solanabr/academy-courses ──► compile-content.ts ──► committed bundle
-      (git = source of truth)      (pinned by apps/web/content.lock)
+      (git = source of truth)   (pinned by apps/web/content.lock)
 ```
 
-### Monorepo Layout
+### Monorepo layout
 
-| Directory                      | Purpose                                                                                 |
-| ------------------------------ | --------------------------------------------------------------------------------------- |
-| `apps/web/`                    | Next.js 14 application (pages, API routes, components, services)                        |
-| `apps/build-server/`           | Rust/Axum Solana program compiler on GCP Cloud Run                                      |
-| `onchain-academy/`             | On-chain program workspace (Pinocchio implementation, IDL, tests)                       |
-| `packages/types/`              | Shared TypeScript interfaces (`Course`, `Lesson`, `LessonBlock`, …)                     |
-| `packages/content-schema/`     | Zod schemas for the content standard (course, lesson, blocks, achievement, quest, path) |
-| `packages/content-lint/`       | The content linter — runs in `academy-courses` CI, gating what is publishable           |
-| `packages/challenge-executor/` | Challenge runner (QuickJS sandbox) shared by the app and the linter's executor gate     |
-| `packages/deploy/`             | Browser-based Solana program deployment library                                         |
-| `packages/config/`             | Shared ESLint, TypeScript, Tailwind configs                                             |
-| `supabase/`                    | Postgres schema + migrations (21 tables, indexes, RLS, functions, views)                |
+| Directory                      | Purpose                                                             |
+| ------------------------------ | ------------------------------------------------------------------- |
+| `apps/web/`                    | Next.js 15 app — pages, API routes, components, service layer       |
+| `apps/build-server/`           | Rust/Axum SBF compiler on Cloud Run                                 |
+| `onchain-academy/`             | Pinocchio program workspace, committed IDL, Rust + LiteSVM tests    |
+| `packages/types/`              | Shared TypeScript interfaces                                        |
+| `packages/content-schema/`     | Zod schemas for the content standard                                |
+| `packages/content-lint/`       | Content linter — the gate in `academy-courses` CI                   |
+| `packages/challenge-executor/` | Sandboxed challenge runner shared by the app and the linter         |
+| `packages/deploy/`             | Browser-side Solana program deployment (BPF loader chunking)        |
+| `packages/config/`             | Shared ESLint, TypeScript, Tailwind configs                         |
+| `supabase/`                    | 62 migrations (source of truth) + a generated `schema.sql` snapshot |
 
-Content itself lives **outside** this repo, in
-[`solanabr/academy-courses`](https://github.com/solanabr/academy-courses).
+### Deployment model
 
-### Deployment Model
-
-| Service          | Host                       | Notes                                                          |
-| ---------------- | -------------------------- | -------------------------------------------------------------- |
-| Web app          | Vercel                     | Edge middleware, automatic deploys from `main`                 |
-| Database + Auth  | Supabase (hosted Postgres) | RLS, SECURITY DEFINER functions. Prod project: `<project-ref>` |
-| Content          | **Committed to this repo** | Compiled bundle; no hosted service, no runtime credential      |
-| On-chain program | Solana devnet              | Pinocchio 0.11 (see docs/SPEC.md), Token-2022, Metaplex Core   |
-| Build server     | GCP Cloud Run              | Docker, no IAM gateway, `X-API-Key` auth                       |
+| Service          | Host              | Notes                                                    |
+| ---------------- | ----------------- | -------------------------------------------------------- |
+| Web app          | Vercel            | Root directory `apps/web`, auto-deploys from `main`      |
+| Database + Auth  | Supabase          | RLS everywhere, SECURITY DEFINER functions, service_role |
+| Content          | Committed to repo | No hosted service, no runtime credential                 |
+| On-chain program | Solana devnet     | Pinocchio 0.11, Token-2022, Metaplex Core                |
+| Build server     | GCP Cloud Run     | Docker, `X-API-Key` at the app layer, scale-to-zero      |
+| Scheduled jobs   | Vercel Cron       | Two email jobs, declared in `apps/web/vercel.json`       |
 
 ---
 
-## 2. Component Structure
-
-### Page Hierarchy
+## 2. Page structure
 
 ```
-RootLayout (app/layout.tsx)
-  └── [locale] layout (ThemeProvider + SolanaWalletProvider + GamificationOverlays)
-       ├── (marketing)/           ← Public landing page
-       │    └── page.tsx          ← Landing with terminal typewriter
-       │
-       ├── (platform)/            ← Platform routes (layout: Header + Sidebar + Footer)
-       │    ├── dashboard/        ← Auth-gated: enrolled courses, XP, streaks, daily quests
-       │    ├── courses/          ← Public: course catalog
-       │    │    └── [slug]/      ← Public: course detail
-       │    │         └── lessons/[id]/  ← Public: lesson view + code editor
-       │    ├── community/        ← Public: forum home (categories)
-       │    │    └── [category-slug]/   ← Category threads
-       │    │         └── [thread-slug]/ ← Thread detail + answers
-       │    ├── profile/          ← Auth-gated (own profile)
-       │    │    └── [username]/  ← Public: other users' profiles
-       │    ├── leaderboard/      ← Public: XP rankings
-       │    ├── certificates/     ← Public: certificate list
-       │    │    └── [id]/        ← Public: individual certificate
-       │    └── settings/         ← Auth-gated: account settings
-       │
-       └── admin/                 ← Admin console (signed admin_session cookie required)
-            ├── courses/          ← Default screen. Step 1 publish (content pin: bundle
-            │                       SHA vs academy-courses HEAD) + step 2 deploy (course
-            │                       & achievement on-chain tables), with a state legend
-            ├── publish/          ← Redirect → courses/ (retired screen, kept for bookmarks)
-            ├── deploy/           ← Redirect → courses/ (retired screen, kept for bookmarks)
-            ├── moderation/       ← Pending community-flag queue
-            └── status/           ← Program health + data resync
+app/layout.tsx
+  └── [locale]/  (ThemeProvider + wallet providers + reward overlays)
+       ├── (marketing)/       landing, /start onboarding intake
+       ├── (platform)/        header + sidebar chrome
+       │    ├── dashboard/    auth-gated: enrolled courses, XP, streak, quests
+       │    ├── courses/[slug]/lessons/[id]
+       │    ├── community/[category]/[thread]
+       │    ├── leaderboard/  all-time, weekly, monthly, cohort
+       │    ├── certificates/[id]
+       │    ├── profile/[username]
+       │    ├── review/       spaced repetition
+       │    ├── teach/        instructor course stats + PR preview
+       │    └── settings/
+       └── admin/             courses · moderation · insights · status
 ```
 
-`/admin` itself renders the login form when unauthenticated and redirects to
-`/admin/courses` when authenticated. A persistent nav rail (rendered by the
-admin `layout.tsx`) links the three screens.
+Auth-gated: `/dashboard`, `/settings`, `/teach`, `/review`, and `/profile`
+exactly. Everything else on the platform is publicly readable — a signed-out
+visitor can read a lesson, they just cannot complete one.
 
-### Component Groups
-
-| Directory       | Components                                                                                                                                                                                                       | Purpose                                                    |
-| --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
-| `ui/`           | Button, Card, Dialog, Avatar, Progress, Tabs, DropdownMenu                                                                                                                                                       | shadcn/ui base primitives (Radix UI)                       |
-| `course/`       | CourseCard, ProgressBar, CurriculumAccordion, DifficultyBadge                                                                                                                                                    | Course display and progress tracking                       |
-| `community/`    | ThreadList, ThreadCard, AnswerCard, AnswerEditor, VoteButton, FlagButton, AcceptAnswerButton, CommunitySearch, CommunityStats, CreateThreadModal, CategoryCard, ThreadFilters, ThreadStatusBadge, MarkdownEditor | Forum threads, answers, voting, moderation (14 components) |
-| `editor/`       | ChallengeInterface, CodeEditor, ChallengeRunner, OutputPanel                                                                                                                                                     | Monaco editor with in-browser test runner                  |
-| `gamification/` | XpPopup, LevelUpOverlay, LevelBadge, StreakDisplay, SkillRadar, AchievementCard, AchievementGrid, AchievementPopup, CertificatePopup, GamificationOverlays                                                       | XP animations, achievement celebrations, streak display    |
-| `certificates/` | CertificateCard, CertificateGrid, CourseCompletionMint                                                                                                                                                           | NFT credential display and minting UI                      |
-| `deploy/`       | DeployPanel, WalletFundingCard, GenericProgramExplorer                                                                                                                                                           | Student program deployment panel                           |
-| `admin/`        | CourseSyncTable, AchievementSyncTable, DataResyncPanel, FlagsPanel, StatusBadge, SyncDiffView                                                                                                                    | Admin console: content-to-chain deploy, resync, moderation |
-| `auth/`         | AuthModal, WalletAuthHandler, UserMenu                                                                                                                                                                           | Wallet + OAuth authentication                              |
-| `layout/`       | Header, Footer, Sidebar, LanguageSwitcher, ThemeProvider, ThemeToggle                                                                                                                                            | Page chrome, navigation, theming                           |
-| `landing/`      | TerminalTypewriter                                                                                                                                                                                               | Landing page animation                                     |
-| `profile/`      | WalletNameGenerator                                                                                                                                                                                              | Fun name generation for wallet users                       |
-| `analytics/`    | AnalyticsProvider                                                                                                                                                                                                | GA4 + PostHog + Sentry wrapper                             |
-
-### Client vs Server Components
-
-| Type                    | Used For                             | Examples                                                 |
-| ----------------------- | ------------------------------------ | -------------------------------------------------------- |
-| Server                  | Data fetching, SEO, static rendering | Course detail page, lesson page, leaderboard             |
-| Client (`"use client"`) | Interactivity, browser APIs, wallet  | AuthModal, CodeEditor, GamificationOverlays, ThemeToggle |
+`/start` (under `(marketing)`, ISR at 300s) is the onboarding intake: a few taps
+map the learner to one of three segments and route them at an entry lesson. The
+route resolution is sync-gated — an unsynced entry course falls back to
+`/courses` rather than a 404ing lesson page.
 
 ---
 
-## 3. Data Flow
+## 3. Data flow
 
-### Four Data Sources
+### Four data sources
 
-| Source                       | Data                                                                                            | Access Pattern                                                            |
-| ---------------------------- | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
-| **Committed content bundle** | Course content (courses, lessons, blocks, achievements, quests, paths)                          | Statically imported at build time by `lib/content/store.ts` (server-only) |
-| **Supabase Postgres**        | User data (profiles, progress, XP, achievements, certificates) **+ on-chain deployment status** | Client reads via anon key + RLS; writes via API routes + service_role     |
-| **Solana Blockchain**        | Token-2022 XP balances, Enrollment PDAs, Credential NFTs                                        | On-chain writes via backend signer; reads via RPC                         |
-| **Build Server**             | Compiled Solana programs (.so binaries)                                                         | POST source to `/build`, GET binary from `/deploy/{uuid}`                 |
+| Source            | Data                                                  | Access                                                |
+| ----------------- | ----------------------------------------------------- | ----------------------------------------------------- |
+| Committed bundle  | Courses, lessons, blocks, achievements, quests, paths | Static import at build time, `server-only`            |
+| Supabase Postgres | User data + on-chain deployment status                | Anon key + RLS for reads; service_role via API routes |
+| Solana            | Token-2022 XP, Enrollment PDAs, credential NFTs       | Backend signer writes; RPC + Helius webhook reads     |
+| Build server      | Compiled `.so` binaries                               | `POST /build`, returned inline as base64              |
 
-### Content Flow (git to pages)
-
-Content is **compiled ahead of time and committed**. Nothing fetches it at
-request time.
+### Content: git to page
 
 ```
-solanabr/academy-courses         ← git repo: course.yaml, lesson.yaml,
-        │                          achievements/, quests/, paths/, instructors/
+solanabr/academy-courses     course.yaml, lesson.yaml, achievements/,
+        │                    quests/, paths/, skills/, slots.lock.json
         │  pinned to ONE commit by apps/web/content.lock
         ▼
 apps/web/scripts/compile-content.ts
         │  fetch tarball @ locked SHA → Zod-validate every doc (fail-closed)
         │  → project → emit deterministic JSON (sorted keys, no timestamps)
         ▼
-apps/web/src/content/generated/*.json   ← COMMITTED, prettier-ignored
-apps/web/public/content-assets/*        ← COMMITTED
+apps/web/src/content/generated/*.json    COMMITTED, prettier-ignored
+apps/web/public/content-assets/*         COMMITTED
         │
         ▼ static import (server-only)
-lib/content/store.ts  ──►  lib/content/queries.ts  ──►  Server Components
+lib/content/store.ts ──► lib/content/queries.ts ──► Server Components
 ```
 
-Properties this buys:
+The bundle currently carries 4 courses, 23 lessons, 18 achievements, 5 quests,
+and 1 learning path (see `meta.json`).
 
-- **Determinism** — output is a pure function of the locked SHA. CI recompiles and
-  fails on any byte of drift, catching a stale bundle after a lock bump _and_ a
-  hand-edit of the generated files.
+What this buys:
+
+- **Determinism** — output is a pure function of the locked SHA. CI recompiles
+  and fails on a single byte of drift, catching both a stale bundle after a lock
+  bump and a hand-edit of the generated files.
 - **No runtime dependency** — a content-repo outage cannot affect the site.
-- **No content-write credential exists.** The app cannot mutate content under any
-  credential. Publishing is a PR that bumps `content.lock` + commits the
-  regenerated bundle. `GITHUB_TOKEN` is **read-only** and only polls HEAD/CI state
-  for the admin Publish screen.
+- **No content-write credential exists.** Publishing is a PR that bumps
+  `content.lock` and commits the regenerated bundle. `GITHUB_TOKEN` is read-only
+  and only polls HEAD and CI state for the admin publish card.
 
-`lib/content/store.ts` is `server-only` **by necessity**: the bundle contains quiz
-answer keys, code solutions, and hidden tests. The `server-only` marker makes a
-client value-import a build error. Client components read the safe subset through
-the public `/api/content/*` routes (via `lib/content/client-queries.ts`, whose fn
-signatures are identical to the server ones).
+`lib/content/store.ts` is `server-only` **by necessity**: the bundle holds quiz
+answer keys, code solutions, and hidden tests, so a client value-import must be a
+build error. Client components read the safe subset through `/api/content/*`.
 
 ### The visibility gate
 
@@ -207,929 +174,505 @@ A course is visible to learners **iff its Supabase deployment row says so**:
 visible  ⇔  onchain_deployments.status == "synced"  AND  coalesce(is_active, true)
 ```
 
-This is the post-SP2 replacement for the old CMS `onChainStatus` field. It lives in
-**exactly one function** — `isSynced()` in `lib/content/deployments.ts` — and is
-applied to every public read. Content with **no** deployment row is **hidden**
-(fail-closed: hidden > leaked). `is_active` is tri-state; `NULL` coalesces to
-`true`, so deactivation is opt-in.
+It lives in exactly one function — `isSynced()` in `lib/content/deployments.ts` —
+and is applied to every public read. Content with **no** deployment row is hidden
+(fail-closed). `is_active` is tri-state; `NULL` coalesces to `true`, so
+deactivation is opt-in.
 
-Two read paths into `onchain_deployments`:
+Two read paths:
 
-| Function                 | Client                                                                                                                    | Used by                                                             |
-| ------------------------ | ------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
-| `getActiveDeployments()` | Cookieless **anon** client over the `public_onchain_deployments` view, wrapped in `unstable_cache` (tag `courses`, 3600s) | Public catalog + lesson reads. Cookieless so pages stay static/ISR. |
-| `getDeploymentById(id)`  | **service_role** client, uncached, full row                                                                               | Reward paths + admin reads that need `track_collection_address`     |
+| Function                 | Client                                                                 | Used by                         |
+| ------------------------ | ---------------------------------------------------------------------- | ------------------------------- |
+| `getActiveDeployments()` | Cookieless anon read of `public_onchain_deployments`, `unstable_cache` | Public catalog and lesson reads |
+| `getDeploymentById(id)`  | service_role, uncached, full row                                       | Reward paths and admin reads    |
 
-Key queries in `lib/content/queries.ts` (server-only):
+The cookieless anon path is what keeps catalog and lesson routes static/ISR; an
+admin sync purges the `courses` tag via `revalidateTag`.
 
-| Function                                  | Returns                                                                  |
-| ----------------------------------------- | ------------------------------------------------------------------------ |
-| `getAllCourses()`                         | All synced+active courses with lesson summaries                          |
-| `getCourseBySlug(slug)`                   | Single course with full lesson content                                   |
-| `getLessonBySlug(courseSlug, lessonSlug)` | Single lesson with its ordered `blocks[]` (code, tests, hints, solution) |
-| `getCourseById(id)`                       | Course by content `_id` (used in API routes)                             |
-| `getAllCourseLessonCounts()`              | `{ _id, totalLessons }[]` for course-completion detection                |
-| `getAllAchievements()`                    | All achievement definitions (for unlock checking)                        |
-| `getDeployedAchievements()`               | Achievements with on-chain PDAs only                                     |
-| `getAllCoursesAdmin()`                    | All courses joined with their full Supabase deployment row               |
-| `getAllAchievementsAdmin()`               | All achievements joined with their full Supabase deployment row          |
+### Lesson slots — the bit that bites
 
-Deployment writes (`lib/content/deployment-writes.ts`, service_role only) — these
-kept their original signatures across the CMS removal, so their four call sites
-(`courses/sync`, `achievements/sync`, `courses/{deactivate,reactivate}`) were
-untouched:
+**A learner's on-chain progress bit is the lesson's SLOT from `slots.lock.json`,
+never its position in `course.yaml`.** `getLessonSlot()`
+(`lib/courses/lesson-slot.ts`) resolves it and **fails closed** — an unslotted
+lesson id throws rather than guessing, because a wrong slot corrupts on-chain
+state. `findLessonIndex()` is the array position and is display-only; conflating
+the two was a real incident. `deriveActiveMask()` builds the on-chain
+`active_lessons` mask from the same lock, and CI gate-3 in `content-lint` fails
+any `academy-courses` PR that moves a surviving slot, reuses a retired one, or
+walks `next` backwards.
 
-| Function                                                               | Purpose                                                    |
-| ---------------------------------------------------------------------- | ---------------------------------------------------------- |
-| `writeCourseOnChainStatus(id, status, coursePda, txSignature)`         | Upsert the course row as `synced` after an on-chain deploy |
-| `writeCourseTrackCollection(id, trackCollectionAddress)`               | Store the credential collection address                    |
-| `writeAchievementOnChainStatus(id, achievementPda, collectionAddress)` | Upsert the achievement row as `synced`                     |
+### Lesson completion (the critical path)
 
-Each upsert is keyed on the `content_id` PK and sets **only the columns that writer
-owns** (`ON CONFLICT DO UPDATE` merge semantics), preserving the rest of the row.
-
-### Auth Flow
-
-#### SIWS (Sign In With Solana)
+`POST /api/lessons/complete` orchestrates the whole learning loop:
 
 ```
-1. User clicks "Connect Wallet" → wallet adapter modal
-2. POST /api/auth/nonce → server generates nonce, stores in siws_nonces table (5-min TTL)
-3. Client builds SIWS message (domain, nonce, expiry) → wallet signs
-4. POST /api/auth/wallet → server validates:
-   ├── Nonce exists in siws_nonces with status='pending' and not expired
-   ├── Domain matches Host header
-   └── Ed25519 signature valid (tweetnacl)
-5. Server creates/finds user (synthetic email: {pubkey}@wallet.superteam-lms.local)
-6. Generates magic link → verifies OTP → session cookies set
-7. Updates profiles.wallet_address, assigns generated wallet name if placeholder
+1.  Auth ── Supabase session                            → 401
+2.  Enrollment check (Supabase)                          → 403
+3.  Idempotency: user_progress.completed                 → early return
+4.  Wallet + program liveness — no wallet or no program? skip chain, keep going
+5.  On-chain bitmap idempotency: isLessonComplete()      → skip the TX
+6.  complete_lesson — backend signer, XP minted by CPI   → 500 on TX failure
+7.  Re-fetch enrollment, test the mask for completion
+8.  finalize_course if complete — bonus XP + creator XP  (non-fatal)
+9.  issue_credential if finalized and no credential      (non-fatal)
+10. Supabase writes: user_progress (required), award_xp  (non-fatal)
+11. Achievement check against the content award rules    (non-fatal)
+12. Response → client enqueues reward popups
 ```
 
-#### Google/GitHub OAuth
+**The "non-fatal" pattern**: mirror writes and on-chain achievement mints are
+wrapped in try/catch. A failure is logged and queued, never a 500. On-chain state
+is the truth; the mirror is rebuildable from `/admin/status`.
+
+### The retry queue
+
+`pending_onchain_actions` holds anything the chain leg could not finish:
+`achievement | certificate | course_finalize | xp | quest_xp | quest_xp_mint |
+enroll`.
+
+Written from three places: Postgres itself (`get_daily_quest_state` inserts a
+`quest_xp` row **in the same transaction** that flips `xp_granted`, so a quest can
+never be marked granted without a durable pending row), the Helius event
+handlers, and the mint/quest API routes.
+
+Drained by `retryPendingOnchainActions()` (`lib/solana/onchain-queue.ts`) at the
+**three login chokepoints** — `/api/auth/callback`, `/api/auth/wallet`,
+`/api/auth/dynamic` — each inside `after()`, never a bare floating promise: the
+drain does per-row RPC reads and on-chain sends, and a detached promise can be
+killed mid-write when the response is flushed. Pass 1 settles DB-only `quest_xp`
+credits; pass 2 does on-chain work and needs a linked wallet. The whole pass
+defers when the platform freeze is on. `lib/dashboard/loaders.ts` runs a narrower
+quest-XP sweep for learners who never log out.
+
+### Helius webhook → DB credit
+
+`POST /api/webhooks/helius` is the read-back path that keeps the mirror honest
+when the app is not the one that observed the transaction.
 
 ```
-1. User clicks "Sign in with Google/GitHub"
-2. Supabase redirects to OAuth consent screen
-3. Provider redirects to /api/auth/callback with authorization code
-4. Server exchanges code for session (redirect URL sanitization applied)
-5. Database trigger auto-creates profiles + user_xp rows
-6. User redirected to dashboard
+Helius → Bearer compare (timing-safe, HELIUS_WEBHOOK_SECRET) → 1 MB body cap
+  → decodeEventsFromTransaction (Anchor event decode against the IDL)
+  → normalizeEventData → switch on event name
 ```
 
-### Lesson Completion Flow (Critical Path)
+| Event                | Credit                                                           |
+| -------------------- | ---------------------------------------------------------------- |
+| `Enrolled`           | upsert `enrollments`                                             |
+| `EnrollmentClosed`   | update `enrollments`                                             |
+| `LessonCompleted`    | upsert `user_progress`, then `award_xp()`                        |
+| `CourseFinalized`    | `award_xp()` for the learner **and** the creator; referral point |
+| `CredentialIssued`   | Irys/Arweave metadata upload + `nft_metadata` + `certificates`   |
+| `AchievementAwarded` | `unlock_achievement()` + `award_xp()`, deduped                   |
+| `XpRewarded`         | `award_xp()`                                                     |
 
-The `POST /api/lessons/complete` route orchestrates the entire learning loop. This is the most complex API route in the system. Each step is documented with its failure mode.
+Handler errors are logged and swallowed so the remaining events in a batch still
+process — the route never 500s at Helius. Anything that fails lands in
+`pending_onchain_actions`.
 
-```
-Client: POST /api/lessons/complete { lessonId, courseId }
-  │
-  ├── 1. Auth check ── getUser() from Supabase session cookie
-  │    Failure: 401 Unauthorized
-  │
-  ├── 2. Supabase enrollment check ── enrollments table lookup
-  │    Failure: 403 Not enrolled
-  │
-  ├── 3. Supabase idempotency check ── user_progress.completed lookup
-  │    If already completed: return { alreadyCompleted: true, xpEarned: 0 }
-  │
-  ├── 4. Wallet + program liveness check
-  │    If no wallet or program not deployed: skip on-chain, continue to DB writes
-  │
-  ├── 5. On-chain bitmap idempotency ── fetchEnrollment() → isLessonComplete()
-  │    If bit already set: skip completeLesson TX, fall through
-  │
-  ├── 6. completeLesson instruction ── backend signer signs, XP minted via CPI
-  │    Pre-instruction: create learner Token-2022 ATA if needed
-  │    Failure: 500 (transaction fails)
-  │
-  ├── 7. Re-fetch enrollment ── check updated bitmap for course completion
-  │
-  ├── 8. Auto-finalize if all lessons complete:
-  │    ├── finalizeCourse instruction ── completion bonus XP + creator XP
-  │    ├── Supabase mirror: enrollments.completed_at = now  (non-fatal)
-  │    └── Failure: logged, can retry later
-  │
-  ├── 9. Auto-mint credential if finalized and no credential_asset:
-  │    ├── Validate track collection (exists on-chain, owned by Metaplex Core)
-  │    ├── Store metadata JSON in nft_metadata table
-  │    ├── issueCredential instruction ── Metaplex Core NFT, Config PDA signs
-  │    ├── Supabase mirror: certificates table insert  (non-fatal)
-  │    └── Failure: logged, orphaned metadata cleaned up, non-fatal
-  │
-  ├── 10. Supabase DB writes:
-  │    ├── Upsert user_progress (lesson marked complete)  ── REQUIRED, 500 on failure
-  │    ├── award_xp() SECURITY DEFINER (XP + streak)  ── non-fatal
-  │    └── These are "Supabase mirror" writes: on-chain is source of truth
-  │
-  ├── 11. Achievement check:
-  │    ├── Fetch user state (XP, streaks, completed lessons/courses)
-  │    ├── checkNewAchievements() against UNLOCK_CHECKS
-  │    ├── For each new achievement:
-  │    │    ├── unlock_achievement() in Supabase  ── logged on failure
-  │    │    └── awardAchievement() on-chain (NFT mint)  ── non-fatal
-  │    └── Failed achievements listed in response as failedAchievements
-  │
-  └── 12. Response → client dispatches popup events:
-       ├── dispatchXpGain(xpEarned)           → "xp-gain" CustomEvent
-       ├── dispatchAchievementUnlock(id, name) → "superteam:achievement-unlock"
-       └── dispatchCertificateMinted(certId)   → "superteam:certificate-minted"
-```
+### Reward-XP idempotency
 
-**"Non-fatal" pattern**: Supabase mirror writes and on-chain achievement mints use try/catch. Failure is logged but does not abort the response or return a 500. The on-chain state (enrollment bitmap, XP tokens, credential NFT) is the source of truth; Supabase mirrors exist for fast queries, streaks, and leaderboards.
-
-### Enrollment Flow
-
-```
-1. Client builds enroll(courseId) instruction
-2. Learner wallet signs the transaction
-3. On-chain: Enrollment PDA created (lesson_flags = 0, completed_at = None)
-4. If course has prerequisite: verified via remaining accounts
-5. Supabase: enrollment row mirrored by the client via the enrollments table
-```
-
-### Admin Deployment Flow
-
-```
-/admin/courses → POST /api/admin/courses/sync
-  │
-  ├── requireAdminAuth() — same-origin check + HMAC-signed `admin_session` cookie
-  ├── deployCoursePda() via admin-signer.ts → createCourse instruction
-  ├── deployCourseTrackCollection() → Metaplex Core collection (UMI)
-  ├── writeCourseOnChainStatus()   → Supabase `onchain_deployments` row = "synced"
-  ├── writeCourseTrackCollection() → Supabase stores the collection address
-  └── revalidateTag("courses")     → purge the cached deployment map so the
-                                      catalog picks the new course up
-
-Similarly for achievements:
-  POST /api/admin/achievements/sync
-  ├── deployAchievementType() → createAchievementType + collection
-  └── writeAchievementOnChainStatus() → Supabase row = "synced"
-```
-
-**Admin auth is a signed cookie, not a bearer token.** `requireAdminAuth()`
-(`lib/admin/auth.ts`) requires a same-origin request **and** a valid HMAC-signed
-`admin_session` cookie, minted by `POST /api/admin/auth` when the operator enters
-`ADMIN_SECRET` at the login form. No admin route accepts
-`Authorization: Bearer <ADMIN_SECRET>`.
+`reward_xp` has **no receipt PDA**, so the chain cannot reject a duplicate — the
+caller must guarantee at-most-once itself. The pattern is reserve-then-send:
+`buildSignedRewardXpTx()` returns a signed transaction whose signature is known
+before anything is broadcast, the drainer reserves that signature in
+`xp_transactions.tx_signature` with a conditional update, and then
+`sendSignedTransaction()` broadcasts those exact bytes. Re-sending identical
+signed bytes is idempotent on Solana. **Never rebuild the transaction to retry
+it** — a fresh blockhash means a fresh signature, which mints again.
 
 ---
 
-## 4. Service Interfaces
+## 4. Service layer
 
-### `lib/content/*` -- The Content Read Layer
+### `lib/content/*` — the content read layer
 
-All server-only. Composes three seams: the committed bundle (content), Supabase
-(on-chain status), and projectors (shape).
+All server-only. Composes three seams: the bundle, Supabase deployment status,
+and projectors.
 
-| Module                 | Purpose                                                                                                                                                                        |
-| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `store.ts`             | Statically imports the generated JSON into id/slug-keyed maps. **The `server-only` marker here is load-bearing** — the bundle holds quiz answers, solutions, and hidden tests. |
-| `queries.ts`           | The query API (`getAllCourses`, `getCourseBySlug`, `getLessonBySlug`, …). Owns `COURSES_CACHE_TAG`.                                                                            |
-| `deployments.ts`       | The on-chain status read seam. `getActiveDeployments()` (cached anon view read), `getDeploymentById()` (service_role full row), and `isSynced()` — the entire visibility gate. |
-| `deployment-writes.ts` | The four service_role upserts into `onchain_deployments`.                                                                                                                      |
-| `project.ts`           | Projectors that map raw bundle docs to the app's `Course` / `Lesson` / … types.                                                                                                |
-| `meta.ts`              | `contentMeta` + `SYNCED_SHA` — the pinned SHA, a **build-time constant** (the bundle _is_ the synced content).                                                                 |
-| `client-queries.ts`    | Browser-side fetch wrappers over `/api/content/*`. Same fn names/signatures as the server ones, so swapping a component over is an import-line change.                         |
-| `compile/*`            | The compiler internals (tarball extract, validate, project, assets, prune), shared with `scripts/compile-content.ts`.                                                          |
+| Module                 | Purpose                                                                          |
+| ---------------------- | -------------------------------------------------------------------------------- |
+| `store.ts`             | Static imports into id/slug-keyed maps. The `server-only` marker is load-bearing |
+| `queries.ts`           | The query API; owns `COURSES_CACHE_TAG`                                          |
+| `deployments.ts`       | The visibility gate: `getActiveDeployments`, `getDeploymentById`, `isSynced`     |
+| `deployment-writes.ts` | The service_role upserts into `onchain_deployments`                              |
+| `project.ts`           | Projectors from raw bundle docs to app types                                     |
+| `meta.ts`              | `contentMeta` + `SYNCED_SHA`, a build-time constant                              |
+| `client-queries.ts`    | Browser fetch wrappers over `/api/content/*`, same signatures as the server ones |
+| `compile/*`            | Compiler internals, shared with `scripts/compile-content.ts`                     |
 
-### `lib/github/*` -- Read-Only GitHub Seam
+### `lib/solana/*` — the chain layer
 
-| Module              | Purpose                                                                                                                                           |
-| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `github.ts`         | The GitHub client: `fetchHeadSha`, `fetchChecksState`, `fetchAheadBy`. **Read scope only.**                                                       |
-| `publish-pin.ts`    | Pure drift/verdict + PR-link helpers for `/admin/courses`. Builds the one-line `content.lock` diff and a prefilled PR URL. **Performs no write.** |
-| `drift.ts`          | `computeContentDrift` / `computeChainDrift`.                                                                                                      |
-| `content-commit.ts` | `deriveActiveMask` — the `active_lessons` bitmask derived from a course's `slots.lock.json`.                                                      |
+| Module                                        | Purpose                                                                          |
+| --------------------------------------------- | -------------------------------------------------------------------------------- |
+| `academy-program.ts`                          | Server-only backend-signed instructions (complete lesson, finalize, credential)  |
+| `admin-signer.ts`                             | Server-only authority-signed instructions (course + achievement deploys)         |
+| `academy-reads.ts`                            | Account decoding. Course decode is **length-dispatched**: 224 → v1, 253 → v-next |
+| `instructions.ts`                             | Client-side builders for the learner-signed instructions (`enroll`, `close`)     |
+| `pda.ts`                                      | All six PDA derivations; `getProgramId()` throws when the env var is unset       |
+| `bitmap.ts`                                   | `lesson_flags` / `active_lessons` encode and decode                              |
+| `onchain-queue.ts`                            | The retry-queue drainer                                                          |
+| `xp-mint.ts`                                  | Raw Token-2022 mint/burn for the wallet link/unlink flow                         |
+| `sponsor-enroll.ts`                           | Backend-sponsored enroll (payer split from learner)                              |
+| `verify-program-deploy.ts`                    | BPF Upgradeable Loader parsing to verify program id + upgrade authority          |
+| `parse-program-error.ts`, `program-errors.ts` | Custom error code → IDL error → i18n key                                         |
 
-### `academy-program.ts` -- Backend-Signed Instructions
+Everything encodes through `@coral-xyz/anchor`'s `BorshCoder`, not a hand-rolled
+encoder — the IDL stays the single wire contract even though no Anchor crate
+produces it any more.
 
-Server-only module (`import "server-only"`). Builds and sends Anchor instructions using the `BACKEND_SIGNER_SECRET` keypair. Lazy-loaded connection and program singletons.
+### `lib/ai/*` — the lesson assistant
 
-| Export                                                                                      | Purpose                                                   |
-| ------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
-| `getConnection()`                                                                           | Lazy singleton RPC connection                             |
-| `getBackendSigner()`                                                                        | Load backend signer from `BACKEND_SIGNER_SECRET` env var  |
-| `getProgram()`                                                                              | Lazy Anchor `Program` instance (camelCase IDL conversion) |
-| `isOnChainProgramLive()`                                                                    | Check if Config PDA exists (cached, 60s TTL)              |
-| `completeLesson(courseId, learner, lessonIndex)`                                            | Set bitmap bit + mint XP via CPI                          |
-| `finalizeCourse(courseId, learner)`                                                         | Verify all lessons complete, award bonus XP               |
-| `issueCredential(courseId, learner, name, uri, coursesCompleted, totalXp, trackCollection)` | Mint Metaplex Core soulbound credential NFT               |
-| `awardAchievement(achievementId, recipient)`                                                | Mint achievement NFT + XP reward                          |
-
-All instruction wrappers pre-create Token-2022 ATAs via `createAssociatedTokenAccountIdempotentInstruction` before the program instruction.
-
-### `admin-signer.ts` -- Admin Deployment Functions
-
-Server-only module. Uses `PROGRAM_AUTHORITY_SECRET` (the `config.authority` keypair) for admin-level instructions.
-
-| Export                                | Purpose                                                                  |
-| ------------------------------------- | ------------------------------------------------------------------------ |
-| `isAdminSignerReady()`                | Check if authority keypair loaded successfully                           |
-| `deployCoursePda(params)`             | Submit `createCourse` instruction on-chain                               |
-| `updateCoursePda(params)`             | Submit `updateCourse` with optional fields                               |
-| `deactivateCoursePda(courseId)`       | Set `is_active = false` (convenience wrapper)                            |
-| `deployAchievementType(params)`       | Submit `createAchievementType` + generate collection keypair             |
-| `deployCourseTrackCollection(params)` | Create Metaplex Core collection via UMI (Config PDA as update authority) |
-| `verifyAuthorityMatchesConfig()`      | Compare local keypair against on-chain Config.authority                  |
-
-### `pda.ts` -- PDA Derivation Helpers
-
-| Function                                                          | Seeds                                               | Returns             |
-| ----------------------------------------------------------------- | --------------------------------------------------- | ------------------- |
-| `findConfigPDA(programId?)`                                       | `["config"]`                                        | `[PublicKey, bump]` |
-| `findCoursePDA(courseId, programId?)`                             | `["course", courseId]`                              | `[PublicKey, bump]` |
-| `findEnrollmentPDA(courseId, user, programId?)`                   | `["enrollment", courseId, user]`                    | `[PublicKey, bump]` |
-| `findMinterRolePDA(minter, programId?)`                           | `["minter", minter]`                                | `[PublicKey, bump]` |
-| `findAchievementTypePDA(achievementId, programId?)`               | `["achievement", achievementId]`                    | `[PublicKey, bump]` |
-| `findAchievementReceiptPDA(achievementId, recipient, programId?)` | `["achievement_receipt", achievementId, recipient]` | `[PublicKey, bump]` |
-
-All functions accept an optional `programId` parameter (defaults to `PROGRAM_ID` from env).
-
-### `bitmap.ts` -- Lesson Completion Bitmap
-
-The on-chain Enrollment account stores lesson completion as `lesson_flags: [u64; 4]` -- a 256-bit bitmap. Each lesson index maps to a single bit: `word = floor(index / 64)`, `bit = index % 64`.
-
-| Function                                         | Purpose                                             |
-| ------------------------------------------------ | --------------------------------------------------- |
-| `decodeLessonBitmap(lessonFlags, lessonCount)`   | Returns `boolean[]` of completion status per lesson |
-| `isLessonComplete(lessonFlags, lessonIndex)`     | Check single lesson bit                             |
-| `isAllLessonsComplete(lessonFlags, lessonCount)` | True when all bits 0..lessonCount-1 are set         |
-
-Input accepts `BN`, `bigint`, or `number` -- converts internally to `BigInt` for bitwise operations.
-
-### `parse-program-error.ts` -- Error Resolution
-
-| Function                       | Purpose                                                                          |
-| ------------------------------ | -------------------------------------------------------------------------------- |
-| `extractCustomErrorCode(logs)` | Extract Anchor custom error code from `"custom program error: 0x..."` in TX logs |
-| `resolveIdlError(code, idl)`   | Map error code to `{ code, name, msg }` using the IDL's errors array             |
-
-Error codes >= 6000 are program-specific (index = code - 6000). Codes < 6000 are Anchor framework errors.
-
-### `account-resolver.ts` -- IDL-Driven Account Resolution
-
-Used by the generic program explorer (`deploy/generic-program-explorer.tsx`) to auto-fill instruction accounts for student-deployed programs.
-
-Resolution priority:
-
-1. IDL `address` field (Anchor 0.32 format)
-2. Wallet convention names (`user`, `authority`, `signer`, `payer`)
-3. Well-known programs (`SystemProgram`, `TokenProgram`, etc.)
-4. PDA derivation from IDL seed definitions
-5. Stored/generated keypairs for mutable + signer accounts
-6. Unresolved fallback (manual input required)
-
-### `xp-mint.ts` -- Token-2022 XP Minting/Burning
-
-Server-only module using `XP_MINT_AUTHORITY_SECRET`. Separate from `academy-program.ts` because it uses raw `@solana/spl-token` calls rather than Anchor instructions.
-
-| Function                                | Purpose                                                                     |
-| --------------------------------------- | --------------------------------------------------------------------------- |
-| `mintXpToWallet(walletAddress, amount)` | Mint Token-2022 XP tokens to a user's ATA (creates ATA if needed)           |
-| `burnXpFromWallet(walletAddress)`       | Burn ALL XP from a wallet via PermanentDelegate (no owner signature needed) |
-
-Used for wallet link/unlink flow, not for lesson completion (which uses on-chain CPI).
+Gemini over raw REST (no SDK). Per-action model routing lives in `models.ts`:
+cheap models for hints and Socratic turns, the larger model for ask/propose/
+review. Spend is metered in micro-USD into the `ai_spend_ledger` table across
+three dimensions (account, IP, global) with soft and hard caps per
+America/São_Paulo day. Over a soft cap the tutor degrades to a shorter output
+budget; over a hard cap it denies with a 503. Unlike the rate limiter, the spend
+ledger **fails closed** — a ledger error denies rather than allows.
 
 ---
 
-## 5. On-Chain Integration Points
+## 5. On-chain integration
 
-### Program Instructions (18 total)
+The program is Pinocchio 0.11, 18 instructions, 6 PDA types, 37 errors, 18
+events. [SPEC.md](./SPEC.md) is authoritative for layouts and validation order;
+what follows is only how the app touches it.
 
-The Solana program (`onchain-academy`) is built with Pinocchio 0.11 (`cargo build-sbf`); the committed IDL is the client contract. Instruction names in Rust are snake_case; the `@coral-xyz/anchor` `Program` client converts them to camelCase for TypeScript.
+| Instruction                                                                    | Signer            | Called from                        |
+| ------------------------------------------------------------------------------ | ----------------- | ---------------------------------- |
+| `initialize`, `update_config`, `close_course`                                  | Authority         | operator scripts                   |
+| `create_course`, `update_course`                                               | Authority         | `admin-signer.ts` (admin sync)     |
+| `create_achievement_type`, `deactivate_achievement_type`                       | Authority         | `admin-signer.ts` / scripts        |
+| `register_minter`, `update_minter`, `revoke_minter`                            | Authority         | operator scripts                   |
+| `enroll`                                                                       | Learner + payer   | `/api/enroll/sponsor` + client sig |
+| `close_enrollment`                                                             | Learner           | `instructions.ts`                  |
+| `complete_lesson`, `finalize_course`, `issue_credential`, `upgrade_credential` | Backend signer    | `academy-program.ts`               |
+| `reward_xp`, `award_achievement`                                               | Registered minter | quest drainer, achievement award   |
 
-Source of truth: `onchain-academy/programs/onchain-academy/src/instructions/`.
+### PDAs
 
-| Instruction (Rust)            | TypeScript Builder (`academy-program.ts`)                                                    | Signer            |
-| ----------------------------- | -------------------------------------------------------------------------------------------- | ----------------- |
-| `initialize`                  | -- (one-time setup via `scripts/init-program.ts`)                                            | Authority         |
-| `update_config`               | -- (admin CLI)                                                                               | Authority         |
-| `create_course`               | `deployCoursePda()` in `admin-signer.ts`                                                     | Authority         |
-| `update_course`               | `updateCoursePda()` in `admin-signer.ts`                                                     | Authority         |
-| `close_course`                | -- (admin CLI)                                                                               | Authority         |
-| `enroll`                      | `/api/enroll/sponsor` → client co-signs                                                      | Learner + payer   |
-| `complete_lesson`             | `completeLesson()` in `academy-program.ts`                                                   | Backend signer    |
-| `finalize_course`             | `finalizeCourse()` in `academy-program.ts`                                                   | Backend signer    |
-| `close_enrollment`            | Client-side via `instructions.ts`                                                            | Learner wallet    |
-| `issue_credential`            | `issueCredential()` in `academy-program.ts`                                                  | Backend signer    |
-| `upgrade_credential`          | -- (not yet used in API routes)                                                              | Backend signer    |
-| `register_minter`             | -- (admin CLI)                                                                               | Authority         |
-| `update_minter`               | -- (admin CLI)                                                                               | Authority         |
-| `revoke_minter`               | -- (admin CLI)                                                                               | Authority         |
-| `reward_xp`                   | `buildSignedRewardXpTx()` + `sendSignedTransaction()` in `academy-program.ts` (daily quests) | Registered minter |
-| `create_achievement_type`     | `deployAchievementType()` in `admin-signer.ts`                                               | Authority         |
-| `award_achievement`           | `awardAchievement()` in `academy-program.ts`                                                 | Registered minter |
-| `deactivate_achievement_type` | -- (admin CLI)                                                                               | Authority         |
+| PDA                | Seeds                                                | Size  |
+| ------------------ | ---------------------------------------------------- | ----- |
+| Config             | `["config"]`                                         | 113 B |
+| Course             | `["course", course_id]`                              | 253 B |
+| Enrollment         | `["enrollment", course_id, learner]`                 | 127 B |
+| MinterRole         | `["minter", minter]`                                 | 110 B |
+| AchievementType    | `["achievement", achievement_id]`                    | 338 B |
+| AchievementReceipt | `["achievement_receipt", achievement_id, recipient]` | 49 B  |
 
-`reward_xp` is split across two functions on purpose. It has no receipt PDA, so the chain cannot reject a duplicate — the caller must guarantee at-most-once itself. `buildSignedRewardXpTx()` returns a signed transaction whose signature is known before anything is broadcast; the quest drainer reserves that signature in `xp_transactions.tx_signature` with a conditional update, then `sendSignedTransaction()` broadcasts those exact bytes (re-sending identical signed bytes is idempotent on Solana). Never rebuild the transaction to retry it: a fresh blockhash means a fresh signature, which mints again.
+Config is the singleton root: it holds `authority`, the rotatable
+`backend_signer`, `xp_mint`, and the `paused` kill switch, and it is the update
+authority for every Metaplex Core collection. Enrollment holds the 256-bit
+`lesson_flags` bitmap, `completed_at`, and `credential_asset`.
+AchievementReceipt is a thin existence-proof PDA — a second award collides on
+init and errors.
 
-### PDA Table
+> **ID convention**: the content `_id` (`course-*`, `achievement-*`) is the PDA
+> seed, used **verbatim**. Stripping the prefix derives a different PDA and the
+> deploy or award silently targets a non-existent account.
 
-Derived from the Rust state structs (`onchain-academy/programs/onchain-academy/src/state/*.rs`) and the TypeScript helpers (`lib/solana/pda.ts`).
+### XP and credentials
 
-| PDA                | Seeds                                                | Closeable | Size  | TypeScript                                            |
-| ------------------ | ---------------------------------------------------- | --------- | ----- | ----------------------------------------------------- |
-| Config             | `["config"]`                                         | No        | 113 B | `findConfigPDA()`                                     |
-| Course             | `["course", course_id]`                              | No        | 192 B | `findCoursePDA(courseId)`                             |
-| Enrollment         | `["enrollment", course_id, learner]`                 | Yes       | 127 B | `findEnrollmentPDA(courseId, user)`                   |
-| MinterRole         | `["minter", minter]`                                 | Yes       | 110 B | `findMinterRolePDA(minter)`                           |
-| AchievementType    | `["achievement", achievement_id]`                    | No        | 338 B | `findAchievementTypePDA(achievementId)`               |
-| AchievementReceipt | `["achievement_receipt", achievement_id, recipient]` | No        | 49 B  | `findAchievementReceiptPDA(achievementId, recipient)` |
+**XP** is a Token-2022 mint created during `initialize`, owned by the Config PDA,
+0 decimals, with NonTransferable (cannot move between wallets) and
+PermanentDelegate (the platform can burn without an owner signature). Minted by
+CPI in `complete_lesson` and `finalize_course`, and by `reward_xp` /
+`award_achievement` for the extensible paths.
 
-**Config** is the singleton root. It stores `authority` (platform multisig), `backend_signer` (rotatable), and `xp_mint` (Token-2022 mint address). Config PDA is also the update authority for all Metaplex Core collections.
+**Credentials** are Metaplex Core assets, made soulbound by a
+`PermanentFreezeDelegate { frozen: true }` plugin applied at creation, with an
+Attributes plugin carrying `track_id`, `track_level`, `courses_completed`, and
+`total_xp`. One collection per course track. `enrollment.credential_asset == None`
+triggers a create; `Some(pubkey)` triggers an update.
 
-**Enrollment** tracks per-user per-course state: `lesson_flags` (256-bit bitmap), `completed_at`, and `credential_asset` (set after `issue_credential`).
+### Trust boundary
 
-**AchievementReceipt** is a thin PDA whose existence prevents double-awarding (PDA init collision = error).
-
-### Token-2022 XP
-
-- **Mint**: Created during `initialize`, owned by Config PDA
-- **Extensions**: NonTransferable (soulbound, cannot be transferred between wallets) + PermanentDelegate (platform can burn/adjust without owner signature)
-- **Decimals**: 0 (1 token = 1 XP)
-- **Minting**: Via CPI in `complete_lesson` (`xp_per_lesson` amount) and `finalize_course` (completion bonus = `floor(xp_per_lesson * lesson_count / 2)`)
-- **Creator rewards**: `finalize_course` mints `creator_reward_xp` to the course creator's ATA when `total_completions >= min_completions_for_reward`
-
-### Metaplex Core Credentials
-
-- **Standard**: Metaplex Core (not legacy Token Metadata)
-- **Soulbound**: `PermanentFreezeDelegate` plugin applied at creation
-- **Collection**: One Metaplex Core collection per course track, created via `deployCourseTrackCollection()` using UMI
-- **Update authority**: Config PDA signs as collection update authority for CPI calls
-- **Attributes plugin**: Stores `courses_completed` and `total_xp` on the NFT
-- **Create vs upgrade**: `enrollment.credential_asset == None` triggers `createV2` CPI; `Some(pubkey)` triggers `updateV1` + `updatePluginV1` CPI
-
-### Idempotency Model
-
-Three layers of idempotency prevent duplicate completions and wasteful transactions:
-
-1. **Supabase check**: `user_progress.completed` -- if already true, return early (no TX submitted)
-2. **On-chain bitmap check**: `isLessonComplete(enrollment.lesson_flags, index)` -- if bit already set, skip `completeLesson` TX
-3. **Enrollment.completed_at**: If already set, skip `finalizeCourse` but proceed to credential check
-4. **Enrollment.credential_asset**: If already set, skip `issueCredential`
-
-### Trust Boundaries
-
-| Role                     | Signs                                                                                                                          | Why                                                                             |
-| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------- |
-| **Learner wallet**       | `enroll`, `close_enrollment`                                                                                                   | Enrollment is a personal commitment; only the learner should create or close it |
-| **Backend signer**       | `complete_lesson`, `finalize_course`, `issue_credential`                                                                       | Prevents gaming: backend validates lesson content was consumed before signing   |
-| **Authority (multisig)** | `create_course`, `update_course`, `register_minter`, `revoke_minter`, `create_achievement_type`, `deactivate_achievement_type` | Platform governance, content management                                         |
-| **Registered minter**    | `reward_xp`, `award_achievement`                                                                                               | Extensible XP distribution (events, community, streaks)                         |
-
-The backend signer is stored in Config PDA and is rotatable via `update_config`. On devnet, authority and backend signer are typically the same keypair.
-
-#### Trust assumption: the backend signer is trusted, not verified
-
-The backend signer is a **trusted off-chain authority**, and its co-signature is an _authorization_ boundary, not a _proof of merit_. Every XP-minting and credential instruction (`complete_lesson`, `finalize_course`, `reward_xp`, `award_achievement`, `issue_credential`, `upgrade_credential`) requires it as an additional signer, enforced on-chain by `constraint = backend_signer.key() == config.backend_signer`.
-
-What the program **does** verify is structural only: the lesson bit was not already set, the course is finalized at most once, supply and minter caps hold, the kill-switch (`Config.paused`) is off across all six minting/credential paths, and every account matches its PDA. The program **does not** verify that the learner actually completed the lesson or passed the challenge — that eligibility check is performed off-chain by the backend before it co-signs, and the program trusts it to have done so. Consequently a compromised backend-signer key can mint XP and credentials at will (bounded by minter caps and the kill-switch); the mitigation is rotation via `update_config`. The same boundary is documented in the `//!` module header of `programs/onchain-academy/src/lib.rs`.
-
-### Supabase Mirror Pattern
-
-On-chain state is the source of truth for XP balances (Token-2022 ATA), enrollment status (bitmap), and credentials (Metaplex Core NFTs). Supabase mirrors this data for:
-
-- **Fast queries**: Indexed tables for leaderboard, dashboard, profile
-- **Streak tracking**: No on-chain equivalent (daily activity is Supabase-only)
-- **Achievement records**: Supabase `user_achievements` is the UI source; on-chain minting is a bonus
-- **Progress display**: `user_progress` table for lesson-level completion tracking
-
-Mirror writes are non-fatal: if a Supabase write fails after an on-chain TX succeeds, the response still returns success. The on-chain state can be re-synced later.
+The backend signer is a **trusted off-chain authority**, and its co-signature is
+an _authorization_ boundary, not a _proof of merit_. The program verifies
+structure only: the lesson bit was not already set, the course finalizes at most
+once, supply and minter caps hold, the kill switch is off, and every account
+matches its PDA. It does **not** verify that the learner completed the lesson —
+that check happens off-chain before the co-signature. A compromised backend key
+can therefore mint XP and credentials at will, bounded by minter caps and the
+pause flag; the mitigation is rotation via `update_config`.
 
 ---
 
-## 6. Authentication and Authorization
+## 6. Authentication
 
-### SIWS Flow
+[AUTH-FLOWS.md](./AUTH-FLOWS.md) is the authoritative map. The architectural
+invariant, in one line:
 
-1. `GET /api/auth/nonce` -- generates nonce, stores in `siws_nonces` table with 5-minute TTL
-2. Client builds SIWS message with domain + nonce + expiry, wallet signs via Ed25519
-3. `POST /api/auth/wallet` -- verifies nonce (pending + not expired), domain match, signature
-4. Nonce marked as `consumed` (replay protection)
-5. Creates Supabase user with synthetic email `{pubkey}@wallet.superteam-lms.local`
-6. Magic link generated → OTP verified → session cookies set
-7. Assigns generated wallet name if username is placeholder (`user_XXXXXXXX`)
+> An external prover proves things (Dynamic for Google handshakes and
+> embedded-wallet ownership, wallet-adapter for external-wallet ownership,
+> Supabase OAuth for the fallback); **Supabase owns identity**; every proof is
+> exchanged **server-side** for a Supabase cookie session.
 
-### Security Measures
+Three session-minting routes — `/api/auth/wallet` (SIWS), `/api/auth/dynamic`
+(Dynamic JWT verified against the per-environment JWKS), `/api/auth/callback`
+(Supabase OAuth) — and they share four post-login rituals: tombstone refusal on
+`profiles.deleted_at`, placeholder-username replacement, the
+`pending_onchain_actions` drain, and first-login avatar adoption. Add a new way
+in, add all four.
 
-- **Nonce replay**: Postgres table with status tracking (`pending` → `consumed`), background cleanup
-- **Per-IP rate limiting**: Max 10 pending nonces per IP within TTL window
-- **Domain validation**: SIWS message domain must match request Host header
-- **Body size limit**: Wallet auth rejects requests > 10KB
-- **Redirect sanitization**: OAuth callback prevents open redirects (no protocol-relative, no backslashes)
-- **Generic errors**: No stack traces or internal details in API responses
-- **Env var guards**: API routes fail-fast with 500 if required vars are missing
-
-### RLS Model (20 tables, all with RLS enabled)
-
-<!-- Table count corrected 19 → 20 per #645: schema.sql defines 20 tables; the 20th is `challenge_assists` (the AI-assist ledger). The per-table matrices below enumerate a subset for the RLS-policy summary and are not a full inventory. -->
-
-#### Core Tables
-
-| Table               | SELECT                            | INSERT | UPDATE | DELETE |
-| ------------------- | --------------------------------- | ------ | ------ | ------ |
-| `profiles`          | Own + public (`is_public = true`) | Own    | Own    | --     |
-| `enrollments`       | Own + public profiles             | Own    | --     | Own    |
-| `user_progress`     | Own + public profiles             | Own    | Own    | --     |
-| `user_xp`           | All (leaderboard)                 | --     | --     | --     |
-| `xp_transactions`   | All (leaderboard)                 | --     | --     | --     |
-| `user_achievements` | Own + public profiles             | --     | --     | --     |
-| `certificates`      | Own + public profiles             | --     | --     | --     |
-| `nft_metadata`      | All (public)                      | --     | --     | --     |
-| `siws_nonces`       | None                              | None   | --     | --     |
-| `deployed_programs` | Own                               | Own    | Own    | --     |
-
-#### Community Tables
-
-| Table              | SELECT       | INSERT        | UPDATE | DELETE |
-| ------------------ | ------------ | ------------- | ------ | ------ |
-| `forum_categories` | All (public) | --            | --     | --     |
-| `threads`          | All (public) | Authenticated | Own    | --     |
-| `answers`          | All (public) | Authenticated | Own    | --     |
-| `votes`            | All (public) | Authenticated | --     | --     |
-| `flags`            | --           | Authenticated | --     | --     |
-
-#### Queue / Quest Tables
-
-| Table                     | SELECT | INSERT | UPDATE | DELETE |
-| ------------------------- | ------ | ------ | ------ | ------ |
-| `pending_onchain_actions` | Own    | Own    | Own    | --     |
-| `user_daily_quests`       | Own    | --     | --     | --     |
-
-`user_xp`, `xp_transactions`, and `user_achievements` have no INSERT/UPDATE policies for authenticated users. All writes go through SECURITY DEFINER functions (`award_xp`, `unlock_achievement`) that are `REVOKE`d from `authenticated`, `anon`, and `public` and `GRANT`ed only to `service_role`.
-
-`certificates` and `nft_metadata` have no INSERT policies for authenticated users. All writes go through service_role API routes to prevent users from fabricating completion records.
-
-Community data (categories, threads, answers, votes) has public SELECT policies. Thread/answer writes are authenticated. Vote writes are via SECURITY DEFINER functions (`cast_vote`, `create_thread_rpc`, `create_answer_rpc`).
-
-### Admin Auth
-
-Admin auth is separate from Supabase auth. `/admin` renders a login form; entering
-`ADMIN_SECRET` mints an **HMAC-signed `admin_session` cookie** (`POST /api/admin/auth`).
-`ADMIN_SECRET` is both the login secret and the HMAC signing key — rotating it
-invalidates every session.
-
-- Middleware redirects `/admin/*` sub-routes back to `/admin` when the cookie is
-  absent or expired.
-- Every `/api/admin/*` route calls `requireAdminAuth()`, which enforces a
-  **same-origin check plus the signed cookie**. There is no bearer-token path.
-- `ADMIN_SECRET` is never read in a page component, so it cannot be serialized into
-  a client payload.
+Dynamic is entirely optional: unset `NEXT_PUBLIC_DYNAMIC_ENVIRONMENT_ID` and no
+provider mounts, no SDK loads, no network call happens. SIWS with an external
+wallet is the guaranteed path and the kill switch.
 
 ### Middleware
 
-The middleware (`src/middleware.ts`) chains two concerns in order:
+`src/middleware.ts` chains three concerns: a per-request CSP nonce, Supabase auth
+via `getClaims()` (local JWT verification against a cached JWKS — no per-request
+DB query), then next-intl with `localePrefix: "always"`. Server components share
+one claims read per request through `getAuthClaims()` (`lib/auth/dal.ts`, React
+`cache()`).
 
-1. **Supabase auth**: Creates server client, calls `getUser()` (may refresh tokens via `setAll`)
-2. **next-intl**: Adds locale prefix (default: `en`)
+Soft-deleted accounts are refused at the login chokepoints rather than on every
+request; every `profiles.deleted_at` writer pairs with session revocation, so a
+stale session dies at its next token refresh.
 
-**Auth-gated routes** (redirect to landing if unauthenticated):
+### Admin authorization
 
-- `/dashboard`
-- `/settings`
-- `/profile` (exact -- own profile only)
+There is **no admin password and no login form**. Access is the caller's ordinary
+Supabase session checked against the `admin_users` allowlist — a table with RLS
+on and _zero_ policies plus explicit REVOKEs, readable only by the service role.
+`requireAdmin()` (`lib/admin/auth.ts`) verifies the user server-side via
+`auth.getUser()` (never a client-supplied id) and fails closed on everything: no
+session, DB error, missing env. Signed-in non-admins get a **404**, so the panel's
+existence is not revealed. `requireAdminAuth()` adds a same-origin CSRF check on
+state-changing methods.
 
-**Public routes**:
-
-- `/` (landing), `/courses`, `/courses/[slug]/lessons/[id]`
-- `/leaderboard`, `/certificates`, `/certificates/[id]`
-- `/profile/[username]` (viewing other users)
-
-**Admin routes**: Checked against the signed `admin_session` cookie, separate from Supabase auth.
-
-The middleware matcher excludes API routes, `_next`, `_vercel`, and static assets
-(`matcher: ["/((?!api|_next|_vercel|.*\\..*).*)"]`).
-
----
-
-## 7. Community Forum
-
-Full-stack Q&A forum with XP integration, moderation, and course-scoped discussions.
-
-### Pages
-
-| Route                                      | Component                  | Purpose                                             |
-| ------------------------------------------ | -------------------------- | --------------------------------------------------- |
-| `/community`                               | `community/page.tsx`       | Forum home — category grid + recent threads         |
-| `/community/[category-slug]`               | `[category-slug]/page.tsx` | Category page — filtered thread list + create modal |
-| `/community/[category-slug]/[thread-slug]` | `[thread-slug]/page.tsx`   | Thread detail — body, answers, voting, accept       |
-
-Course and lesson pages embed a `<ThreadList>` tab filtered by `courseId` / `lessonId` for contextual discussions.
-
-### Data Flow
-
-```
-User action → API route → Supabase (RLS/service_role)
-                       ↘ award_xp() SECURITY DEFINER → xp_transactions + user_xp
-                       ↘ on-chain reward_xp (for thread/answer/accept XP)
-```
-
-### API Routes (9)
-
-| Route                                | Method | Auth     | Rate Limit | Purpose                                                                                            |
-| ------------------------------------ | ------ | -------- | ---------- | -------------------------------------------------------------------------------------------------- |
-| `/api/community/threads`             | GET    | None     | —          | List threads with cursor pagination, category/course/lesson filters                                |
-| `/api/community/threads`             | POST   | Required | 10/hr      | Create thread (5 XP, awards via `award_xp()`)                                                      |
-| `/api/community/threads/[id]`        | GET    | None     | —          | Thread detail with answers, increments view count                                                  |
-| `/api/community/threads/[id]/delete` | POST   | Required | —          | Soft-delete own thread (author only)                                                               |
-| `/api/community/answers`             | POST   | Required | 30/hr      | Post answer to thread (10 XP)                                                                      |
-| `/api/community/answers/[id]/accept` | POST   | Required | —          | Accept answer (thread author only, 25 XP to answerer). Re-accept revokes previous XP.              |
-| `/api/community/answers/[id]/delete` | POST   | Required | —          | Soft-delete own answer (author only)                                                               |
-| `/api/community/votes`               | POST   | Required | 60/hr      | Three-state vote (+1/0/-1). Self-vote prevented by DB trigger.                                     |
-| `/api/community/flags`               | POST   | Required | 20/hr      | Flag content for moderation. Dedup index prevents duplicate flags. Self-flag prevented by trigger. |
-| `/api/community/search`              | GET    | None     | —          | Full-text search (tsvector on title + body)                                                        |
-
-Rate limiting uses a per-user in-memory token bucket (`lib/rate-limit.ts`). Process-local; not globally enforced across serverless instances.
-
-### Database Tables (5 + 1 view)
-
-| Table              | Key Columns                                                                                                                                                                            | Notes                                                                                                                                                                                         |
-| ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `forum_categories` | `name`, `slug`, `description`, `sort_order`                                                                                                                                            | Seeded manually. Public SELECT, no user writes.                                                                                                                                               |
-| `threads`          | `title`, `body`, `type` (question/discussion), `category_id`, `course_id`, `lesson_id`, `author_id`, `vote_score`, `view_count`, `answer_count`, `is_solved`, `is_pinned`, `is_locked` | `search_vector` tsvector for full-text search. `last_activity_at` updated on new answers only.                                                                                                |
-| `answers`          | `body`, `thread_id`, `author_id`, `vote_score`, `is_accepted`                                                                                                                          | One accepted answer per thread (enforced by accept route logic).                                                                                                                              |
-| `votes`            | `user_id`, `thread_id`/`answer_id`, `value` (+1/-1)                                                                                                                                    | Unique constraint `(user_id, thread_id)` / `(user_id, answer_id)`. Self-vote prevented by `trg_prevent_self_vote` trigger. `update_vote_score()` trigger maintains denormalized `vote_score`. |
-| `flags`            | `reporter_id`, `thread_id`/`answer_id`, `reason` (enum), `status`                                                                                                                      | Unique partial indexes prevent duplicate flags per user per target. `trg_prevent_self_flag` trigger prevents self-flagging.                                                                   |
-| `community_stats`  | (view)                                                                                                                                                                                 | Aggregated thread/answer/accepted counts per user for profile display.                                                                                                                        |
-
-### Components (14)
-
-| Component            | Purpose                                                                                |
-| -------------------- | -------------------------------------------------------------------------------------- |
-| `ThreadList`         | Paginated thread list with filters (category, course, lesson). Uses `useThreads` hook. |
-| `ThreadCard`         | Thread preview card with vote score, answer count, status badge.                       |
-| `VoteButton`         | Three-state vote UI (up/neutral/down).                                                 |
-| `AnswerCard`         | Answer display with vote, accept button (for thread author).                           |
-| `AnswerEditor`       | Markdown editor for posting answers.                                                   |
-| `CreateThreadModal`  | Modal for creating new threads (title, body, type, category).                          |
-| `CommunitySearch`    | Full-text search bar with debounced API calls.                                         |
-| `CommunityStats`     | User forum stats (threads, answers, accepted).                                         |
-| `FlagButton`         | Content flagging with reason selector.                                                 |
-| `ThreadStatusBadge`  | Question/discussion + solved/unsolved badge.                                           |
-| `ThreadFilters`      | Category, sort, and type filter controls.                                              |
-| `CategoryCard`       | Forum category card with thread count.                                                 |
-| `MarkdownEditor`     | Markdown textarea with preview toggle.                                                 |
-| `AcceptAnswerButton` | Accept/unaccept answer (thread author only).                                           |
-
-### Hooks
-
-| Hook                | Purpose                                                          |
-| ------------------- | ---------------------------------------------------------------- |
-| `useThreads`        | Cursor-based thread pagination with SWR-like caching.            |
-| `useCommunityStats` | Fetch community stats for a user.                                |
-| `useVote`           | Optimistic three-state vote management with rollback on failure. |
-
-### XP Rewards
-
-| Action          | XP  | Idempotency Key                |
-| --------------- | --- | ------------------------------ |
-| Create thread   | 5   | `thread:{threadId}`            |
-| Post answer     | 10  | `answer:{answerId}`            |
-| Answer accepted | 25  | `accept:{threadId}:{answerId}` |
-
-Daily community XP cap: 50 XP (enforced by `award_xp()` SECURITY DEFINER function).
-
-Re-accepting a different answer revokes the previous answerer's 25 XP via `revoke_community_xp()` before awarding the new one.
+The retired `ADMIN_SECRET` / HMAC-cookie system is gone from all runtime code.
 
 ---
 
-## 8. Gamification System
+## 7. Database
 
-### XP
+**36 tables, RLS enabled on all of them.** Migrations in `supabase/migrations/`
+are the source of truth (62 of them); `supabase/schema.sql` is a generated
+snapshot kept for diffing.
 
-XP is dual-tracked: Token-2022 on-chain (source of truth) + Supabase mirror (fast queries).
+| Group                | Tables                                                                                                                                                            |
+| -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Core (10)            | `profiles`, `enrollments`, `user_progress`, `user_xp`, `xp_transactions`, `user_achievements`, `certificates`, `nft_metadata`, `siws_nonces`, `deployed_programs` |
+| Community (6)        | `forum_categories`, `threads`, `answers`, `votes`, `flags`, `thread_views`                                                                                        |
+| Gamification (5)     | `user_daily_quests`, `challenge_assists`, `streak_freezes_used`, `review_items`, `review_schedule`                                                                |
+| Leagues (3)          | `league_cohorts`, `league_members`, `league_tiers`                                                                                                                |
+| Referrals (2)        | `referral_events`, `referral_seasons`                                                                                                                             |
+| AI (1)               | `ai_spend_ledger`                                                                                                                                                 |
+| Email (2)            | `email_subscriptions`, `email_reminder_log`                                                                                                                       |
+| Moderation/admin (2) | `moderation_actions`, `admin_users`                                                                                                                               |
+| Infra/queue (5)      | `pending_onchain_actions`, `rate_limits`, `course_changelog`, `onchain_deployments`, `platform_freeze`                                                            |
 
-| Action                  | XP Range                                  | Enforcement                              |
-| ----------------------- | ----------------------------------------- | ---------------------------------------- |
-| Complete lesson         | 10-50 (by difficulty)                     | `xp_per_lesson` from on-chain Course PDA |
-| Complete course (bonus) | `floor(xp_per_lesson * lesson_count / 2)` | `finalize_course` instruction            |
-| Creator reward          | `creator_reward_xp` (when threshold met)  | `finalize_course` instruction            |
+Views: `public_user_xp`, `public_profiles`, `community_stats`,
+`public_onchain_deployments`.
 
-**Level formula**: `Level = floor(sqrt(totalXP / 100))`
+### The access pattern
 
-Levels: 1 at 100 XP, 2 at 400 XP, 3 at 900 XP, 5 at 2,500 XP, 10 at 10,000 XP.
+RLS is row-level, not column-level, so wherever a table needs a _narrower public
+surface_ the answer is a **view**, not a policy. Both `user_xp` and
+`onchain_deployments` follow that shape:
+
+- Users SELECT/INSERT/UPDATE only their own rows, verified through `auth.uid()`.
+- `user_xp`, `xp_transactions`, `user_achievements`, `certificates`, and
+  `nft_metadata` have no user INSERT/UPDATE policies at all — every write goes
+  through a SECURITY DEFINER function.
+- Those functions (`award_xp`, `unlock_achievement`, `get_daily_quest_state`,
+  and ~55 more) are **REVOKE**d from `authenticated`, `anon`, and `public`, and
+  **GRANT**ed only to `service_role`. API routes call them via
+  `createAdminClient()`.
+- `onchain_deployments` has RLS on with **zero policies** — service_role only.
+  Anon and authenticated read the `public_onchain_deployments` view, which
+  exposes only `content_id, kind, status, is_active, achievement_pda`. Never add
+  a raw pubkey, tx signature, or `track_collection_address` to that view.
+- Community data (categories, threads, answers, votes) has public SELECT.
+- Leaderboards go through `get_leaderboard()` and the `public_user_xp` view, not
+  a broad SELECT policy on `user_xp`.
+
+`handle_new_user()` fires on every `auth.users` insert and provisions the
+`profiles` and `user_xp` rows.
+
+> **Migration ledger caveat.** Migrations applied through the Supabase MCP get an
+> MCP-stamped version that diverges from the repo filename, so
+> `schema_migrations` does not match `supabase/migrations/`. Read
+> [DB-MIGRATION-LEDGER.md](./DB-MIGRATION-LEDGER.md) before any `supabase db
+push` or `migration list`.
+
+---
+
+## 8. Gamification, as shipped
+
+### XP and levels
+
+XP is dual-tracked: Token-2022 on-chain (truth) plus a Supabase mirror (speed).
+
+| Action                  | XP                                                      |
+| ----------------------- | ------------------------------------------------------- |
+| Complete lesson         | 10–50 by difficulty (`xp_per_lesson` on the Course PDA) |
+| Complete course (bonus) | `floor(xp_per_lesson * lesson_count / 2)`               |
+| Creator reward          | `creator_reward_xp` on finalize                         |
+| Community               | thread 5, answer 10, accepted answer 25                 |
+
+**Level** is `floor(sqrt(totalXP / 100))` — 100 XP for L1, 400 for L2, 10 000 for
+L10. The same formula is implemented in `award_xp()` in SQL; both must move
+together. Community XP is capped at 50/day inside `award_xp()`; API routes cap
+per-call awards independently (100 per lesson, 2000 per generic award).
 
 ### Streaks
 
-Handled entirely in the `award_xp()` SQL function:
+Handled entirely inside `award_xp()`: yesterday's activity increments, today's is
+a no-op, a gap longer than a day resets to 1, and `longest_streak` is a running
+`GREATEST`. Streak freezes (`streak_freezes_used`) can cover missed days.
 
-- Yesterday activity: increment `current_streak`
-- Today activity: no change
-- Gap > 1 day: reset to 1
-- `longest_streak = GREATEST(longest_streak, current_streak)`
+### Achievements — content, not code
 
-### Achievements
+Each achievement doc in `academy-courses` carries a declarative `award` rule (a
+Zod discriminated union). The app holds one predicate per award **kind** — not
+per achievement — in `PREDICATES satisfies Record<AwardKind, Predicate>`
+(`lib/gamification/achievements.ts`). The `satisfies` makes a missing kind a
+compile error, and no course or path id is hardcoded anywhere.
 
-**Unlock logic is content, not TypeScript.** Each achievement doc in
-`academy-courses` carries a declarative `award` rule (a Zod discriminated union,
-`packages/content-schema/src/achievement.ts`). The app holds one predicate per
-award _kind_ — not per achievement — in `PREDICATES`
-(`lib/gamification/achievements.ts`):
+The eight kinds: `lessons-completed`, `lessons-completed-in-course`,
+`course-completed`, `path-completed`, `streak`, `user-number`, `community-stat`,
+`manual`.
 
-```ts
-export const PREDICATES = { ... } satisfies Record<AwardKind, Predicate>;
+The bundle currently carries **18** achievements: a course-agnostic progress
+ladder (1/3/5/10/25/50 lessons), a streak ladder (3/7/14/30/100 days), three
+community achievements, one path completion, **`speedrunner` as the only
+course-specific badge**, and two `manual` ones (`bug-hunter` and `early-adopter`,
+the latter retired from auto-award to admin grant). Do not enumerate them here —
+the content repo is the source of truth.
+
+`buildUserState()` assembles lessons, courses, paths, streak, user number, and
+community stats in one pass; `checkNewAchievements()` evaluates every
+not-yet-unlocked rule against it after each lesson completion.
+
+### Quests
+
+Five quests in the bundle, four active: complete a lesson (20 XP), two lessons
+(40), a module (60), a 3-day login streak (50 XP, multi-day). **`quest-challenge`
+is `active: false`.** Evaluation is server-side through the
+`get_daily_quest_state` RPC — idempotent under `WHERE xp_granted = false`, keyed
+on the UTC date — fired off the response path via `after()` and swept by
+`retryQuestXpForUser`. Quest XP mints on-chain through the reserve-then-send
+pattern described in §3.
+
+### Reward popups
+
+One FIFO queue for level-ups, quest completions, and achievements, 3.5s per card.
+After **two individual cards**, any remaining rewards collapse into a single
+summary card — a **3-card ceiling**, roughly seven seconds per moment, at most
+one level-up card. The queue length is published to a module store so the
+certificate popup and its full confetti burst **wait for the queue to drain**
+rather than playing underneath it.
+
+Confetti is deliberately scarce: full tier for a credential mint, medium for a
+successful program deploy, and none at all for level-ups, achievements, or
+quests. Everything respects `prefers-reduced-motion`. **There is no surprise
+bonus** — the feature was removed; only historical `surprise_bonus` XP rows in
+the activity feed remain.
+
+---
+
+## 9. Community forum
+
+Threads and answers with three-state voting, accepted answers, full-text search
+over a tsvector, and a flag queue feeding `/admin/moderation`.
+
+Nine routes under `/api/community/*`: threads (list, detail, create, delete),
+answers (create, accept, delete), votes, flags, search. Writes are authenticated
+and rate-limited; votes and thread/answer creation go through SECURITY DEFINER
+functions. Self-voting and self-flagging are blocked by database triggers, and
+denormalized counters (`vote_score`, `answer_count`) are maintained by triggers
+rather than application code.
+
+XP is idempotency-keyed (`thread:{id}`, `answer:{id}`,
+`accept:{threadId}:{answerId}`). Re-accepting a different answer revokes the
+previous answerer's 25 XP through `revoke_community_xp()` before awarding the new
+one.
+
+---
+
+## 10. API routes
+
+**72 routes** under `apps/web/src/app/api/`. Re-derive rather than trusting any
+table:
+
+```bash
+find apps/web/src/app/api -name route.ts \
+  | sed 's|apps/web/src/app/api/||; s|/route.ts||' | sort
 ```
 
-The `satisfies` makes a missing kind a **compile error**, and no course or path id
-is hardcoded anywhere — every target is named by content.
+The per-route reference — auth, rate limits, and failure modes — lives in
+`apps/web/src/app/api/CLAUDE.md`, which is maintained alongside the routes. The
+grouping:
 
-The eight award kinds:
+| Group               | Count | Notable                                                         |
+| ------------------- | ----- | --------------------------------------------------------------- |
+| Auth                | 6     | `wallet`, `dynamic`, `callback`, `nonce`, link/unlink           |
+| Admin               | 16    | sync, publish pin, insights, flags, freeze, resync, recreate    |
+| Content (public)    | 9     | bundle projections, deployment-gated                            |
+| Lessons + learning  | 7     | `complete`, `reflect`, `reveal-solution`, review, test-out      |
+| AI                  | 4     | tutor turn, log, reset, comprehension-check seal                |
+| Gamification/social | 6     | quests, leaderboards, referrals                                 |
+| Community           | 9     | see §9                                                          |
+| Chain + credentials | 5     | mint, metadata, sponsored enroll, Helius webhook, schema health |
+| Code exec + deploy  | 3     | build proxy, deploy record, Rust playground proxy               |
+| Teacher/preview     | 4     | PR preview, instructor stats                                    |
+| Cron/email/account  | 4     | two cron jobs, unsubscribe, account delete                      |
 
-| `award.kind`                  | Unlocks when                                              |
-| ----------------------------- | --------------------------------------------------------- |
-| `lessons-completed`           | `completedLessons >= gte`                                 |
-| `lessons-completed-in-course` | completed lessons in `course` >= `gte`                    |
-| `course-completed`            | `course` is fully completed                               |
-| `path-completed`              | every course in learning path `path` is completed         |
-| `streak`                      | `currentStreak >= days`                                   |
-| `user-number`                 | `userNumber <= lte` (early-adopter style)                 |
-| `community-stat`              | a community stat (threads/answers/accepted) >= `gte`      |
-| `manual`                      | never auto-fires — admin-granted only (e.g. `bug-hunter`) |
-
-`checkNewAchievements(deployed, state, alreadyUnlocked)` evaluates the rule on each
-not-yet-unlocked achievement against one fully-populated `UserState` (lessons,
-courses, paths, streak, user number, community stats) built in a single pass by
-`buildUserState()`.
-
-The bundle currently carries **10** achievements. Their conditions are defined in
-the content repo, not here — do not enumerate them in this doc.
-
-> `perfect-score` was **dropped**: block results are transient by design, so there
-> is no durable "passed on first try" signal to key it on.
-
-The check runs after every lesson completion. New achievements are:
-
-1. Recorded in Supabase via the `unlock_achievement()` SECURITY DEFINER function
-2. Minted on-chain as Metaplex Core NFTs via `awardAchievement()` (non-fatal)
-
-> **ID convention**: the achievement's full content `_id` (e.g.
-> `achievement-first-steps`) is used **verbatim** as the on-chain PDA seed. Never
-> strip the `achievement-` prefix — doing so derives the wrong PDA and the award
-> fails silently.
-
-### Celebration Popups (Event Bus Pattern)
-
-The client uses `window.dispatchEvent` / `CustomEvent` for real-time celebrations:
-
-| Event Name                     | Dispatch Function                          | Listener Component | Duration |
-| ------------------------------ | ------------------------------------------ | ------------------ | -------- |
-| `xp-gain`                      | `dispatchXpGain(amount)`                   | `XpPopup`          | 2.5s     |
-| `superteam:achievement-unlock` | `dispatchAchievementUnlock(id, name)`      | `AchievementPopup` | 4s       |
-| `superteam:certificate-minted` | `dispatchCertificateMinted(certificateId)` | `CertificatePopup` | 5s       |
-
-The `GamificationOverlays` component mounts all listener components when a user session exists. It renders in the `[locale]` layout so popups appear on all platform pages.
-
-```
-GamificationOverlays
-  ├── XpPopup              ← fixed bottom-left, floating +XP badges
-  ├── LevelUpOverlay       ← full-screen level-up celebration
-  ├── AchievementPopup     ← bottom-left toast with achievement name
-  └── CertificatePopup     ← bottom-left toast with "View Certificate" link
-```
+No admin route holds a write credential for the content repo. `GITHUB_TOKEN` is
+read-only and the publish flow's output is a prefilled PR link, not a write.
 
 ---
 
-## 9. API Routes
+## 11. Build server
 
-All routes are in `apps/web/src/app/api/`. **44 routes** as of the last sync.
+A standalone Rust/Axum service on Cloud Run that compiles learner-authored Solana
+programs.
 
-> **How to re-derive this list** (do this rather than trusting the table):
->
-> ```bash
-> find apps/web/src/app/api -name route.ts \
->   | sed 's|apps/web/src/app/api/||; s|/route.ts||' | sort
-> ```
->
-> A route exists iff it has a `route.ts`. Anything in this table with no
-> corresponding file is a doc bug — `/api/deploy/[uuid]` was exactly that.
+| Route            | Auth      | Purpose                     |
+| ---------------- | --------- | --------------------------- |
+| `/build`         | X-API-Key | Compile, returns the binary |
+| `/deploy/{uuid}` | X-API-Key | Fetch a cached artifact     |
+| `/health`        | —         | Health + cache stats        |
+| `/metrics`       | X-API-Key | Counts, durations, hit rate |
 
-"Admin" auth below means the same-origin + signed-`admin_session`-cookie check
-(`requireAdminAuth`), **not** a bearer token.
-
-### Content (public, serve the bundle to client components)
-
-These exist because `lib/content/*` is `server-only` (the bundle holds answer keys
-and solutions). They expose only summary-safe shapes — there is deliberately **no**
-client-side route for a full lesson read.
-
-| Route                            | Method | Auth | Purpose                                          |
-| -------------------------------- | ------ | ---- | ------------------------------------------------ |
-| `/api/content/courses`           | GET    | None | Course summaries by id                           |
-| `/api/content/lessons-summary`   | GET    | None | Lesson summaries by id                           |
-| `/api/content/recommended`       | GET    | None | Recommended courses (excluding given ids)        |
-| `/api/content/tags`              | GET    | None | Course tags (cached, revalidated hourly)         |
-| `/api/content/achievements`      | GET    | None | Achievement catalog (cached, revalidated hourly) |
-| `/api/content/instructor-wallet` | GET    | None | Is this wallet an instructor?                    |
-
-### Auth / core / community
-
-| Route                             | Method   | Auth                  | Purpose                                                                                                                                                                             |
-| --------------------------------- | -------- | --------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `/api/auth/nonce`                 | GET      | None                  | Generate SIWS nonce (stored in `siws_nonces` table)                                                                                                                                 |
-| `/api/auth/wallet`                | POST     | None                  | SIWS authentication (nonce + Ed25519 verification)                                                                                                                                  |
-| `/api/auth/callback`              | GET      | None                  | Google/GitHub OAuth callback (code exchange)                                                                                                                                        |
-| `/api/auth/link-wallet`           | POST     | Required              | Link wallet to existing account                                                                                                                                                     |
-| `/api/auth/unlink`                | POST     | Required              | Unlink auth method (wallet/Google/GitHub)                                                                                                                                           |
-| `/api/account/delete`             | POST     | Required              | Account deletion                                                                                                                                                                    |
-| `/api/lessons/complete`           | POST     | Required              | Mark lesson complete, award XP, auto-finalize, auto-credential, check achievements                                                                                                  |
-| `/api/lessons/validate-challenge` | POST     | Required              | Server-side challenge validation (UX pass/fail)                                                                                                                                     |
-| `/api/leaderboard`                | GET      | None                  | XP rankings (alltime/weekly/monthly)                                                                                                                                                |
-| `/api/certificates/metadata`      | GET      | None                  | Serve NFT metadata JSON by UUID                                                                                                                                                     |
-| `/api/certificates/mint`          | POST     | Required              | Manual credential mint with retry queue                                                                                                                                             |
-| `/api/build-program`              | POST     | Required              | Proxy Anchor build to build server                                                                                                                                                  |
-| `/api/deploy/save`                | POST     | Required              | Save deployed program record. **The only route under `/api/deploy`** — the compiled `.so` comes back inline (base64) from `/api/build-program`, not from a separate download route. |
-| `/api/rust/execute`               | POST     | Required              | Proxy basic Rust execution to Rust Playground                                                                                                                                       |
-| `/api/quests/daily`               | GET/POST | Required              | Get daily quest state / award quest XP (on-chain minting via `reward_xp`)                                                                                                           |
-| `/api/ai/partner`                 | POST     | Required              | AI lesson assistant (Gemini); rate-limited + input-capped                                                                                                                           |
-| `/api/ai/partner/verify`          | POST     | Required              | Verify the sealed comprehension-check token                                                                                                                                         |
-| `/api/teacher/courses/[id]/stats` | GET      | Required              | Read-only per-course stats for the instructor (`/teach`) viewer                                                                                                                     |
-| `/api/community/*`                | Varies   | Varies                | 9 routes: threads (+delete), answers (+accept, +delete), votes, flags, search — see §7                                                                                              |
-| `/api/webhooks/helius`            | POST     | HELIUS_WEBHOOK_SECRET | Process on-chain events (XP, achievements)                                                                                                                                          |
-
-### Admin
-
-| Route                           | Method   | Auth  | Purpose                                                                     |
-| ------------------------------- | -------- | ----- | --------------------------------------------------------------------------- |
-| `/api/admin/auth`               | POST     | None  | Exchange `ADMIN_SECRET` for the signed `admin_session` cookie               |
-| `/api/admin/status`             | GET      | Admin | Program liveness, authority match, per-item deploy state (drives 2 screens) |
-| `/api/admin/publish/pin`        | GET      | Admin | Pinned bundle SHA vs `academy-courses` HEAD + CI checks + drift verdict     |
-| `/api/admin/courses/sync`       | POST     | Admin | Deploy course PDA + track collection on-chain, record it in Supabase        |
-| `/api/admin/courses/deactivate` | POST     | Admin | Set course `is_active = false` (hides it from learners)                     |
-| `/api/admin/courses/reactivate` | POST     | Admin | Set course `is_active = true`                                               |
-| `/api/admin/achievements/sync`  | POST     | Admin | Deploy achievement type + collection on-chain                               |
-| `/api/admin/flags`              | GET/POST | Admin | Pending moderation queue / resolve+dismiss a flag                           |
-| `/api/admin/resync`             | POST     | Admin | Re-read on-chain state and backfill the Supabase mirror                     |
-
-No admin route holds a content- or repo-write credential. `GITHUB_TOKEN` is
-read-only; the publish flow's output is a **prefilled PR link**, not a write.
+The pipeline validates paths and sizes (`/src/*.rs` only), blocks
+`std::process` / `std::fs` / `std::net` / `Command::new` / `proc_macro`, hashes
+the content for a cache lookup, then runs `cargo-build-sbf --offline` against a
+pre-cached crate set behind a concurrency semaphore. Defense in depth: SBF is the
+compile target so the output cannot touch the host, the container runs non-root,
+CORS is an exact origin match, the body limit is 512 KB, and the API key compare
+is constant-time.
 
 ---
 
-## 10. Database Schema
+## 12. Design decisions worth knowing
 
-### Tables (21)
+**Hybrid on-chain / off-chain.** Chain first, mirror second, mirror failures
+non-fatal. The alternative — writing Supabase first — would make the mirror
+authoritative in exactly the failure cases where it must not be.
 
-#### Core Tables (11)
+**Backend signer, not learner signer, for progress.** Lesson completion,
+finalization, and credential issuance are backend-signed so eligibility is
+checked before the chain is touched. Enrollment and closure stay learner-signed:
+they are personal commitments with no anti-cheat concern.
 
-| Table                 | Purpose                                  | Key Columns                                                        |
-| --------------------- | ---------------------------------------- | ------------------------------------------------------------------ |
-| `profiles`            | User identity                            | `id` (FK auth.users), `wallet_address`, `username`, `is_public`    |
-| `enrollments`         | Course enrollment records                | `user_id`, `course_id`, `completed_at`, `tx_signature`             |
-| `user_progress`       | Per-lesson completion                    | `user_id`, `lesson_id`, `completed`, `lesson_index`                |
-| `user_xp`             | XP totals and streaks                    | `user_id`, `total_xp`, `level`, `current_streak`, `longest_streak` |
-| `xp_transactions`     | XP award history                         | `user_id`, `amount`, `reason`, `source`, `tx_signature`            |
-| `user_achievements`   | Achievement unlock records               | `user_id`, `achievement_id`, `asset_address`                       |
-| `certificates`        | Credential NFT records                   | `user_id`, `course_id`, `mint_address`, `credential_type`          |
-| `nft_metadata`        | Full Metaplex metadata JSON              | `id`, `data` (JSONB)                                               |
-| `siws_nonces`         | Nonce replay protection                  | `nonce`, `status`, `ip_address`, TTL-based cleanup                 |
-| `deployed_programs`   | **Learner** practice program deployments | `user_id`, `program_id`, `network`                                 |
-| `onchain_deployments` | **Platform** content → chain state       | `content_id` (PK), `kind`, `status`, `course_pda`, `is_active`, …  |
+**Content as a committed artifact.** Content changes become reviewable diffs with
+CI gates, the read path has zero network hops, and no runtime path can mutate
+content because no write token exists. The cost is that publishing needs a
+deploy — the intended trade.
 
-#### `onchain_deployments` — the visibility gate
+**Visibility gated in Supabase, not in content.** Courses stay hidden until they
+actually exist on-chain, and an admin can hide one again without destroying the
+PDA. Fail-closed: no row means hidden.
 
-The post-SP2 home of what used to be a CMS `onChainStatus` field. One row per synced
-course (`course-*`) or achievement (`achievement-*`), keyed by the content `_id`
-**used verbatim as the on-chain PDA seed**.
+**Sandboxed challenge execution.** Challenge code runs in a QuickJS sandbox in
+the browser with a mock console — no DOM, no network, no module imports, and no
+server-side execution infrastructure to secure.
 
-It is deliberately **not** `deployed_programs`: that table is per-learner practice
-deploys (UUID pk, `user_id` FK, own-row RLS). This one is per-content platform
-state (TEXT pk, no user). They never mix.
-
-Security follows the house `public_user_xp` pattern — RLS is row-level, not
-column-level, so the minimal public surface is a **view**:
-
-- Base table: **RLS enabled, zero policies** → service_role only (which bypasses
-  RLS). All four writer sites use `createAdminClient()`.
-- `public_onchain_deployments` view: `SELECT` granted to `anon` + `authenticated`,
-  exposing **only** `content_id, kind, status, is_active, achievement_pda`.
-- **Invariant**: never add a raw pubkey, tx signature, or
-  `track_collection_address` to that view — those are reward-path reads served via
-  service_role only.
-
-#### Community Tables (6)
-
-| Table              | Purpose                  | Key Columns                                                                   |
-| ------------------ | ------------------------ | ----------------------------------------------------------------------------- |
-| `forum_categories` | Global forum sections    | `name`, `slug`, `description`, `sort_order`                                   |
-| `threads`          | Discussion threads       | `author_id`, `category_id`, `title`, `body`, `course_id`, `lesson_id`, `tags` |
-| `answers`          | Thread replies           | `thread_id`, `author_id`, `body`, `is_accepted`                               |
-| `votes`            | Upvotes/downvotes        | `user_id`, `thread_id` or `answer_id`, `value` (+1/-1)                        |
-| `flags`            | Content moderation flags | `reporter_id`, `thread_id` or `answer_id`, `reason`, `status`                 |
-| `thread_views`     | Per-user view dedup      | `user_id`, `thread_id`                                                        |
-
-#### Queue / Quest / Infra Tables (4)
-
-| Table                     | Purpose                             | Key Columns                                                         |
-| ------------------------- | ----------------------------------- | ------------------------------------------------------------------- |
-| `pending_onchain_actions` | On-chain retry queue for failed TXs | `user_id`, `action_type`, `payload`, `attempts`, `status`           |
-| `user_daily_quests`       | Daily quest completion tracking     | `user_id`, `quest_id`, `current_value`, `completed`, `period_start` |
-| `challenge_assists`       | Per-user AI-assist budget           | `user_id`, `lesson_id`, assist counters                             |
-| `rate_limits`             | Cross-instance API rate limiter     | key, window, count                                                  |
-
-#### Views (3)
-
-| View                         | Purpose                                                                      |
-| ---------------------------- | ---------------------------------------------------------------------------- |
-| `community_stats`            | Aggregated thread/answer/accepted counts per user (for profile display)      |
-| `public_user_xp`             | Non-sensitive `user_id`/`total_xp`/`level` for public profiles + leaderboard |
-| `public_onchain_deployments` | The 5-column public read surface of `onchain_deployments` (see above)        |
-
-### Auto-Provisioning
-
-The `on_auth_user_created` trigger fires `handle_new_user()` on every new auth.users insert:
-
-1. Creates `profiles` row with username `user_{first_8_chars_of_id}`
-2. Creates `user_xp` row initialized to 0 XP, level 0
-
-### SECURITY DEFINER Functions
-
-| Function                                         | Access                   | Purpose                                                                                  |
-| ------------------------------------------------ | ------------------------ | ---------------------------------------------------------------------------------------- |
-| `award_xp(user_id, amount, reason)`              | `service_role` only      | Insert XP transaction, update totals, manage streaks                                     |
-| `unlock_achievement(user_id, achievement_id)`    | `service_role` only      | Record achievement (ON CONFLICT DO NOTHING for idempotency)                              |
-| `get_leaderboard(timeframe, limit)`              | `authenticated` + `anon` | Leaderboard query (alltime uses `user_xp`, weekly/monthly uses `xp_transactions` window) |
-| `get_daily_quest_state(p_user_id, p_quest_defs)` | `service_role` only      | Evaluate daily quest progress in a single pass, return quest states                      |
-
-### Storage
-
-- **avatars** bucket (public): Users can upload/update/delete their own avatar via `auth.uid()` folder path
-
----
-
-## 11. Build Server Architecture
-
-The build server is a standalone Rust/Axum service deployed on GCP Cloud Run for compiling student-authored Solana programs.
-
-### Endpoints
-
-| Route            | Method | Auth      | Rate Limit | Purpose                                 |
-| ---------------- | ------ | --------- | ---------- | --------------------------------------- |
-| `/build`         | POST   | X-API-Key | 5 req/min  | Compile Solana program                  |
-| `/deploy/{uuid}` | GET    | X-API-Key | 20 req/min | Download compiled .so binary            |
-| `/health`        | GET    | None      | None       | Health check with cache stats           |
-| `/metrics`       | GET    | X-API-Key | None       | Build counts, durations, cache hit rate |
-
-### Build Pipeline
-
-1. Validate files (regex: `/src/*.rs` only, max 64 files, max 100KB each)
-2. Block dangerous patterns (`std::process`, `std::fs`, `std::net`, `Command::new`, `proc_macro`)
-3. SHA-256 content hash for cache lookup (cache hit returns immediately)
-4. Semaphore-gated concurrency (default: 2 concurrent builds)
-5. `cargo-build-sbf --offline` with pre-cached Anchor 0.32.1 dependencies
-6. Background TTL cleanup of build directories
-
-### Security
-
-- SBF compilation target cannot access host system
-- File validation (paths, sizes, blocked patterns)
-- Non-root Docker execution (`academy` user)
-- CORS exact origin match
-- Per-IP rate limiting via tower-governor
-- Request body limit: 512KB
-- Constant-time API key comparison (`subtle::ConstantTimeEq`)
-
----
-
-## 12. Key Design Decisions
-
-### Hybrid On-Chain / Off-Chain Progress
-
-On-chain state (Token-2022 XP, enrollment bitmap, Metaplex Core credentials) is the source of truth. Supabase mirrors this data for fast queries, streak tracking, and leaderboard display. The lesson completion API route writes on-chain first, then mirrors to Supabase. Mirror failures are non-fatal.
-
-### Backend Signer Pattern
-
-The backend server holds a rotatable keypair (`BACKEND_SIGNER_SECRET`, stored in Config PDA). Lesson completion, course finalization, and credential issuance are all backend-signed to prevent gaming. Enrollment and enrollment closure are learner-signed (personal commitment, no anti-cheat concern).
-
-### Content as a Committed Artifact (no CMS)
-
-Course content is authored in git (`solanabr/academy-courses`), compiled by
-`compile-content.ts` at a SHA pinned in `apps/web/content.lock`, and **committed**
-to this repo as typed JSON. The app never fetches content at runtime.
-
-Why: content changes become reviewable diffs with CI gates; the read path has zero
-network hops and cannot be broken by a third-party outage; and — because no
-server-side content-write token exists anywhere in the app — there is no runtime
-path by which content can be mutated. Publishing is a pull request. The cost is
-that publishing requires a deploy, which is the intended trade.
-
-### Content Gate (Supabase, not content)
-
-Courses become visible to learners only when their `onchain_deployments` row is
-`status == "synced"` **and** `coalesce(is_active, true)`. This keeps courses hidden
-until they are actually deployed on-chain, and lets an admin hide one again without
-destroying the PDA. Content with no row at all is hidden (fail-closed).
-
-The gate is one function — `isSynced()` in `lib/content/deployments.ts`. The admin
-console shows all content regardless of status.
-
-### Browser-Side Code Execution
-
-Challenge code runs via `new Function()` in the browser. Blocked patterns: `eval`, `Function`, `document`, `window`, `fetch`, `XMLHttpRequest`, `import()`. Mock console and mock Solana SDK provide isolation without server-side execution infrastructure.
-
-### Dark Mode First
-
-Solana brand colors (#9945FF, #14F195) contrast best against dark backgrounds. Developer tools are overwhelmingly used in dark mode.
-
----
-
-_Last updated: 2026-07-12_
+**Ink over gradient.** The visual system is a dark-green/mint "ink" construction
+with outlined chips and pressed-key affordances, not the Solana purple-to-teal
+gradient, which is now reserved for credentials. See
+[CUSTOMIZATION.md](./CUSTOMIZATION.md).

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -75,7 +75,7 @@ solanabr/academy-courses ──► compile-content.ts ──► committed bundle
 | `packages/challenge-executor/` | Sandboxed challenge runner shared by the app and the linter         |
 | `packages/deploy/`             | Browser-side Solana program deployment (BPF loader chunking)        |
 | `packages/config/`             | Shared ESLint, TypeScript, Tailwind configs                         |
-| `supabase/`                    | 62 migrations (source of truth) + a generated `schema.sql` snapshot |
+| `supabase/`                    | 60 migrations (source of truth) + a generated `schema.sql` snapshot |
 
 ### Deployment model
 
@@ -449,7 +449,7 @@ The retired `ADMIN_SECRET` / HMAC-cookie system is gone from all runtime code.
 ## 7. Database
 
 **36 tables, RLS enabled on all of them.** Migrations in `supabase/migrations/`
-are the source of truth (62 of them); `supabase/schema.sql` is a generated
+are the source of truth (60 of them); `supabase/schema.sql` is a generated
 snapshot kept for diffing.
 
 | Group                | Tables                                                                                                                                                            |

--- a/docs/CUSTOMIZATION.md
+++ b/docs/CUSTOMIZATION.md
@@ -1,325 +1,138 @@
-> Last synced: 2026-03-02
+> Last synced: 2026-08-24
 
 # Customization Guide
 
-How to customize and extend Superteam Academy for your own needs.
+How to retheme, translate, and extend Superteam Academy.
 
-## Theme Customization
+## Theming
 
-### CSS Custom Properties
+The design system is **Solarium v9** — an "ink" construction of cream outlines,
+forest-green and amber fills, chips, and pressed-key button affordances. It is
+deliberately _not_ the Solana purple-to-teal gradient, which is now reserved for
+credentials. The rendered reference is `docs/design-system.html` (the brand
+guide); `apps/web/src/styles/globals.css` is the implementation and the only CSS
+file in the app.
 
-The design system is built on CSS custom properties defined in `apps/web/src/styles/globals.css`. These control all colors across both light and dark modes. Values are plain hex or rgba.
+### Where the tokens live
 
-**Light Mode** (`:root`):
+Light mode is the `:root` baseline. Dark mode is **`[data-theme="dark"]`**, an
+attribute — not a `.dark` class.
 
 ```css
 :root {
-  /* -- Primary: Deep Teal -- */
-  --primary: #0d9488;
-  --primary-hover: #0b7e73;
-  --primary-dark: #087068;
-  --primary-light: #ccfbf1;
-  --primary-bg: #f0fdfa;
-
-  /* -- Accent: Warm Amber -- */
-  --accent: #f59e0b;
-  --accent-hover: #d97706;
-  --accent-dark: #b45309;
-  --accent-light: #fef3c7;
-  --accent-bg: #fffbeb;
-
-  /* -- Secondary: Ink Teal -- */
-  --secondary: #0f2f2d;
-  --secondary-light: #134e4a;
-  --secondary-bg: #e6fffb;
-
-  /* -- Success: Botanical Green -- */
-  --success: #16a34a;
-  --success-dark: #15803d;
-  --success-light: #dcfce7;
-  --success-bg: #f0fdf4;
-
-  /* -- Streak: Flame Orange -- */
-  --streak: #ea580c;
-  --streak-light: #fff7ed;
-
-  /* -- Danger: Warm Coral -- */
-  --danger: #e11d48;
-  --danger-light: #ffe4e6;
-
-  /* -- Solana Nod (used sparingly) -- */
-  --solana-purple: #9945ff;
-  --solana-green: #14f195;
-
-  /* -- Neutrals: warm cream -- */
-  --bg: #fafaf7;
+  --bg: #fafaf7; /* warm cream page */
+  --surface: #ffffff;
   --card: #ffffff;
-  --subtle: #f5f3ee;
-  --warm: #fdf8f0;
-  --border: #e7e4dd;
-  --border-hover: #d4d0c7;
-  --text: #1c1917;
-  --text-2: #57534e;
-  --text-3: #a8a29e;
+  --primary: #0a7055; /* Forest Emerald — dark enough for a light ground */
+  --xp: #f59e0b; /* Warm Amber */
+  --border: rgba(0, 0, 0, 0.08);
+}
 
-  /* -- Radii -- */
-  --r-sm: 10px;
-  --r-md: 14px;
-  --r-lg: 18px;
-  --r-xl: 24px;
+[data-theme="dark"] {
+  --bg: #111111; /* neutral gray, not blue-black */
+  --surface: #181818;
+  --card: #1b1b1b;
+  --primary: #2ecc8e; /* lifted mint for a dark ground */
+  --border: rgba(255, 255, 255, 0.07);
 }
 ```
 
-**Dark Mode** (`.dark`):
+The dark neutrals are the luminance-matched grays of the blue-tinted surfaces
+they replaced, so every contrast ratio the palette was tuned for is unchanged —
+only the hue is gone. The blue cast fought the ink construction, whose cream
+outlines and green/amber fills are meant to carry the only colour on those
+surfaces.
 
-```css
-.dark {
-  /* -- Neutrals: Soft Neutral Dark -- */
-  --bg: #343431;
-  --card: #3d3c38;
-  --subtle: #46443f;
-  --warm: #4a4843;
-  --border: #57534e;
-  --border-hover: #6a655e;
-  --text: #f5f1ea;
-  --text-2: #d4cec3;
-  --text-3: #a79f93;
+The token families, so you know what you are reaching for:
 
-  /* -- Primary: lifted for dark readability -- */
-  --primary: #2dd4bf;
-  --primary-hover: #22c7b3;
-  --primary-dark: #0b7e73;
-  --primary-light: rgba(45, 212, 191, 0.15);
-  --primary-bg: rgba(45, 212, 191, 0.1);
+| Family         | Tokens                                                                                                      |
+| -------------- | ----------------------------------------------------------------------------------------------------------- |
+| Surfaces       | `--bg`, `--surface`, `--card`, `--card-hover`, `--card-alt`, `--inset`, `--input`                           |
+| Borders        | `--border`, `--border-default`, `--border-strong`, `--keyline{,-hover,-raised}`                             |
+| Brand          | `--primary{,-hover,-dark,-dim,-light,-bg,-border}`                                                          |
+| XP / accent    | `--xp`, `--xp-dim`, `--xp-dark`, and the `--accent*` Tailwind aliases                                       |
+| **Ink**        | `--ink-line`, `--ink-bright`, `--ink-cream`, `--ink-dark`, `--ink-green`, `--ink-orange`, `--ink-on-orange` |
+| Buttons        | `--btn-fill{,-hover,-press,-disabled}`, `--btn-label`, `--btn-line`                                         |
+| Identity chips | `--avatar-bg`, `--avatar-fg`, `--xp-chip-{bg,fg}`, `--streak-chip-{bg,fg}`                                  |
+| Code islands   | `--code-bg`, `--code-fg`                                                                                    |
+| Layout         | `--header-h`, `--rim-h`, `--chip-radius`, `--focus-ring`                                                    |
+| Semantic       | `--danger*`, `--error`, `--freeze*`, `--gold-ink`, `--gold-hi`                                              |
 
-  /* -- Accent: lifted -- */
-  --accent: #fbbf24;
-  --accent-hover: #f59e0b;
-  --accent-dark: #b45309;
-  --accent-light: rgba(251, 191, 36, 0.18);
-  --accent-bg: rgba(251, 191, 36, 0.1);
+The ink family is the one to understand before making changes. Only `--ink-line`
+flips between themes; the rest hold across both so outlined chrome reads as one
+system in either mode.
 
-  /* etc. -- see globals.css for the full set */
-}
-```
+### Rebranding
 
-To change the color scheme, update the hex/rgba values in `globals.css`. All components reference these properties through Tailwind classes like `bg-primary`, `text-text`, `border-border`, etc.
+1. Change the `--primary-*` and `--xp-*` values in **both** the `:root` and
+   `[data-theme="dark"]` blocks. Dark needs a lifted variant — the light-mode
+   value will not carry on a `#111` ground.
+2. Nothing in `tailwind.config.ts` needs touching. Every colour there is a
+   `var(--token)` reference, so it follows automatically.
+3. Confetti colours in the celebration layer are hardcoded hex — update them to
+   match.
 
-### Changing the Primary Color Scheme
+To add a whole new colour group, define the variables in both blocks in
+`globals.css`, then add the Tailwind mapping in `tailwind.config.ts`.
 
-To rebrand from Deep Teal to a different primary color:
+### Tailwind
 
-1. Update the `--primary-*` variables in both `:root` (light) and `.dark` blocks in `globals.css`
-2. Update the `--accent-*` variables if desired
-3. The Tailwind config (`apps/web/tailwind.config.ts`) references these CSS variables, so no Tailwind changes are needed
-4. Confetti colors in `apps/web/src/components/gamification/level-up-overlay.tsx` use hardcoded hex values -- update those to match
+`darkMode: ["selector", "[data-theme='dark']"]` — the `dark:` variant keys on
+the same attribute `next-themes` writes, so the CSS variables and the Tailwind
+utilities can never disagree about which mode is active.
 
-### Tailwind Configuration
+Beyond the colour mappings the config extends `borderRadius`, `fontFamily`,
+`boxShadow` (including the push-button and card-lift shadows the ink system
+relies on), and a set of keyframe animations for XP pops, shimmer, breathe, and
+pulse rings. Plugins: `tailwindcss-animate` and `@tailwindcss/typography` (the
+latter styles rendered lesson markdown).
 
-Extended theme values are defined in `apps/web/tailwind.config.ts`. Colors reference CSS variables so they respond to light/dark mode automatically.
-
-**Color System:**
-
-The Tailwind config maps semantic color names to CSS custom properties:
-
-```typescript
-colors: {
-  primary: {
-    DEFAULT: "var(--primary)",
-    hover: "var(--primary-hover)",
-    dark: "var(--primary-dark)",
-    light: "var(--primary-light)",
-    bg: "var(--primary-bg)",
-    foreground: "#FFFFFF",
-  },
-  accent: {
-    DEFAULT: "var(--accent)",
-    hover: "var(--accent-hover)",
-    dark: "var(--accent-dark)",
-    light: "var(--accent-light)",
-    bg: "var(--accent-bg)",
-    foreground: "#FFFFFF",
-  },
-  secondary: {
-    DEFAULT: "var(--secondary)",
-    light: "var(--secondary-light)",
-    bg: "var(--secondary-bg)",
-    foreground: "#FFFFFF",
-  },
-  success: {
-    DEFAULT: "var(--success)",
-    dark: "var(--success-dark)",
-    light: "var(--success-light)",
-    bg: "var(--success-bg)",
-  },
-  streak: {
-    DEFAULT: "var(--streak)",
-    light: "var(--streak-light)",
-  },
-  danger: {
-    DEFAULT: "var(--danger)",
-    light: "var(--danger-light)",
-  },
-  solana: {
-    purple: "var(--solana-purple)",
-    green: "var(--solana-green)",
-  },
-  /* Neutrals */
-  bg: "var(--bg)",
-  card: { DEFAULT: "var(--card)", foreground: "var(--text)" },
-  subtle: "var(--subtle)",
-  warm: "var(--warm)",
-  border: { DEFAULT: "var(--border)", hover: "var(--border-hover)" },
-  text: { DEFAULT: "var(--text)", 2: "var(--text-2)", 3: "var(--text-3)" },
-}
-```
-
-To add a new color group, define the CSS variables in `globals.css` (both `:root` and `.dark` blocks), then add the Tailwind mapping in `tailwind.config.ts`.
-
-**Legacy shadcn Compatibility:**
-
-The config also includes compatibility aliases for shadcn/ui components:
-
-- `background` -> `var(--bg)`
-- `foreground` -> `var(--text)`
-- `destructive` -> `var(--danger)` (with white foreground)
-- `muted` -> `var(--subtle)` (with `--text-3` foreground)
-- `popover` -> `var(--card)` (with `--text` foreground)
-- `input` -> `var(--border)`
-- `ring` -> `var(--primary)`
-
-**Certificate Gradient:**
-
-```typescript
-backgroundImage: {
-  "cert-gradient":
-    "linear-gradient(135deg, var(--solana-purple) 0%, var(--solana-green) 100%)",
-}
-```
-
-The Solana gradient is used sparingly (certificates only). A matching `.bg-cert-gradient` utility class is also available in `globals.css`.
-
-**Border Radius:**
-
-```typescript
-borderRadius: {
-  sm: "var(--r-sm)",   // 10px
-  md: "var(--r-md)",   // 14px
-  lg: "var(--r-lg)",   // 18px
-  xl: "var(--r-xl)",   // 24px
-}
-```
-
-**Custom Shadows:**
-
-```typescript
-boxShadow: {
-  push: "0 4px 0 0 var(--shadow-push-color)",        // 3D push button
-  "push-sm": "0 2px 0 0 var(--shadow-push-color)",   // Small push button
-  "push-active": "0 1px 0 0 var(--shadow-push-color)", // Pressed push button
-  card: "var(--shadow-card)",                          // Chunky card
-  "card-hover": "var(--shadow-card-hover)",            // Card hover lift
-  glow: "var(--shadow-glow)",                          // Dark-mode glow
-  cert: "var(--shadow-cert)",                          // Certificate cards
-  "cert-hover": "var(--shadow-cert-hover)",            // Certificate hover
-  "cert-lg": "var(--shadow-cert-lg)",                  // Large certificate
-}
-```
-
-**Custom Animations:**
-
-| Name             | Duration / Timing                      | Purpose                                     |
-| ---------------- | -------------------------------------- | ------------------------------------------- |
-| `accordion-down` | 0.2s ease-out                          | Radix accordion open transition             |
-| `accordion-up`   | 0.2s ease-out                          | Radix accordion close transition            |
-| `xp-pop`         | 2s ease-out (forwards)                 | XP gain popup: scale up, float up, fade out |
-| `shimmer`        | 2s infinite                            | Loading skeleton shimmer effect             |
-| `breathe`        | 2s infinite alternate ease-in-out      | Gentle pulsing scale for emphasis           |
-| `pop`            | 0.6s cubic-bezier(0.34, 1.56, 0.64, 1) | Bounce-in entry for popups                  |
-| `pulse-ring`     | 2s infinite                            | Pulsing glow ring on CTAs                   |
-| `bounce-in`      | 0.4s cubic-bezier(0.34, 1.56, 0.64, 1) | Quick elastic scale-in                      |
-
-**Additional transition utilities:**
-
-- `duration-600`: 600ms transition duration
-- `ease-smooth`: `cubic-bezier(0.4, 0, 0.2, 1)` timing function
-
-**CSS Utility Classes (in globals.css):**
-
-Beyond Tailwind's generated classes, `globals.css` provides additional utilities:
-
-- `.btn-push` / `.btn-push:active`: 3D push-button press effect
-- `.card-chunky` / `.card-chunky:hover`: Bordered card with shadow lift on hover
-- `.progress-fat` / `.progress-fat-fill`: Thick progress bar with inner highlight
-- `.progress-fill-teal` / `.progress-fill-amber` / `.progress-fill-green`: Progress bar color variants
-- `.banner-beginner` / `.banner-intermediate` / `.banner-advanced`: Difficulty-based gradient banners (with dark mode variants)
-- `.font-display` / `.font-body`: Font family shortcuts
-
-**Tailwind Plugins:**
-
-- `tailwindcss-animate`: Animation utility classes
-- `@tailwindcss/typography`: Prose styling for Markdown content
+`globals.css` also carries the component classes that are too structural for
+utilities: `.patch` / `.chip` (with `data-cat` and `data-locked` variants),
+`.nav-pill`, `.lv-badge`, the `.prog-*` progress system, `.banner-*` difficulty
+banners, `.term-*` and `.hero-*` landing animations, `.ach-ring*`, and the
+sidebar rules.
 
 ### Fonts
 
-Three font families are configured in `apps/web/src/app/layout.tsx`:
+Three families, self-hosted through `next/font/google` in
+`apps/web/src/app/layout.tsx` — no runtime request to Google, so the CSP does
+not need to allow one.
 
-| Variable         | Font              | Usage                  |
-| ---------------- | ----------------- | ---------------------- |
-| `--font-sans`    | Plus Jakarta Sans | Body text, UI elements |
-| `--font-display` | Nunito            | Headings, display text |
-| `--font-mono`    | JetBrains Mono    | Code blocks, editor    |
+| Variable   | Font              | Used for            |
+| ---------- | ----------------- | ------------------- |
+| `--font-d` | Nunito            | Headings, display   |
+| `--font-b` | Plus Jakarta Sans | Body, UI            |
+| `--font-m` | JetBrains Mono    | Code blocks, editor |
 
-To change fonts, update the `next/font/google` imports in `layout.tsx`. The CSS variables are set automatically via Next.js's `variable` option, so `globals.css` and `tailwind.config.ts` need no changes.
+Swapping a font is an edit to the `next/font/google` import; the CSS variable is
+wired by Next's `variable` option, so neither `globals.css` nor the Tailwind
+config changes.
 
-### Dark/Light Mode Toggle
+### Theme switching
 
-Theme switching is handled by `next-themes`:
+`next-themes` with `attribute="data-theme"`, mounted by
+`components/layout/theme-provider.tsx` and toggled by `theme-toggle.tsx`. Because
+selection is an attribute on `<html>`, both the CSS variables and Tailwind's
+`dark:` variant switch from a single source.
 
-- `ThemeProvider` in `components/layout/theme-provider.tsx` wraps the app
-- `ThemeToggle` in `components/layout/theme-toggle.tsx` provides the UI toggle
-- `darkMode: "class"` in `tailwind.config.ts` enables class-based dark mode
+## Adding a language
 
-All color tokens have separate light and dark values. Components use `dark:` Tailwind variants or the CSS variable system (which switches automatically based on the `.dark` class on `<html>`).
+`next-intl`, three locales today: `en` (default), `pt-BR`, `es`. Message files
+are `apps/web/src/messages/<locale>.json`.
 
-## Adding New Languages (i18n)
+**1. Create the message file.** Copy `en.json` and translate every value. All
+locale files must have identical key structures — a missing key is a runtime
+`MISSING_MESSAGE` error, and two test suites enforce it
+(`src/messages/__tests__/parity.test.ts` and `no-duplicate-keys.test.ts`). There
+are currently 31 top-level namespaces; take the list from `en.json` rather than
+from this document, which will rot.
 
-The platform uses `next-intl` for internationalization.
-
-### Current Locales
-
-Three locales are currently supported (files in `apps/web/src/messages/`):
-
-- `en.json` -- English (default)
-- `pt-BR.json` -- Portuguese (Brazil)
-- `es.json` -- Spanish
-
-### Step 1: Create the Message File
-
-Create a new JSON file in `apps/web/src/messages/`. Copy the structure from `en.json` and translate all values. Every key must be present -- missing keys cause `MISSING_MESSAGE` errors at runtime.
-
-```
-apps/web/src/messages/fr.json
-```
-
-The top-level namespace structure to replicate (21 namespaces):
-
-```
-common, nav, auth, landing, courses, lesson, dashboard,
-gamification, certificates, profile, settings, a11y, footer,
-notFound, error, errors, timeAgo, nameGenerator, deploy,
-community, programErrors
-```
-
-### Step 2: Register the Locale
-
-Update `apps/web/src/lib/i18n/config.ts`:
+**2. Register it** in `apps/web/src/lib/i18n/config.ts`:
 
 ```typescript
 export const locales = ["en", "pt-BR", "es", "fr"] as const;
-export type Locale = (typeof locales)[number];
 export const defaultLocale: Locale = "en";
-
 export const localeNames: Record<Locale, string> = {
   en: "English",
   "pt-BR": "Portugues (BR)",
@@ -328,76 +141,64 @@ export const localeNames: Record<Locale, string> = {
 };
 ```
 
-### Step 3: No Middleware Changes Needed
+**3. That is all.** The middleware and `lib/i18n/request.ts` both read from
+`config.ts` — the middleware iterates `locales`, and the request handler imports
+`@/messages/${locale}.json` dynamically. `localePrefix` is `"always"`, so the new
+locale is live at `/fr/` immediately.
 
-The middleware (`apps/web/src/middleware.ts`) imports from `config.ts`:
+Two conventions worth keeping: never hardcode a UI string in a component, and
+remember that the root-level `not-found.tsx` and `error.tsx` render _outside_ the
+`[locale]` layout — they cannot use `next-intl` and carry inline translation
+objects keyed off `usePathname()` instead.
 
-```typescript
-import { locales, defaultLocale } from "@/lib/i18n/config";
-```
+## Wallets
 
-It reads from the `locales` array dynamically, so no separate middleware update is needed.
-
-The i18n request handler (`apps/web/src/lib/i18n/request.ts`) also imports from `config.ts` and dynamically loads the message file:
-
-```typescript
-messages: (await import(`@/messages/${locale}.json`)).default,
-```
-
-### Step 4: Verify
-
-Run the development server and navigate to `http://localhost:3000/fr/` to verify the new locale loads correctly.
-
-### Translation Guidelines
-
-- All UI strings must be externalized in message files -- never hardcode text in components
-- Use nested keys for organization (e.g., `courses.difficulty.beginner`)
-- Keep keys descriptive: `auth.connectWallet` not `btn1`
-- Pluralization is supported via next-intl's ICU message format
-- Root-level files (`not-found.tsx`, `error.tsx`) cannot use `next-intl` because they render outside the `[locale]` layout. They use inline translation objects.
-
-### Critical vs Optional Namespaces
-
-All namespaces are required for a complete translation. The most critical ones (used on every page):
-
-- `common` -- shared buttons, labels, app name
-- `nav` -- navigation links
-- `auth` -- wallet connection, sign in/out
-- `footer` -- footer links and text
-- `a11y` -- accessibility labels (screen readers)
-
-The remaining namespaces are page-specific and can be translated incrementally, though missing keys will show `MISSING_MESSAGE` warnings.
-
-## Adding New Wallet Adapters
-
-The Solana wallet provider is configured in `apps/web/src/lib/solana/wallet-provider.tsx`.
-
-### Wallet Standard Auto-Discovery
-
-The platform uses the **Wallet Standard** protocol, which automatically discovers any wallet extension the user has installed (Phantom, Solflare, Backpack, MetaMask Snap, etc.). No wallet adapters are explicitly imported or instantiated:
+`apps/web/src/lib/solana/wallet-provider.tsx` configures the external-wallet
+layer. It relies on the **Wallet Standard**, so the adapter array is empty:
 
 ```typescript
 const wallets = useMemo(() => [], []);
 ```
 
-This means:
+Any Wallet Standard-compliant extension the learner has installed is discovered
+automatically. No code changes when a new wallet ships.
 
-- Any Wallet Standard-compliant wallet works out of the box
-- No code changes are needed when new wallets are released
-- The wallet selection modal shows whatever wallets the user has installed
+Embedded wallets are a separate, optional layer: Dynamic, gated entirely on
+`NEXT_PUBLIC_DYNAMIC_ENVIRONMENT_ID`. Unset it and no provider mounts, no SDK
+loads, and no network call happens — SIWS with an external wallet stays the
+guaranteed way in. Read the flag only through
+`lib/dynamic/config.ts` (`isDynamicEnabled` / `getDynamicEnvironmentId`).
 
-### Network Configuration
+> `NEXT_PUBLIC_*` values are inlined at **build** time. Changing the Dynamic
+> environment id needs a redeploy with build cache **disabled** — a cache-reusing
+> redeploy silently keeps the old value baked into the served chunks.
 
-The RPC endpoint is configured via the `NEXT_PUBLIC_SOLANA_RPC_URL` environment variable. It defaults to Solana Devnet if not set:
+The RPC endpoint comes from `NEXT_PUBLIC_SOLANA_RPC_URL` and must carry no
+privileged key; the server-side `SOLANA_RPC_URL` is the one that may hold the
+Helius key. To move clusters, change both and set
+`NEXT_PUBLIC_SOLANA_NETWORK=mainnet-beta`.
 
-```typescript
-const endpoint = useMemo(
-  () => process.env.NEXT_PUBLIC_SOLANA_RPC_URL ?? clusterApiUrl("devnet"),
-  []
-);
-```
+## Adding a course
 
-To switch to mainnet, update the environment variable and set `NEXT_PUBLIC_SOLANA_NETWORK=mainnet-beta`.
+Course content is not in this repo. It lives in
+[`solanabr/academy-courses`](https://github.com/solanabr/academy-courses), is
+compiled by `pnpm --filter web compile-content` at the SHA pinned in
+`apps/web/content.lock`, and ships as a committed bundle.
+
+Adding or changing a course is therefore three steps, in order:
+
+1. Merge the content change in `academy-courses`. Its CI runs the content linter
+   (`packages/content-lint`), which is what certifies a tree as publishable.
+2. In this repo, bump `"sha"` in `apps/web/content.lock`, run
+   `pnpm --filter web compile-content`, and commit the lock **and** the
+   regenerated bundle together. CI byte-compares a fresh recompile against what
+   you committed, so a stale bundle or a hand-edit fails the build.
+3. Deploy it on-chain from `/admin` — a course stays invisible to learners until
+   its `onchain_deployments` row is `synced` and active. See
+   [ADMIN.md](./ADMIN.md).
+
+Never hand-edit `apps/web/src/content/generated/*`; an ESLint rule also bans
+importing it outside `src/lib/content/`.
 
 ## Extending the Gamification System
 

--- a/docs/DEPLOY-PROGRAM.md
+++ b/docs/DEPLOY-PROGRAM.md
@@ -1,482 +1,263 @@
-> Last synced: 2026-03-02
+> Last synced: 2026-08-24
 
-# Deploying Onchain Academy to Devnet
+# Deploying the program to devnet
 
-Each bounty applicant deploys their own program instance on devnet. This gives you full authority over the program — no shared keys, no waiting on others, and a clean environment to test your frontend against.
+Deploy your own instance of `onchain_academy` on devnet: full authority, no
+shared keys, a clean environment to test a frontend against.
 
-Architecture reference: [ARCHITECTURE.md](./ARCHITECTURE.md) (program specification + on-chain details)
+The program is **Pinocchio-only**. The Anchor implementation was deleted, along
+with `Anchor.toml` — there is no `anchor build`, no `anchor deploy`, and no
+`anchor account` in this runbook. You build with `cargo build-sbf` and deploy
+with `solana program deploy`.
 
-> **⚠️ The program is now Pinocchio-only (the Anchor build was retired).** The
-> canonical, current runbook is **[Pinocchio Runtime § Fresh devnet
-> instance](#fresh-devnet-instance-self-owned-id)** below — it builds with
-> `cargo build-sbf` and deploys with `solana program deploy`. The legacy §1–12
-> below still describe the old Anchor-CLI flow (`update-program-id.sh`,
-> `anchor deploy`, `anchor account`, editing `Anchor.toml`); those commands no
-> longer apply — `Anchor.toml` and the Anchor crate have been deleted. Read
-> §1–2, §6, §8–12 for context (keypairs, funding, initialize, verify), but take
-> the build/deploy steps (§3–5, §7) from the Fresh devnet instance runbook.
+Companion docs: [SPEC.md](./SPEC.md) is the authoritative program specification;
+[PINOCCHIO-MIGRATION.md](./PINOCCHIO-MIGRATION.md) explains what the port
+changed for clients; [ARCHITECTURE.md](./ARCHITECTURE.md) covers how the app
+uses it.
 
 ---
 
 ## Prerequisites
 
-| Tool       | Version |
-| ---------- | ------- |
-| Rust       | 1.82+   |
-| Solana CLI | 1.18+   |
-| Anchor CLI | 0.31+   |
-| Node.js    | 18+     |
-| pnpm       | any     |
-
-Verify:
+| Tool       | Version          | Note                                          |
+| ---------- | ---------------- | --------------------------------------------- |
+| Rust       | 1.89+            | Pinocchio 0.11.2 requires it                  |
+| Solana CLI | Agave 2.x or 3.x | Downloads platform-tools `v1.54` on demand    |
+| Node.js    | 20               | For the TypeScript helper scripts (`npx tsx`) |
+| pnpm       | 10               | Pinned by `packageManager` at the repo root   |
 
 ```bash
-rustc --version
-solana --version
-anchor --version
-node --version
+rustc --version && solana --version && node --version
 ```
+
+## Two program-id flavors
+
+The program id is baked in at compile time, so which artifact you deploy matters.
+
+| Build                        | Program id                                     | Use                                                                            |
+| ---------------------------- | ---------------------------------------------- | ------------------------------------------------------------------------------ |
+| `pnpm build:pinocchio`       | `7NeJaSRyb4Wxay3Tcd9bdpD7T3GWYUQSFyrhG8SgwE8V` | Default. The upstream id the IDL declares; what every parity gate runs against |
+| `pnpm build:pinocchio:fresh` | `Dsro2Cd9Mhgk8L71imh3LLPwYU5PU8hvBY5HEcPrcx5u` | `--features fresh-id`. The self-owned devnet instance — deploy this one        |
+
+A new id means new PDAs, so a fresh instance starts empty. Every client works
+unchanged apart from the id.
+
+Deploying the **default** artifact at the fresh id cannot corrupt anything: the
+baked-id self-check rejects every instruction with `DeclaredProgramIdMismatch`
+(4100). Seeing 4100 on devnet means you deployed the wrong artifact — rebuild
+and redeploy `…_fresh.so`. The reverse mix-up is impossible, since the
+fresh-flavor binary never carries the upstream id.
 
 ---
 
-## 1. Clone and Setup
+## 1. Keypairs
 
-```bash
-git clone https://github.com/solanabr/superteam-academy
-cd superteam-academy/onchain-academy
-pnpm install
-```
-
----
-
-## 2. Generate Keypairs
-
-Three keypairs are needed. All go in the `wallets/` directory at the repo root (gitignored).
+All keypairs live in `wallets/` (gitignored).
 
 ```bash
 mkdir -p wallets
-```
 
-**Authority/payer keypair** — your deployer wallet. Skip this step if you already have a Solana CLI wallet you want to use; copy it to `wallets/signer.json`.
-
-```bash
+# Deployer / authority. Skip if you already have a CLI wallet to use.
 solana-keygen new --outfile wallets/signer.json
-```
 
-**Program keypair** — determines the program ID. Use `grind` for a vanity address (optional) or `new` for a random one.
-
-```bash
-# Option A: random
+# Program keypair — determines the program id. `grind` for a vanity address.
 solana-keygen new --outfile wallets/program-keypair.json
 
-# Option B: vanity (takes time, skip on first deploy)
-solana-keygen grind --starts-with ACAD:1 --outfile wallets/program-keypair.json
-```
-
-**XP mint keypair** — determines the XP token mint address. This is passed as a signer to `initialize`, not a PDA.
-
-```bash
-# Option A: random
+# XP mint keypair — a signer to `initialize`, not a PDA.
 solana-keygen new --outfile wallets/xp-mint-keypair.json
-
-# Option B: vanity
-solana-keygen grind --starts-with XP:1 --outfile wallets/xp-mint-keypair.json
 ```
 
-Confirm all three exist:
+The already-provisioned fresh instance uses
+`onchain-academy/wallets/pinocchio-program-devnet-v2.json` and
+`onchain-academy/wallets/xp-mint-keypair.json` (both gitignored). Generating a
+genuinely new id means changing the baked constant in `src/consts.rs` and
+rebuilding, not just swapping the keypair file.
 
-```bash
-ls wallets/
-# signer.json  program-keypair.json  xp-mint-keypair.json
-```
+## 2. Fund the deployer
 
----
-
-## 3. Update Program ID
-
-Run the script from the repo root. It reads the pubkey from `wallets/program-keypair.json` and patches `declare_id!()` in `lib.rs` and the `onchain_academy` entry in `Anchor.toml`.
-
-```bash
-chmod +x scripts/update-program-id.sh
-./scripts/update-program-id.sh
-```
-
-The script uses `sed -i ''` (macOS syntax). On Linux, edit the script to use `sed -i` without the empty string:
-
-```bash
-# In scripts/update-program-id.sh, change:
-sed -i '' "s/..."
-# To:
-sed -i "s/..."
-```
-
-Verify the program ID was updated:
-
-```bash
-grep "declare_id" onchain-academy/programs/onchain-academy/src/lib.rs
-grep "onchain_academy" onchain-academy/Anchor.toml
-```
-
-Both should show the pubkey from `wallets/program-keypair.json`.
-
----
-
-## 4. Build
-
-```bash
-cd onchain-academy
-pnpm build:pinocchio
-```
-
-The committed IDL the clients load lives at:
-
-- `idl/onchain_academy.ts` — TypeScript types for your client
-- `idl/onchain_academy.json` — raw JSON IDL
-
-**If you get `edition2024` or dependency resolution errors**, pin these crates and rebuild:
-
-```bash
-cargo update -p blake3 --precise 1.7.0
-cargo update -p rmp --precise 0.8.14
-cargo update -p rmp-serde --precise 1.3.0
-pnpm build:pinocchio
-```
-
----
-
-## 5. Configure Devnet
-
-Edit `onchain-academy/Anchor.toml`. Change the cluster:
-
-```toml
-[provider]
-cluster = "devnet"
-wallet = "../wallets/signer.json"
-```
-
-Also update the programs table key. Change `[programs.localnet]` to `[programs.devnet]`:
-
-```toml
-[programs.devnet]
-onchain_academy = "<YOUR_PROGRAM_ID>"
-```
-
-Set Solana CLI to devnet:
+Deployment costs roughly 1.5–2 SOL for the ~213 KB binary, plus about 0.01 SOL
+of rent for `initialize`.
 
 ```bash
 solana config set --url devnet
-solana config set --keypair ../wallets/signer.json
+solana config set --keypair wallets/signer.json
+
+solana airdrop 2
+solana airdrop 2
+solana balance
 ```
 
----
+If the CLI airdrop is rate-limited, use <https://faucet.solana.com>.
 
-## 6. Fund Your Wallet
+## 3. Pre-flight gates
 
-You need 3-5 SOL for deployment and transactions.
+Both must be green before you spend devnet SOL:
 
 ```bash
-# Airdrop (limited to 2 SOL per request, run twice if needed)
-solana airdrop 2 wallets/signer.json
-solana airdrop 2 wallets/signer.json
+cd onchain-academy
 
-# Check balance
-solana balance ../wallets/signer.json
+pnpm build:pinocchio    # cargo build-sbf --tools-version v1.54
+pnpm test:layout        # host tests: byte/discriminator/CPI-wire parity
+pnpm test:integration   # LiteSVM: every instruction, happy and error paths
 ```
 
-If the CLI airdrop is rate-limited, connect Github and use the web faucet: https://faucet.solana.com
+`fresh_id_smoke.rs` inside the integration suite runs `initialize` in-SVM and
+byte-checks the resulting Config — a fresh-id deploy is proven before it touches
+devnet.
 
----
-
-## 7. Deploy
-
-Run from inside `onchain-academy/`:
+## 4. Build the deploy artifact
 
 ```bash
-anchor deploy --program-name onchain_academy --provider.cluster devnet --program-keypair ../wallets/program-keypair.json
-```
-
-On success you will see:
-
-```
-Program Id: <YOUR_PROGRAM_ID>
-Deploy success
-```
-
----
-
-## 8. Initialize the Program
-
-This is a one-time operation that:
-
-- Creates the `Config` PDA
-- Creates the XP mint (Token-2022, NonTransferable + PermanentDelegate, 0 decimals)
-- Auto-registers the authority as a `MinterRole` (label: "backend", unlimited cap)
-
-The deployer wallet becomes both `authority` and `backend_signer` — no separate backend key needed for devnet.
-
-Run `scripts/initialize.ts`:
-
-```bash
-export ANCHOR_PROVIDER_URL=https://api.devnet.solana.com \
-export ANCHOR_WALLET=../wallets/signer.json \
-npx ts-node scripts/initialize.ts
-```
-
-Note: `initialize` will fail with `already initialized` if run a second time — this is expected. The program enforces single initialization via the `config` PDA init constraint.
-
-Note on XP token metadata: The `initialize` instruction sets the `MetadataPointer` extension on the mint but defers actual metadata initialization to a separate client transaction. This is cosmetic — the mint works fully for XP minting without it. You can initialize metadata later when building the frontend.
-
----
-
-## 9. Create a Test Course
-
-```bash
-npx ts-node scripts/create-mock-course.ts
-```
-
-> **Mainnet caveat.** `create-mock-course.ts` uses a placeholder creator wallet
-> and default `trackId` / `trackLevel`. `Course.creator`, `track_id`, and
-> `track_level` are **immutable** after `create_course` (no `update_course`
-> setter; recoverable on devnet only via a full recreate, and NOT at all on
-> mainnet). Before any mainnet course creation, work the **instructor
-> credibility & track ladder** section of the Pre-Mainnet Checklist in the
-> `superteam-academy-dev` skill (`deployment.md`): real instructor wallets
-> confirmed per course, `trackId` / `trackLevel` finalized per owner decision
-> D-6, credibility display verified.
-
----
-
-## 10. Create Track Collection (optional — credential flow only)
-
-Required only if you are testing `issue_credential` or `upgrade_credential`. Metaplex Core is already deployed on devnet — no fixtures needed.
-
-```bash
-npx ts-node scripts/create-mock-track.ts
-```
-
-Store the collection address — it is required as an account in `issue_credential`.
-
----
-
-## 11. Verify Deployment
-
-```bash
-# Show program info
-solana program show <YOUR_PROGRAM_ID>
-
-# Fetch config account
-anchor account onchain_academy.Config <CONFIG_PDA> --provider.cluster devnet
-
-# Check XP mint
-spl-token display <XP_MINT_ADDRESS> --program-id TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb
-```
-
----
-
-## 12. Frontend Environment Variables
-
-Add these to your `.env.local`:
-
-```env
-# Public (safe to expose)
-NEXT_PUBLIC_PROGRAM_ID=<YOUR_PROGRAM_ID>
-NEXT_PUBLIC_XP_MINT_ADDRESS=<YOUR_XP_MINT_ADDRESS>
-NEXT_PUBLIC_SOLANA_NETWORK=devnet
-
-# Server-side only (never expose to client)
-BACKEND_SIGNER_SECRET=<BASE58_PRIVATE_KEY>
-PROGRAM_AUTHORITY_SECRET=<BASE58_PRIVATE_KEY>
-```
-
-For devnet, `BACKEND_SIGNER_SECRET` and `PROGRAM_AUTHORITY_SECRET` can be the same keypair (as base58). In production these are separate keys.
-
-To extract the base58 private key from a Solana keypair JSON file:
-
-```bash
-node -e "const k=require('./wallets/signer.json'); const bs58=require('bs58'); console.log(bs58.encode(Buffer.from(k)))"
-```
-
----
-
-## Quick Reference
-
-See [Pinocchio Runtime § Fresh devnet instance](#fresh-devnet-instance-self-owned-id)
-for the full, live deploy runbook. In short:
-
-```bash
-# Build the deploy artifact (run from onchain-academy/)
+cd onchain-academy
 pnpm build:pinocchio:fresh
-
-# Deploy under your own wallet (fee payer + upgrade authority default to
-# ~/.config/solana/id.json)
-solana program deploy target/deploy/onchain_academy_pinocchio_fresh.so \
-  --program-id wallets/pinocchio-program-devnet.json --url devnet
-
-# Initialize
-ANCHOR_PROVIDER_URL=https://api.devnet.solana.com \
-ANCHOR_WALLET=~/.config/solana/id.json \
-npx ts-node scripts/initialize.ts
-
-# Verify
-solana program show <PROGRAM_ID>
 ```
 
----
+`scripts/build-pinocchio-deploy.sh` gates on `cargo test --features fresh-id`
+first, emits `target/deploy/onchain_academy_pinocchio_fresh.so`, and restores the
+default artifact afterwards.
 
-## Troubleshooting
+> **`edition2024` or dependency-resolution errors**: pin the offending crates and
+> rebuild.
+>
+> ```bash
+> cargo update -p blake3 --precise 1.7.0
+> cargo update -p rmp --precise 0.8.14
+> cargo update -p rmp-serde --precise 1.3.0
+> ```
 
-**`edition2024` or `rmp-serde` build errors**
-
-Rust edition 2024 resolver conflicts. Pin the affected crates:
-
-```bash
-cargo update -p blake3 --precise 1.7.0
-cargo update -p rmp --precise 0.8.14
-cargo update -p rmp-serde --precise 1.3.0
-pnpm build:pinocchio
-```
-
-**`sed: illegal option` on Linux**
-
-The `update-program-id.sh` script uses macOS `sed -i ''` syntax. On Linux, edit the two `sed` lines in the script to remove the empty string argument:
+## 5. Deploy
 
 ```bash
-# macOS (default in repo)
-sed -i '' "s/..."
-
-# Linux
-sed -i "s/..."
-```
-
-**`Error: Account already in use` / "already initialized"**
-
-The Config PDA already exists at this program ID. Either you already initialized successfully, or there is a key collision. Check the Config PDA on-chain:
-
-```bash
-solana account $(solana-keygen pubkey wallets/signer.json) --url devnet
-```
-
-If you want a fresh deployment, generate a new program keypair and redeploy.
-
-**Insufficient SOL**
-
-Deployment costs roughly 2-3 SOL. `initialize` costs an additional ~0.01 SOL for rent. Use https://faucet.solana.com if the CLI airdrop is rate-limited.
-
-**`solana program deploy` fails mid-way (buffer account left behind)**
-
-A failed deploy can leave a funded intermediate buffer account. Reclaim its
-rent and retry:
-
-```bash
-solana program close --buffers --url devnet --keypair wallets/signer.json
-```
-
----
-
-## Pinocchio Runtime
-
-The program is built with Pinocchio
-(`onchain-academy/programs/onchain-academy-pinocchio`) — see
-[SPEC.md](./SPEC.md) and [ANCHOR-VS-PINOCCHIO.md](./ANCHOR-VS-PINOCCHIO.md).
-The live deploy path is a **fresh devnet instance** under a self-owned program
-id (built with `--features fresh-id`): a clean sandbox for end-to-end testing.
-Runbook below.
-
-### Build
-
-```bash
-cd onchain-academy
-pnpm build:pinocchio
-# = cargo build-sbf --manifest-path programs/onchain-academy-pinocchio/Cargo.toml --tools-version v1.54
-```
-
-Pinocchio 0.11.2 requires rustc >= 1.89, hence the pinned platform-tools
-`v1.54` (any Agave 2.x/3.x CLI downloads it on demand). Artifact:
-`target/deploy/onchain_academy_pinocchio.so`.
-
-The default build bakes the upstream program id. `pnpm build:pinocchio:fresh`
-(`scripts/build-pinocchio-deploy.sh`) additionally produces
-`target/deploy/onchain_academy_pinocchio_fresh.so` with the self-owned
-instance id baked in (`--features fresh-id`), gating the id/PDA consts with
-`cargo test --features fresh-id` first and restoring the default artifact
-afterwards.
-
-> Trident and the CU harness load `target/deploy/onchain_academy.so`;
-> `bash scripts/select-program.sh` installs the pinocchio build into that slot
-> (and prints the SHA-256). For devnet deploys use the explicit
-> `solana program deploy` below.
-
-### Pre-flight gates
-
-Both must be green before a deploy:
-
-```bash
-cd onchain-academy
-pnpm build:pinocchio   # cargo build-sbf --tools-version v1.54
-pnpm test:layout       # byte/discriminator/CPI-wire parity
-pnpm test:integration  # single-LiteSVM: all instructions, happy + error paths
-pnpm cu:compare        # regenerates tests/CU_COMPARISON.md (local; needs RAM)
-```
-
-### Fresh devnet instance (self-owned id)
-
-End-to-end testing without the upstream upgrade authority: deploy the
-pinocchio build at its own program id, with your own wallet as both
-`authority` and `backend_signer`. A new id means new PDAs — the instance
-starts empty (no upstream courses carry over); the IDL and all clients work
-unchanged apart from the id.
-
-Identity baked at compile time by `--features fresh-id`, verified by the
-`config_pda_consts` host test and `tests/differential/tests/fresh_id_smoke.rs`
-(in-SVM initialize + byte-checked Config before any devnet SOL is spent):
-
-| What                  | Value                                                                                                                |
-| --------------------- | -------------------------------------------------------------------------------------------------------------------- |
-| Program id            | `Dsro2Cd9Mhgk8L71imh3LLPwYU5PU8hvBY5HEcPrcx5u`                                                                       |
-| Program keypair       | `onchain-academy/wallets/pinocchio-program-devnet-v2.json` (gitignored)                                              |
-| Config PDA (bump 254) | `E9GVGKbyoWNSf9B1iR8gNVecwDwqnzNbUxcBzVCVSXan`                                                                       |
-| XP mint               | `BUk5izZcRompFe2da1yv9BLcMLBEEyg7JCvS8nQYoHHd` (keypair: `onchain-academy/wallets/xp-mint-keypair.json`, gitignored) |
-
-```bash
-cd onchain-academy
-
-# 1. Build the deploy artifact. (The TS helper scripts load the committed IDL
-#    at onchain-academy/idl/ — no extra build step needed.)
-pnpm build:pinocchio:fresh
-
-# 2. Deploy under your own wallet — fee payer + upgrade authority default to
-#    ~/.config/solana/id.json. Rent for the ~200 KB binary is ~1.5 SOL.
 solana program deploy target/deploy/onchain_academy_pinocchio_fresh.so \
   --program-id wallets/pinocchio-program-devnet-v2.json \
   --url devnet
-
-# 3. Initialize: creates Config + the Token-2022 XP mint (from
-#    wallets/xp-mint-keypair.json) + your backend MinterRole.
-#    The public endpoint rate-limits aggressively — any provider URL works
-#    here (e.g. Helius devnet with your key).
-export ACADEMY_PROGRAM_ID=Dsro2Cd9Mhgk8L71imh3LLPwYU5PU8hvBY5HEcPrcx5u
-export ANCHOR_PROVIDER_URL=https://api.devnet.solana.com
-export ANCHOR_WALLET=~/.config/solana/id.json
-# scripts/initialize.ts reads ../wallets/xp-mint-keypair.json relative to CWD —
-# run it from onchain-academy/scripts/. (No ts-node in deps; tsx works.)
-(cd scripts && npx tsx initialize.ts)
-
-# 4. E2E canary — every scripts/*.ts helper honors ACADEMY_PROGRAM_ID:
-npx tsx scripts/create-mock-course.ts
-npx tsx scripts/e2e-flow.ts   # enroll → lessons → finalize → close
-npx tsx scripts/check-xp.ts
-# Credential leg: create a track collection first (§10,
-# create-mock-track.ts) and pass it to e2e-flow.ts / issue-credential.ts.
-
-# 5. Verify
-solana program show Dsro2Cd9Mhgk8L71imh3LLPwYU5PU8hvBY5HEcPrcx5u --url devnet
 ```
 
-Deploying the DEFAULT-flavor `.so` at this id cannot corrupt anything: the
-baked-id self-check rejects every instruction with
-`DeclaredProgramIdMismatch` (4100) — proven in `fresh_id_smoke.rs`. Seeing
-4100 on devnet means the wrong artifact; redeploy `…_fresh.so`. The reverse
-mix-up is impossible (the fresh-flavor binary never holds the upstream id).
+Fee payer and upgrade authority default to `~/.config/solana/id.json`.
 
-Frontend against the fresh instance: point `NEXT_PUBLIC_PROGRAM_ID` and
-`NEXT_PUBLIC_XP_MINT_ADDRESS` (§12) at the table values above.
+> **Use a dedicated RPC, not the public devnet endpoint.** A ~213 KB program
+> deploy is hundreds of sequential write transactions, and the public endpoint
+> rate-limits aggressively enough to fail one part-way through. Pass a provider
+> URL (Helius devnet with your key, for example) to `--url`.
+>
+> If a deploy does fail part-way it leaves a funded buffer account behind.
+> Reclaim the rent before retrying:
+>
+> ```bash
+> solana program close --buffers --url devnet --keypair wallets/signer.json
+> ```
+
+## 6. Initialize
+
+One-time. It creates the Config PDA, creates the XP mint (Token-2022,
+NonTransferable + PermanentDelegate + MetadataPointer, 0 decimals), and
+auto-registers the authority as a `MinterRole` labelled `backend` with an
+unlimited cap. On devnet the deployer is both `authority` and `backend_signer`.
+
+`scripts/initialize.ts` reads `../wallets/xp-mint-keypair.json` relative to the
+working directory, so run it from `scripts/`. There is no `ts-node` in the
+dependency tree — use `tsx`.
+
+```bash
+cd onchain-academy
+
+export ACADEMY_PROGRAM_ID=Dsro2Cd9Mhgk8L71imh3LLPwYU5PU8hvBY5HEcPrcx5u
+export ANCHOR_PROVIDER_URL=<your devnet RPC>
+export ANCHOR_WALLET=~/.config/solana/id.json
+
+(cd scripts && npx tsx initialize.ts)
+```
+
+A second run fails with "already initialized" — expected. The Config PDA's init
+constraint enforces single initialization.
+
+Token metadata is deferred: `initialize` sets the MetadataPointer extension but
+leaves the TokenMetadata initialization to a separate client transaction (an
+Agave 3.0 CPI-realloc restriction). This is cosmetic — the mint works fully for
+XP without it.
+
+## 7. Smoke-test end to end
+
+Every `scripts/*.ts` helper honours `ACADEMY_PROGRAM_ID`.
+
+```bash
+npx tsx scripts/create-mock-course.ts
+npx tsx scripts/e2e-flow.ts        # enroll → lessons → finalize → close
+npx tsx scripts/check-xp.ts
+```
+
+For the credential leg, create a track collection first
+(`scripts/create-mock-track.ts`) and pass it to `e2e-flow.ts` /
+`issue-credential.ts`. Metaplex Core is already live on devnet — no fixtures
+needed.
+
+> **Before any mainnet course creation.** `create-mock-course.ts` uses a
+> placeholder creator wallet and default `trackId` / `trackLevel`.
+> `Course.creator`, `track_id`, and `track_level` are **immutable** after
+> `create_course` — there is no `update_course` setter, recovery on devnet needs
+> a full recreate, and there is no recovery at all on mainnet. Confirm real
+> instructor wallets and the finalized track ladder first.
+
+## 8. Verify
+
+```bash
+solana program show $ACADEMY_PROGRAM_ID --url devnet
+
+npx tsx scripts/fetch-config.ts
+
+spl-token display <XP_MINT_ADDRESS> \
+  --program-id TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb
+```
+
+The live fresh instance, for comparison:
+
+| What        | Value                                                     |
+| ----------- | --------------------------------------------------------- |
+| Program id  | `Dsro2Cd9Mhgk8L71imh3LLPwYU5PU8hvBY5HEcPrcx5u`            |
+| Config PDA  | `E9GVGKbyoWNSf9B1iR8gNVecwDwqnzNbUxcBzVCVSXan` (bump 254) |
+| XP mint     | `BUk5izZcRompFe2da1yv9BLcMLBEEyg7JCvS8nQYoHHd`            |
+| Binary size | 213,024 bytes                                             |
+
+## 9. Point the frontend at it
+
+```env
+NEXT_PUBLIC_PROGRAM_ID=<your program id>
+NEXT_PUBLIC_XP_MINT_ADDRESS=<xp mint from the initialize output>
+NEXT_PUBLIC_SOLANA_NETWORK=devnet
+
+PROGRAM_AUTHORITY_SECRET=<JSON array of 64 keypair bytes>
+BACKEND_SIGNER_SECRET=<JSON array of 64 keypair bytes>
+```
+
+On devnet the two secrets can be the same keypair; in production they are
+separate keys. Both are **JSON byte arrays**, the same format
+`solana-keygen` writes — not base58 strings. `getProgramId()` throws when
+`NEXT_PUBLIC_PROGRAM_ID` is unset rather than silently defaulting.
+
+The full annotated env list is the `## Environment Variables` block in
+[`apps/web/CLAUDE.md`](../apps/web/CLAUDE.md).
+
+---
+
+## Reproducible builds
+
+`.github/workflows/ci.yml` runs a `verifiable-build` job and a `publish-hash`
+job that writes the SHA-256 of the toolchain-reproducible build to a dedicated
+`program-hash` branch on every change. [PROGRAM-HASH.md](./PROGRAM-HASH.md) is
+the human-readable spec and entry point; it is deliberately not CI-updated on
+`main`, because branch protection forbids the bot from pushing there.
+
+Trident and the CU harness load `target/deploy/onchain_academy.so`;
+`bash scripts/select-program.sh` installs the Pinocchio build into that slot and
+prints its SHA-256. Devnet deploys use the explicit `solana program deploy` path
+above instead.
+
+## Troubleshooting
+
+| Symptom                                        | Cause                                                                             |
+| ---------------------------------------------- | --------------------------------------------------------------------------------- |
+| `DeclaredProgramIdMismatch` (4100)             | Wrong artifact for this id. Rebuild with `build:pinocchio:fresh` and redeploy.    |
+| `Account already in use` / already initialized | The Config PDA exists. You already initialized, or you are reusing a live id.     |
+| Deploy stalls or fails part-way                | Public RPC rate limit. Use a provider URL, then `solana program close --buffers`. |
+| `edition2024` / `rmp-serde` build errors       | Edition-2024 resolver conflict. Pin the crates as shown in §4.                    |
+| Insufficient SOL                               | Budget ~2 SOL for the deploy plus rent. Airdrop twice or use the web faucet.      |

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -164,7 +164,7 @@ Subsequent pushes to `main` trigger automatic deployments. Pull requests get pre
    ```bash
    supabase db push
    ```
-   This runs all 62 files in `supabase/migrations/` in order, creating the 36
+   This runs all 60 files in `supabase/migrations/` in order, creating the 36
    tables, RLS policies, indexes, SECURITY DEFINER functions, and views. The
    table inventory and the access model are in
    [ARCHITECTURE.md § Database](./ARCHITECTURE.md#7-database).

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,4 +1,4 @@
-> Last synced: 2026-07-12
+> Last synced: 2026-08-24
 
 # Deployment Guide
 
@@ -51,49 +51,56 @@ compiled from the `solanabr/academy-courses` git repo — see
 
 Add all environment variables in **Vercel → Project → Settings → Environment Variables**.
 
-#### Required Variables
+> **The authoritative list is the `## Environment Variables` block in
+> [`apps/web/CLAUDE.md`](../apps/web/CLAUDE.md)** — every variable, what it does,
+> and what happens when it is unset. `.env.example` is the copyable template.
+> This section covers only what is specific to deploying, and does not repeat the
+> full list.
 
 Validated eagerly at boot (`lib/env.ts` for public, `lib/env.server.ts` for
 server-only, both wired through `instrumentation.ts`). A missing **required** var
 fails the boot loudly rather than degrading silently.
 
-| Variable                        | Type            | Notes                                                                                                                                                                                                                                                            |
-| ------------------------------- | --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `NEXT_PUBLIC_SUPABASE_URL`      | Public          | Bundled into client JS                                                                                                                                                                                                                                           |
-| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | Public          | Bundled into client JS                                                                                                                                                                                                                                           |
-| `SUPABASE_SERVICE_ROLE_KEY`     | **Server-only** | Never exposed to browser                                                                                                                                                                                                                                         |
-| `NEXT_PUBLIC_SOLANA_RPC_URL`    | Public          | Browser RPC. Must carry **no** privileged key (e.g. `https://api.devnet.solana.com`)                                                                                                                                                                             |
-| `SOLANA_RPC_URL`                | **Server-only** | Server RPC — **this** is the one that may carry the Helius key. Required at boot so a misconfig fails loudly instead of falling back to public devnet                                                                                                            |
-| `NEXT_PUBLIC_SOLANA_NETWORK`    | Public          | `devnet`                                                                                                                                                                                                                                                         |
-| `NEXT_PUBLIC_APP_URL`           | Public          | Your Vercel URL (e.g., `https://superteam-academy-web.vercel.app`)                                                                                                                                                                                               |
-| `NEXT_PUBLIC_PROGRAM_ID`        | Public          | Program ID from `solana program deploy` (see [DEPLOY-PROGRAM.md](./DEPLOY-PROGRAM.md))                                                                                                                                                                           |
-| `NEXT_PUBLIC_XP_MINT_ADDRESS`   | Public          | XP mint pubkey from the `initialize` output                                                                                                                                                                                                                      |
-| `BUILD_SERVER_URL`              | **Server-only** | Cloud Run service URL (e.g., `https://academy-build-server-HASH.a.run.app`)                                                                                                                                                                                      |
-| `BUILD_SERVER_API_KEY`          | **Server-only** | Same value as `ACADEMY_API_KEY` on Cloud Run                                                                                                                                                                                                                     |
-| `HELIUS_API_KEY`                | **Server-only** | Helius key for webhook management — the registration/list calls live in the operator tool `scripts/helius-webhook-config.ts`, run by hand; the app itself only verifies inbound deliveries                                                                       |
-| `PROGRAM_AUTHORITY_SECRET`      | **Server-only** | The `Config.authority` keypair (JSON array of 64 bytes) — required for admin on-chain deployments                                                                                                                                                                |
-| `BACKEND_SIGNER_SECRET`         | **Server-only** | The keypair registered in `Config.backend_signer` — signs lesson completion / finalize / credential transactions                                                                                                                                                 |
-| `ADMIN_SECRET`                  | **Server-only** | Admin console password **and** the HMAC key signing the `admin_session` cookie (min 32 chars). Required to access `/{locale}/admin`                                                                                                                              |
-| `HELIUS_WEBHOOK_SECRET`         | **Server-only** | Shared secret for Helius webhook signature verification (`/api/webhooks/helius`)                                                                                                                                                                                 |
-| `XP_MINT_AUTHORITY_SECRET`      | **Server-only** | XP mint authority keypair — required for the wallet link/unlink XP transfers                                                                                                                                                                                     |
-| `GITHUB_TOKEN`                  | **Server-only** | Fine-grained **read** token for `solanabr/academy-courses`. Powers the admin **Publish** screen (HEAD polling + CI checks). Optional at boot, but the admin content routes 503 without it. **Read scope only — no route in the app holds a GitHub write token.** |
+Two things to know before you paste anything in:
 
-#### Optional Variables
+- **`NEXT_PUBLIC_*` is inlined at build time.** Changing one requires a redeploy
+  with "Use existing Build Cache" **disabled** — a cache-reusing redeploy keeps
+  the old value baked into the served chunks while the dashboard shows the new
+  one. That exact trap has caused a live incident. Verify by grepping the served
+  `/_next/static` chunks, not the dashboard.
+- **`ADMIN_SECRET` is retired** and can be deleted. Admin access is a Supabase
+  session checked against the `admin_users` table; there is no admin password.
 
-| Variable                         | Type            | Notes                                                                                                                                                                                                                                                                |
-| -------------------------------- | --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `GEMINI_API_KEY`                 | **Server-only** | Gemini key for the AI lesson assistant (`/api/ai/*`). Omit to disable the assistant.                                                                                                                                                                                 |
-| `AI_PARTNER_SEAL_SECRET`         | **Server-only** | Dedicated key for sealing the comprehension-check token. If unset, derived from `SUPABASE_SERVICE_ROLE_KEY`.                                                                                                                                                         |
-| `ARWEAVE_UPLOADER_SECRET`        | **Server-only** | Funds Irys uploads that pin credential metadata to Arweave at mint. A **Solana** keypair (JSON array of 64 bytes), not an Arweave JWK. Unset → mint falls back to `/api/certificates/metadata`. Required (funded on mainnet-beta) for permanent mainnet credentials. |
-| `MODERATION_WEBHOOK_URL`         | **Server-only** | Slack/Discord-compatible incoming webhook. When set, the first flag on a community post pings it. Unset → no notification (the `/admin/moderation` queue still fills).                                                                                               |
-| `RUST_PLAYGROUND_URL`            | **Server-only** | `/api/rust/execute` upstream (default: play.rust-lang.org)                                                                                                                                                                                                           |
-| `RESEND_API_KEY`                 | **Server-only** | Resend key for outbound email (announcements #769, session-plan reminders #869). The mail pipeline is **fail-closed**: unset ⇒ nothing is ever sent. Set only once a Resend sending domain (DKIM/SPF/DMARC) is verified.                                             |
-| `EMAIL_FROM`                     | **Server-only** | Verified From identity, e.g. `Superteam Academy <news@st.academy>`. Unset → `DEFAULT_EMAIL_FROM` in `lib/email/resend.ts`.                                                                                                                                           |
-| `CRON_SECRET`                    | **Server-only** | Shared secret for Vercel Cron (#869). Vercel sends it as `Authorization: Bearer $CRON_SECRET` to every `/api/cron/*` route. **Unset ⇒ the cron route 503s and no reminder is sent** — an unauthenticated mail trigger must never be reachable.                       |
-| `NEXT_PUBLIC_GA4_MEASUREMENT_ID` | Public          | Google Analytics 4                                                                                                                                                                                                                                                   |
-| `NEXT_PUBLIC_POSTHOG_KEY`        | Public          | PostHog project key                                                                                                                                                                                                                                                  |
-| `NEXT_PUBLIC_POSTHOG_HOST`       | Public          | PostHog instance URL                                                                                                                                                                                                                                                 |
-| `NEXT_PUBLIC_SENTRY_DSN`         | Public          | Sentry error tracking (DSN is safe to expose)                                                                                                                                                                                                                        |
+#### The ones that gate a deploy
+
+Required at boot — the build or the first request fails without them:
+
+| Variable                        | Type            | Notes                                                                                                                                   |
+| ------------------------------- | --------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `NEXT_PUBLIC_SUPABASE_URL`      | Public          | Bundled into client JS                                                                                                                  |
+| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | Public          | Bundled into client JS                                                                                                                  |
+| `SUPABASE_SERVICE_ROLE_KEY`     | **Server-only** | Never exposed to the browser. Also gates admin auth — without it every admin check fails closed                                         |
+| `NEXT_PUBLIC_SOLANA_RPC_URL`    | Public          | Browser RPC. Must carry **no** privileged key                                                                                           |
+| `SOLANA_RPC_URL`                | **Server-only** | Server RPC — **this** is the one that may carry the Helius key. Required so a misconfig fails loudly instead of hitting public devnet   |
+| `NEXT_PUBLIC_APP_URL`           | Public          | A **production** build with this unset fails at boot. An empty value would pin a relative metadata URI into an immutable credential NFT |
+
+#### Feature-gated
+
+Everything else switches a feature on or off. Unset means the feature is off,
+and every one of them degrades deliberately rather than crashing:
+
+| Set these for…           | Variables                                                                                                                                                              |
+| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| On-chain features        | `NEXT_PUBLIC_PROGRAM_ID`, `NEXT_PUBLIC_XP_MINT_ADDRESS`, `NEXT_PUBLIC_SOLANA_NETWORK`, `PROGRAM_AUTHORITY_SECRET`, `BACKEND_SIGNER_SECRET`, `XP_MINT_AUTHORITY_SECRET` |
+| Helius event ingestion   | `HELIUS_API_KEY`, `HELIUS_WEBHOOK_SECRET`                                                                                                                              |
+| The admin publish card   | `GITHUB_TOKEN` (**read scope only** — no route holds a write token; unset ⇒ 503 on that card alone)                                                                    |
+| Rust builds and deploys  | `BUILD_SERVER_URL`, `BUILD_SERVER_API_KEY`, `RUST_PLAYGROUND_URL`                                                                                                      |
+| The AI lesson assistant  | `GEMINI_API_KEY`, `AI_PARTNER_SEAL_SECRET`, the `AI_SPEND_*` caps, the `AI_MODEL_*` overrides                                                                          |
+| Embedded wallets         | `NEXT_PUBLIC_DYNAMIC_ENVIRONMENT_ID` (see the build-cache warning above)                                                                                               |
+| Permanent credentials    | `ARWEAVE_UPLOADER_SECRET` — a **Solana** keypair funding Irys, not an Arweave JWK. Unset ⇒ mint falls back to `/api/certificates/metadata`                             |
+| Outbound email + cron    | `RESEND_API_KEY`, `EMAIL_FROM`, `CRON_SECRET` — all **fail-closed**: unset means nothing is ever sent                                                                  |
+| Moderation notifications | `MODERATION_WEBHOOK_URL` (the queue still fills without it)                                                                                                            |
+| Analytics                | `NEXT_PUBLIC_GA4_MEASUREMENT_ID`, `NEXT_PUBLIC_POSTHOG_KEY`, `NEXT_PUBLIC_POSTHOG_HOST`, `NEXT_PUBLIC_SENTRY_DSN`                                                      |
 
 > **Tip**: Variables prefixed with `NEXT_PUBLIC_` are bundled into the client-side JavaScript bundle. All others are server-only and only accessible in API routes and server components.
 
@@ -157,38 +164,25 @@ Subsequent pushes to `main` trigger automatic deployments. Pull requests get pre
    ```bash
    supabase db push
    ```
-   This runs every file in `supabase/migrations/` in order, creating all 21 tables, RLS policies, indexes, SECURITY DEFINER functions, and views.
+   This runs all 62 files in `supabase/migrations/` in order, creating the 36
+   tables, RLS policies, indexes, SECURITY DEFINER functions, and views. The
+   table inventory and the access model are in
+   [ARCHITECTURE.md § Database](./ARCHITECTURE.md#7-database).
 
-> **Migrations are the source of truth.** `supabase/schema.sql` is a generated snapshot (via `supabase db dump`) kept for reference and diffing — do **not** run or hand-edit it. Ship schema changes as new migrations: `supabase migration new <name>`, then `supabase db push`.
+> **Migrations are the source of truth.** `supabase/schema.sql` is a generated
+> snapshot kept for reference and diffing — do **not** run or hand-edit it. It is
+> also currently **stale**: `admin_users`, `onchain_deployments`, and
+> `platform_freeze` exist only in the migrations. Ship schema changes as new
+> migrations (`supabase migration new <name>`, then `supabase db push`).
 
-The schema includes:
+> **Read [DB-MIGRATION-LEDGER.md](./DB-MIGRATION-LEDGER.md) before any
+> `supabase db push` or `migration list` against production.** Migrations applied
+> through the Supabase MCP carry an MCP-stamped version that diverges from the
+> repo filename, so the CLI considers them unapplied.
 
-| Table                     | Purpose                                                          |
-| ------------------------- | ---------------------------------------------------------------- |
-| `profiles`                | User profiles (wallet, email)                                    |
-| `enrollments`             | Course enrollments                                               |
-| `user_progress`           | Lesson completion tracking                                       |
-| `user_xp`                 | Total XP per user                                                |
-| `xp_transactions`         | XP change log                                                    |
-| `user_achievements`       | Unlocked achievements                                            |
-| `certificates`            | NFT certificate records                                          |
-| `siws_nonces`             | SIWS replay protection                                           |
-| `nft_metadata`            | NFT metadata storage                                             |
-| `deployed_programs`       | **Learner** practice program deployments                         |
-| `onchain_deployments`     | **Platform** content → chain state (the learner-visibility gate) |
-| `pending_onchain_actions` | On-chain retry queue                                             |
-| `user_daily_quests`       | Daily quest progress tracking                                    |
-| `challenge_assists`       | Per-user AI-assist budget for challenges                         |
-| `forum_categories`        | Community forum sections                                         |
-| `threads`                 | Community discussion threads                                     |
-| `answers`                 | Thread replies                                                   |
-| `votes`                   | Upvotes/downvotes                                                |
-| `flags`                   | Content moderation flags                                         |
-| `thread_views`            | Per-user thread view dedup                                       |
-| `rate_limits`             | Cross-instance API rate limiter                                  |
-
-Plus three views: `community_stats`, `public_user_xp`, and
-`public_onchain_deployments`.
+Grant yourself admin access by inserting your `auth.users` id into
+`admin_users` — that table is the entire admin authorization model, and it starts
+empty.
 
 > **`onchain_deployments` is load-bearing for content visibility.** It is the
 > post-SP2 home of the on-chain sync status that gates which courses learners can
@@ -399,7 +393,13 @@ Google OAuth lets users sign in without a wallet. It requires configuration in b
 
 Google OAuth runs through Supabase Auth — enter the **Client ID** and **Client Secret** in the Supabase dashboard (**Authentication → Providers → Google**), not in the app's environment. The app has no `NEXT_PUBLIC_GOOGLE_CLIENT_ID`.
 
-> **Note**: The `profiles` table has a `github_id` column in the schema for future GitHub OAuth, but it is not currently implemented in the app.
+GitHub OAuth works the same way — enable the GitHub provider in Supabase and add
+the callback URL to your GitHub OAuth app.
+
+> **When Dynamic is configured, it owns the Google and GitHub handshakes** and
+> the Supabase providers become the fallback path. Configure both anyway: SIWS
+> and Supabase OAuth are the kill switch if Dynamic is unavailable. See
+> [AUTH-FLOWS.md](./AUTH-FLOWS.md).
 
 ---
 
@@ -624,8 +624,10 @@ After deploying, verify:
 - [ ] Landing page loads without errors
 - [ ] Courses display correctly (served from the committed bundle; a course only
       appears once its `onchain_deployments` row is `synced` + active)
-- [ ] Wallet connect works (Phantom, Solflare, Backpack)
-- [ ] Google OAuth works (if configured)
+- [ ] SIWS works with an external wallet (the guaranteed path — test this one
+      even if Dynamic is configured)
+- [ ] Google / GitHub sign-in works, through whichever rail is live
+- [ ] `/admin` 404s for a non-allowlisted account and loads for an allowlisted one
 - [ ] Completing a lesson awards XP
 - [ ] Leaderboard shows correct rankings
 - [ ] NFT certificate minting works on Devnet


### PR DESCRIPTION
Audited the README and every doc under `docs/` against the actual code, then rewrote the six that had drifted. Net −990 lines: most of the reduction is deleted false content (a full Anchor deploy runbook for a Pinocchio-only program) and env-var tables that duplicated `apps/web/CLAUDE.md`, which the docs now point at instead of re-listing. Every technical claim traces to code I read; where I could not verify something I left it out rather than guessing.

## Worst drift, per doc

**README** — Next.js 14 badge, Anchor 0.31 badge, pnpm 9, `ADMIN_SECRET` login instructions, Phantom/Solflare/Backpack as the auth story with no mention of Dynamic embedded wallets.

**ARCHITECTURE** — 21 tables (36), 44 routes (72), Next 14, `UNLOCK_CHECKS` in the completion flow (that map does not exist), a duplicated and stale SIWS/OAuth section, `ADMIN_SECRET` as the admin auth model. Missing entirely: the Helius webhook credit path, the `after()`-drained retry queue, leagues/referrals/review/AI-spend/email, the reserve-then-send `reward_xp` pattern.

**DEPLOY-PROGRAM** — the worst of them. Twelve sections of Anchor CLI flow (`anchor deploy`, `anchor account`, editing `Anchor.toml`) behind a banner telling you to ignore half of them. `Anchor.toml` and the Anchor crate were deleted. Rewritten around the Pinocchio runbook, with the two program-id flavors made explicit.

**CUSTOMIZATION** — synced 2026-03-02 and never updated. Documented a deep-teal `#0d9488` palette and a `.dark` class; both wrong (Solarium v9, forest emerald `#0a7055` / mint `#2ecc8e`, `[data-theme="dark"]`), so the rebranding instructions did not work. Also 21 i18n namespaces against 31.

**ADMIN** — screens were right, auth model was not: `ADMIN_SECRET` + HMAC cookie, retired in favour of the Supabase session + `admin_users` allowlist with 404-on-non-admin. Added the two unlisted capabilities (platform freeze, destructive course recreate).

**DEPLOYMENT** — 21 tables, `ADMIN_SECRET` as required, and a note claiming GitHub OAuth "is not currently implemented" when it is.

## Verified as still true

18 instructions / 6 PDA types (the brief flagged these for re-check — they hold). Level curve, `XP_REWARDS`, streak logic, the content-bundle pipeline, the visibility gate, and the slot/lockfile rules were all accurate and are kept.

## Deliberately left alone

`DB-MIGRATION-LEDGER.md` and `docs/superpowers/specs/*` per the brief. `ANCHOR-VS-PINOCCHIO.md`, `AUDIT-REPORT.md`, `PRE-DEPLOY-AUDIT.md`, `CU-BUDGET-REVIEW.md`, `HANDOFF-LOOP-2026-07-25.md`, `SECRET-ROTATION.md`, `TASK-CODES.md`, `PROGRAM-HASH.md` — dated records or already-banner'd historical docs. `SPEC.md`, `AUTH-FLOWS.md`, `PINOCCHIO-MIGRATION.md`, `STAGING.md`, `CONTENT-ORIGINALITY.md` are current; ARCHITECTURE now defers to the first two rather than duplicating them. Nothing was deleted.

`LAUNCH-READINESS.md` and `AUTONOMOUS-ISSUE-LOOP.md` were in the brief but do not exist in the repo — nothing to banner.

## Loose ends this surfaced (not fixed here)

- `scripts/init-program.ts` still reads the retired `ADMIN_SECRET` as a bearer token, so it is broken against the current admin routes.
- `supabase/schema.sql` is missing `admin_users`, `onchain_deployments`, and `platform_freeze` — regenerate the snapshot.
- The web IDL `superteam_academy_vnext.json` is missing errors 6035/6036 that the program declares.

Both docs now carry a `Last synced` line, and prettier is clean.