### PR TITLE
feat(quiz): the last question's forward button closes the quiz

### DIFF
--- a/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/blocks/__tests__/quiz-block.test.tsx
+++ b/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/blocks/__tests__/quiz-block.test.tsx
@@ -279,6 +279,39 @@ describe("QuizBlock — a clean sweep leaves the quiz open (owner 2026-08-21)", 
     expect(summary.closest(".hidden")).toBeNull();
   });
 
+  it("turns the forward slot into Close on the last question instead of dead-ending", () => {
+    renderWithIntl(<QuizBlock block={quizBlock} ctx={makeCtx()} />);
+    sweep();
+
+    // Nowhere left to advance to, so the slot collapses the section rather
+    // than sitting there disabled (owner, 2026-08-31).
+    expect(
+      screen.queryByRole("button", { name: "Next question" })
+    ).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Close quiz" }));
+    expect(screen.getByRole("button", { name: /Quiz/ })).toHaveAttribute(
+      "aria-expanded",
+      "false"
+    );
+  });
+
+  it("offers Close on the last question even when the answer is wrong", () => {
+    renderWithIntl(<QuizBlock block={quizBlock} ctx={makeCtx()} />);
+    fireEvent.click(screen.getByLabelText("A program-derived address"));
+    fireEvent.click(checkButton());
+    fireEvent.click(nextButton());
+
+    // Subdued skip-Next path: an attempted-but-wrong last question must not
+    // strand the learner either.
+    fireEvent.click(screen.getByLabelText("SOL"));
+    fireEvent.click(checkButton());
+    fireEvent.click(screen.getByRole("button", { name: "Close quiz" }));
+    expect(screen.getByRole("button", { name: /Quiz/ })).toHaveAttribute(
+      "aria-expanded",
+      "false"
+    );
+  });
+
   it("still folds and reopens by hand, keeping the header score + Complete chip", () => {
     renderWithIntl(<QuizBlock block={quizBlock} ctx={makeCtx()} />);
     sweep();

--- a/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/blocks/quiz-block.tsx
+++ b/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/blocks/quiz-block.tsx
@@ -6,6 +6,7 @@ import {
   CaretDown,
   CaretLeft,
   CaretRight,
+  CaretUp,
   CheckCircle,
   Robot,
   XCircle,
@@ -109,6 +110,7 @@ export function QuizBlock({ block, ctx }: BlockRenderProps) {
   }, [hydrated, storageKey, selections, results, checkedEver]);
   // Section starts open (#770); collapsing leaves the score badge as the recap.
   const [open, setOpen] = useState(true);
+  const headerRef = useRef<HTMLButtonElement>(null);
   const [index, setIndex] = useState(0);
   const promptRef = useRef<HTMLLegendElement>(null);
   // True only between a user-initiated navigation and the focus effect below —
@@ -222,6 +224,17 @@ export function QuizBlock({ block, ctx }: BlockRenderProps) {
   // inputs and Check disable while the verdict + explanation stay visible.
   const locked = result?.correct ?? false;
 
+  // On the final question the forward slot has nowhere to go, so instead of a
+  // dead disabled button it collapses the section — the manual counterpart to
+  // the auto-fold that was removed on 2026-08-21 for snatching the last
+  // explanation away mid-read. Focus returns to the header so the keyboard
+  // path doesn't strand on a control that just disappeared.
+  const lastQuestion = current === total - 1;
+  const collapse = useCallback(() => {
+    setOpen(false);
+    headerRef.current?.focus();
+  }, []);
+
   const onBodyKeyDown = (event: React.KeyboardEvent<HTMLDivElement>): void => {
     if (!q) return;
     const tag = (event.target as HTMLElement).tagName;
@@ -251,6 +264,7 @@ export function QuizBlock({ block, ctx }: BlockRenderProps) {
   return (
     <div className="rounded-[var(--r-lg)] border-[2.5px] border-border bg-card shadow-card">
       <button
+        ref={headerRef}
         type="button"
         onClick={() => setOpen((v) => !v)}
         aria-expanded={open}
@@ -413,12 +427,14 @@ export function QuizBlock({ block, ctx }: BlockRenderProps) {
             <Button
               variant="primary"
               size="sm"
-              onClick={() => goTo(current + 1)}
-              disabled={current === total - 1}
-              aria-disabled={current === total - 1}
+              onClick={lastQuestion ? collapse : () => goTo(current + 1)}
             >
-              {t("quizNext")}
-              <CaretRight size={14} weight="bold" aria-hidden="true" />
+              {lastQuestion ? t("quizCollapse") : t("quizNext")}
+              {lastQuestion ? (
+                <CaretUp size={14} weight="bold" aria-hidden="true" />
+              ) : (
+                <CaretRight size={14} weight="bold" aria-hidden="true" />
+              )}
             </Button>
           )}
           {!locked && q && (
@@ -439,12 +455,14 @@ export function QuizBlock({ block, ctx }: BlockRenderProps) {
                 <Button
                   variant="secondary"
                   size="sm"
-                  onClick={() => goTo(current + 1)}
-                  disabled={current === total - 1}
-                  aria-disabled={current === total - 1}
+                  onClick={lastQuestion ? collapse : () => goTo(current + 1)}
                 >
-                  {t("quizNext")}
-                  <CaretRight size={14} weight="bold" aria-hidden="true" />
+                  {lastQuestion ? t("quizCollapse") : t("quizNext")}
+                  {lastQuestion ? (
+                    <CaretUp size={14} weight="bold" aria-hidden="true" />
+                  ) : (
+                    <CaretRight size={14} weight="bold" aria-hidden="true" />
+                  )}
                 </Button>
               )}
             </div>

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -374,6 +374,7 @@
     "quizPosition": "Question {current} of {total}",
     "quizPrev": "Previous question",
     "quizNext": "Next question",
+    "quizCollapse": "Close quiz",
     "quizUnlocksAssistant": "AI Partner unlocks after the quiz — {answered}/{total} answered",
     "quizCompleteChip": "Complete",
     "quizAllCorrect": "All {total} questions answered correctly.",

--- a/apps/web/src/messages/es.json
+++ b/apps/web/src/messages/es.json
@@ -374,6 +374,7 @@
     "quizPosition": "Pregunta {current} de {total}",
     "quizPrev": "Pregunta anterior",
     "quizNext": "Siguiente pregunta",
+    "quizCollapse": "Cerrar quiz",
     "quizUnlocksAssistant": "El AI Partner se desbloquea después del cuestionario — {answered}/{total} respondidas",
     "quizCompleteChip": "Completado",
     "quizAllCorrect": "Las {total} preguntas respondidas correctamente.",

--- a/apps/web/src/messages/pt-BR.json
+++ b/apps/web/src/messages/pt-BR.json
@@ -374,6 +374,7 @@
     "quizPosition": "Pergunta {current} de {total}",
     "quizPrev": "Pergunta anterior",
     "quizNext": "Próxima pergunta",
+    "quizCollapse": "Fechar quiz",
     "quizUnlocksAssistant": "O AI Partner é liberado depois do quiz — {answered}/{total} respondidas",
     "quizCompleteChip": "Concluído",
     "quizAllCorrect": "Todas as {total} perguntas respondidas corretamente.",


### PR DESCRIPTION
On the final question the forward slot had nowhere to advance to, so it rendered disabled and the learner had to scroll back up to the header to collapse the section. It now reads "Close quiz" and folds the block, with focus returning to the header so the keyboard path doesn't strand on a control that just disappeared.

This is the manual counterpart to the auto-fold removed on 2026-08-21 — the learner closes it once they've read the last explanation, rather than having it snatched away mid-read. Both forward paths are covered: the primary button after a correct answer and the subdued skip after a wrong one.