### PR TITLE
chore(program): allow the new 1.98 clippy chunks lint

### DIFF
--- a/onchain-academy/programs/onchain-academy-pinocchio/src/instructions/update_course.rs
+++ b/onchain-academy/programs/onchain-academy-pinocchio/src/instructions/update_course.rs
@@ -74,6 +74,10 @@ pub fn process(accounts: &mut [AccountView], data: &[u8]) -> ProgramResult {
         }
         if let Some(bytes) = new_active_lessons {
             let mut mask = [0u64; 4];
+            // Rust 1.98 clippy suggests as_chunks; keeping chunks_exact — an
+            // iteration-style rewrite in deployed program code buys nothing and
+            // risks perturbing the verifiable build.
+            #[allow(unknown_lints, clippy::chunks_exact_to_as_chunks)]
             for (w, chunk) in bytes.chunks_exact(8).enumerate() {
                 // chunks_exact(8) over a [u8;32] always yields 8-byte chunks, so
                 // this can't fail — but propagate rather than unwrap (no


### PR DESCRIPTION
CI's stable clippy moved to 1.98 and `chunks_exact_to_as_chunks` now fails any PR that wakes the on-chain job (first tripped by #1181's README link fix). Attribute-only — no codegen change, verifiable build unaffected; `unknown_lints` keeps older local toolchains green.