### PR TITLE
fix(lesson): square the completed chip and make busy spinners visible

### DIFF
--- a/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/blocks/open-ended-block.tsx
+++ b/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/blocks/open-ended-block.tsx
@@ -150,7 +150,7 @@ export function OpenEndedBlock({ block, ctx }: BlockRenderProps) {
             {status === "submitting" ? (
               <>
                 <span
-                  className="h-4 w-4 animate-spin rounded-full border-2 border-white/30 border-t-white"
+                  className="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent"
                   aria-hidden="true"
                 />
                 <span className="sr-only">{t("reflectionSubmitting")}</span>

--- a/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/lesson-client.tsx
+++ b/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/lesson-client.tsx
@@ -938,7 +938,7 @@ export function LessonPageClient({
                       isCompleted ? (
                         <span
                           role="status"
-                          className="inline-flex h-10 items-center justify-center gap-1.5 rounded-full border border-[var(--primary-border)] bg-[var(--primary-dim)] px-4 font-display text-[11px] font-bold uppercase tracking-[0.4px] text-primary"
+                          className="btn-ink inline-flex h-10 items-center justify-center gap-1.5 rounded-md bg-[var(--primary-dim)] px-4 font-display text-[11px] font-bold uppercase tracking-[0.4px] text-primary"
                         >
                           <CheckCircle
                             size={16}
@@ -963,7 +963,7 @@ export function LessonPageClient({
                           {isCompleting && (
                             <>
                               <div
-                                className="h-5 w-5 animate-spin rounded-full border-[3px] border-white/30 border-t-white"
+                                className="h-5 w-5 animate-spin rounded-full border-[3px] border-current border-t-transparent"
                                 aria-hidden="true"
                               />
                               <span className="sr-only">
@@ -987,7 +987,7 @@ export function LessonPageClient({
                         {isEnrolling && (
                           <>
                             <div
-                              className="h-4 w-4 animate-spin rounded-full border-2 border-white/30 border-t-white"
+                              className="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent"
                               aria-hidden="true"
                             />
                             <span className="sr-only">

--- a/apps/web/src/app/[locale]/(platform)/teach/preview/preview-client.tsx
+++ b/apps/web/src/app/[locale]/(platform)/teach/preview/preview-client.tsx
@@ -259,7 +259,7 @@ export function TeachPreviewClient() {
         >
           {busy && (
             <span
-              className="h-4 w-4 animate-spin rounded-full border-2 border-white/30 border-t-white"
+              className="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent"
               aria-hidden="true"
             />
           )}

--- a/apps/web/src/components/community/delete-button.tsx
+++ b/apps/web/src/components/community/delete-button.tsx
@@ -74,7 +74,7 @@ export function DeleteButton({
           >
             {isDeleting && (
               <div
-                className="h-4 w-4 animate-spin rounded-full border-2 border-white/30 border-t-white"
+                className="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent"
                 aria-hidden="true"
               />
             )}


### PR DESCRIPTION
Two things on the lesson footer.

The "lesson complete" chip was a rounded pill sitting between two squared ink buttons — it now takes the same `.btn-ink` construction and `rounded-md` as its siblings, keeping the success tint so it still reads as a status rather than an action.

The spinners were invisible. Every one of them renders inside a button that is disabled while the work is in flight, and the disabled plate is `--card-alt` — so a `border-white/30` ring with a white top was white-on-white. They now use `currentColor` with a transparent gap, which follows the label colour in both the live and disabled states. Fixed in all four places it appeared, not just the one reported: lesson complete, enroll, open-ended submit, teach preview and the community delete button.