### PR TITLE
fix(quiz): ArrowRight closes the quiz on the last question

### DIFF
--- a/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/blocks/__tests__/quiz-block.test.tsx
+++ b/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/blocks/__tests__/quiz-block.test.tsx
@@ -550,6 +550,22 @@ describe("QuizBlock — stepper (#849)", () => {
     expect(screen.getByText("What is a PDA?")).toBeInTheDocument();
   });
 
+  it("ArrowRight on the last question collapses instead of no-opping", () => {
+    renderWithIntl(<QuizBlock block={quizBlock} ctx={makeCtx()} />);
+    fireEvent.keyDown(screen.getByText("What is a PDA?"), {
+      key: "ArrowRight",
+    });
+
+    // Parity with the forward button, which closes the quiz here.
+    fireEvent.keyDown(screen.getByText("Which are soulbound?"), {
+      key: "ArrowRight",
+    });
+    expect(screen.getByRole("button", { name: /Quiz/ })).toHaveAttribute(
+      "aria-expanded",
+      "false"
+    );
+  });
+
   it("does NOT hijack arrow keys inside the radio/checkbox group", () => {
     renderWithIntl(<QuizBlock block={quizBlock} ctx={makeCtx()} />);
     // Arrows on an option input move the native selection, never the card.

--- a/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/blocks/quiz-block.tsx
+++ b/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/blocks/quiz-block.tsx
@@ -254,7 +254,10 @@ export function QuizBlock({ block, ctx }: BlockRenderProps) {
     if (tag === "INPUT") return;
     if (event.key === "ArrowRight") {
       event.preventDefault();
-      goTo(current + 1);
+      // Parity with the forward button: on the last question there is nowhere
+      // to advance to, so ArrowRight collapses instead of silently no-opping.
+      if (lastQuestion) collapse();
+      else goTo(current + 1);
     } else if (event.key === "ArrowLeft") {
       event.preventDefault();
       goTo(current - 1);


### PR DESCRIPTION
Follow-up to the review note on #1189. The forward button now collapses the quiz on the last question, but ArrowRight still called `goTo(current + 1)`, which silently no-ops past the last index — so a keyboard user navigating by arrows didn't get the close the mouse path offers. ArrowLeft is unchanged, and the arrow keys still yield to the radio/checkbox group.