### PR TITLE
fix(challenge): entry-point detection rejects `pub fn` and reads comment text

### DIFF
--- a/apps/web/src/components/editor/challenge-runner.tsx
+++ b/apps/web/src/components/editor/challenge-runner.tsx
@@ -288,8 +288,60 @@ function transformImports(code: string): string {
 // Code analysis helpers — run on the main thread
 // ---------------------------------------------------------------------------
 
+/**
+ * Blank out comment TEXT before any code analysis. detectFunctionName takes the
+ * first declaration-shaped match, so prose could name the entry point: a
+ * starter whose docblock read "keep it a plain top-level function declaration
+ * (no export, no imports)" made the runner call declaration(...) and failed a
+ * correct submission on every case. String and template literals are copied
+ * through untouched — a // inside a URL is not a comment. Each comment leaves a
+ * space behind so it cannot glue two tokens together. The result is used ONLY
+ * to read identifiers; the code that RUNS is always the original source.
+ * Mirrors stripComments in @superteam-lms/challenge-executor.
+ */
+function stripComments(code: string): string {
+  let out = "";
+  let i = 0;
+  const n = code.length;
+  while (i < n) {
+    const c = code.charAt(i);
+    if (c === "/" && code.charAt(i + 1) === "/") {
+      while (i < n && code.charAt(i) !== "\n") i++;
+      out += " ";
+      continue;
+    }
+    if (c === "/" && code.charAt(i + 1) === "*") {
+      i += 2;
+      while (i < n && !(code.charAt(i) === "*" && code.charAt(i + 1) === "/"))
+        i++;
+      i += 2;
+      out += " ";
+      continue;
+    }
+    if (c === '"' || c === "'" || c === "`") {
+      out += c;
+      i++;
+      while (i < n) {
+        const d = code.charAt(i);
+        out += d;
+        i++;
+        if (d === "\\") {
+          out += code.charAt(i);
+          i++;
+          continue;
+        }
+        if (d === c) break;
+      }
+      continue;
+    }
+    out += c;
+    i++;
+  }
+  return out;
+}
+
 function detectFunctionName(code: string): string | null {
-  const fnMatch = code.match(
+  const fnMatch = stripComments(code).match(
     /(?:function\s+(\w+)\s*\(|(?:const|let|var)\s+(\w+)\s*=\s*(?:async\s*)?\()/
   );
   return fnMatch ? (fnMatch[1] ?? fnMatch[2] ?? null) : null;
@@ -299,7 +351,7 @@ function functionHasParams(code: string, fnName: string): boolean {
   const re = new RegExp(
     `(?:function\\s+${fnName}\\s*\\(([^)]*?)\\)|(?:const|let|var)\\s+${fnName}\\s*=\\s*(?:async\\s*)?\\(([^)]*?)\\))`
   );
-  const m = code.match(re);
+  const m = stripComments(code).match(re);
   if (!m) return false;
   const params = (m[1] ?? m[2] ?? "").trim();
   return params.length > 0;
@@ -557,9 +609,13 @@ function stripAnsi(str: string): string {
 }
 
 function buildRustTestHarness(userCode: string, tests: TestCase[]): string {
-  // Match top-level fn declarations (start of line, no indentation).
-  // This skips methods inside impl blocks which are always indented.
-  const topLevelFns = [...userCode.matchAll(/^fn\s+(\w+)\s*\(/gm)];
+  // Match top-level fn declarations (start of line, no indentation), with an
+  // optional visibility modifier — `pub fn` is the natural Rust spelling and
+  // must grade. This skips methods inside impl blocks which are always
+  // indented. Mirrors detectFunctionName in lib/challenge/rust-executor.ts.
+  const topLevelFns = [
+    ...userCode.matchAll(/^(?:pub(?:\s*\([^)]*\))?\s+)?fn\s+(\w+)\s*\(/gm),
+  ];
   const lastMatch = topLevelFns[topLevelFns.length - 1];
   const fnName = lastMatch?.[1] ?? null;
 

--- a/apps/web/src/lib/challenge/__tests__/executor.test.ts
+++ b/apps/web/src/lib/challenge/__tests__/executor.test.ts
@@ -29,6 +29,17 @@ const sumTests: AdminTestCase[] = [
 ];
 
 const CORRECT = "function add(a, b) { return a + b; }";
+// The same correct function behind the docblock an authored starter ships. The
+// prose "a plain top-level function declaration (no export…)" is the exact
+// wording that hijacked entry-point detection in production — see the
+// regression test below.
+const CORRECT_WITH_DOCBLOCK = `/**
+ * Add two numbers.
+ *
+ * The grader calls add(a, b) directly -
+ * keep it a plain top-level function declaration (no export, no imports).
+ */
+function add(a, b) { return a + b; }`;
 // Passes the VISIBLE test (returns 5 for 2,3) but FAILS the hidden test —
 // this is exactly the "passed in the browser" shape that must be caught.
 const PASSES_VISIBLE_ONLY =
@@ -98,6 +109,50 @@ describe.skipIf(!EXECUTOR_AVAILABLE)(
       // in QuickJS -> every test failed -> an un-completable challenge.
       expect(run.passed).toBe(true);
       expect(run.results.find((r) => r.id === "values")?.passed).toBe(true);
+    });
+
+    // REGRESSION: entry-point detection ran over the raw source and took the
+    // FIRST `function <name>(`-shaped text it found, comments included. A
+    // starter whose docblock read "keep it a plain top-level function
+    // declaration (no export, no imports)" made the harness call
+    // `declaration(...)`, so a learner who wrote the reference solution and
+    // left the comment in place — the normal editing path — scored 0/5 with
+    // "'declaration' is not defined" and nothing in the UI to explain it.
+    // Comment text must never name the entry point.
+    it.each([
+      ["a docblock (the production failure)", CORRECT_WITH_DOCBLOCK],
+      [
+        "a line comment",
+        "// do not write function subtract(a, b) here\nfunction add(a, b) { return a + b; }",
+      ],
+      [
+        "a block comment naming an arrow binding",
+        "/* not const total = (a + b) */\nconst add = (a, b) => a + b;",
+      ],
+      [
+        "a trailing comment after the real declaration",
+        "function add(a, b) { return a + b; }\n// function ignored(x) {}",
+      ],
+    ])("picks the real entry point past %s", async (_label, code) => {
+      const run = await runJsSubmission(code, sumTests);
+      expect(run.available).toBe(true);
+      if (!run.available) return;
+      expect(run.results.map((r) => r.detail).join(" | ")).not.toContain(
+        "is not defined"
+      );
+      expect(run.passed).toBe(true);
+    });
+
+    // Guard the fix in the other direction: comment stripping must not reach
+    // into string literals, where `//` and `/*` are ordinary characters.
+    it("keeps string literals containing comment markers intact", async () => {
+      const run = await runJsSubmission(
+        'function add(a, b) { const rpc = "https://example.com/*x*/"; return rpc ? a + b : 0; }',
+        sumTests
+      );
+      expect(run.available).toBe(true);
+      if (!run.available) return;
+      expect(run.passed).toBe(true);
     });
 
     it("rejects a WRONG submission", async () => {

--- a/apps/web/src/lib/challenge/__tests__/rust-executor.test.ts
+++ b/apps/web/src/lib/challenge/__tests__/rust-executor.test.ts
@@ -29,22 +29,27 @@ function mockPlayground(
     code: string
   ) => { ok?: boolean; success?: boolean; stdout?: string; stderr?: string }
 ) {
-  vi.stubGlobal(
-    "fetch",
-    vi.fn(async (_url: string, init: { body: string }) => {
-      const { code } = JSON.parse(init.body) as { code: string };
-      const nonce = code.match(/TEST_([0-9a-f]{24})_/)?.[1] ?? "";
-      const r = respond(nonce, code);
-      return {
-        ok: r.ok ?? true,
-        json: async () => ({
-          success: r.success ?? true,
-          stdout: r.stdout ?? "",
-          stderr: r.stderr ?? "",
-        }),
-      } as unknown as Response;
-    })
-  );
+  const spy = vi.fn(async (_url: string, init: { body: string }) => {
+    const { code } = JSON.parse(init.body) as { code: string };
+    const nonce = code.match(/TEST_([0-9a-f]{24})_/)?.[1] ?? "";
+    const r = respond(nonce, code);
+    return {
+      ok: r.ok ?? true,
+      json: async () => ({
+        success: r.success ?? true,
+        stdout: r.stdout ?? "",
+        stderr: r.stderr ?? "",
+      }),
+    } as unknown as Response;
+  });
+  vi.stubGlobal("fetch", spy);
+  return spy;
+}
+
+/** The harness the grader sent to the Playground on its last (only) call. */
+function sentHarness(spy: ReturnType<typeof mockPlayground>): string {
+  const init = spy.mock.calls[0]?.[1] as { body: string } | undefined;
+  return init ? (JSON.parse(init.body) as { code: string }).code : "";
 }
 
 const passAll = (nonce: string) =>
@@ -128,6 +133,64 @@ describe("runRustSubmission", () => {
     const spy = vi.fn();
     vi.stubGlobal("fetch", spy);
     const r = await runRustSubmission("fn main() { let x = 1; }", tests);
+    expect(r).toMatchObject({ available: true, passed: false });
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  // REGRESSION: the entry-point detector was `/^fn\s+…/`, which no `pub fn`
+  // line can match. A submission spelled the natural Rust way never reached the
+  // Playground at all — every test failed closed with "No top-level function
+  // found in submission", naming nothing the learner had done wrong. Authored
+  // content had to be rewritten to bare `fn` to be gradeable. Both spellings
+  // must work, so neither convention can silently zero a challenge again.
+  it.each([
+    ["bare", "fn add(a: i32, b: i32) -> i32 { a + b }"],
+    ["pub", "pub fn add(a: i32, b: i32) -> i32 { a + b }"],
+    ["pub(crate)", "pub(crate) fn add(a: i32, b: i32) -> i32 { a + b }"],
+    ["pub(super)", "pub(super) fn add(a: i32, b: i32) -> i32 { a + b }"],
+    [
+      "pub(in crate::m)",
+      "pub(in crate::m) fn add(a: i32, b: i32) -> i32 { 0 }",
+    ],
+  ])("grades a %s `fn` entry point", async (_visibility, code) => {
+    const spy = mockPlayground((n) => ({ stdout: passAll(n) }));
+    const r = await runRustSubmission(code, tests);
+    expect(spy).toHaveBeenCalledOnce();
+    // The detected name is spliced into the harness — proves `add` was the
+    // entry point, not just that something was found.
+    expect(sentHarness(spy)).toContain("add(2, 3)");
+    expect(r).toMatchObject({ available: true, passed: true });
+  });
+
+  it("skips `pub fn` methods indented inside an impl block", async () => {
+    const spy = mockPlayground((n) => ({ stdout: passAll(n) }));
+    const code = [
+      "struct S;",
+      "impl S {",
+      "    pub fn helper(&self) -> i32 { 1 }",
+      "}",
+      "pub fn add(a: i32, b: i32) -> i32 { a + b }",
+    ].join("\n");
+    await runRustSubmission(code, tests);
+    expect(sentHarness(spy)).toContain("add(2, 3)");
+    expect(sentHarness(spy)).not.toContain("helper(2, 3)");
+  });
+
+  // Documented convention: helpers are declared above, the entry point last.
+  it("takes the LAST top-level fn as the entry point", async () => {
+    const spy = mockPlayground((n) => ({ stdout: passAll(n) }));
+    const code = [
+      "fn double(x: i32) -> i32 { x * 2 }",
+      "pub fn add(a: i32, b: i32) -> i32 { double(a) + b }",
+    ].join("\n");
+    await runRustSubmission(code, tests);
+    expect(sentHarness(spy)).toContain("add(2, 3)");
+  });
+
+  it("fails closed on a `pub fn main` with no other entry point", async () => {
+    const spy = vi.fn();
+    vi.stubGlobal("fetch", spy);
+    const r = await runRustSubmission("pub fn main() { let x = 1; }", tests);
     expect(r).toMatchObject({ available: true, passed: false });
     expect(spy).not.toHaveBeenCalled();
   });

--- a/apps/web/src/lib/challenge/rust-executor.ts
+++ b/apps/web/src/lib/challenge/rust-executor.ts
@@ -68,11 +68,18 @@ const stripAnsi = (s: string): string => s.replace(ANSI_REGEX, "");
 /**
  * Detect the last top-level `fn` in the submission — the function the tests
  * invoke. Top-level only (start of line, no indentation) so methods inside
- * `impl` blocks are skipped. Mirrors `buildRustTestHarness` in the browser
- * runner. `main` is not a gradeable entry point.
+ * `impl` blocks are skipped, and the LAST match wins because helpers are
+ * declared above the entry point. An optional visibility modifier (`pub`,
+ * `pub(crate)`, `pub(super)`, `pub(in path)`) is accepted: `pub fn` is the
+ * natural Rust spelling of an entry point, and rejecting it failed the whole
+ * submission closed before the Playground was ever called. Mirrors
+ * `buildRustTestHarness` in the browser runner. `main` is not a gradeable entry
+ * point.
  */
 function detectFunctionName(code: string): string | null {
-  const fns = [...code.matchAll(/^fn\s+(\w+)\s*\(/gm)];
+  const fns = [
+    ...code.matchAll(/^(?:pub(?:\s*\([^)]*\))?\s+)?fn\s+(\w+)\s*\(/gm),
+  ];
   const name = fns[fns.length - 1]?.[1] ?? null;
   return name && name !== "main" ? name : null;
 }

--- a/packages/challenge-executor/src/executor.ts
+++ b/packages/challenge-executor/src/executor.ts
@@ -331,13 +331,61 @@ function makeMockConsole() {
 
 /* ---- code analysis (ports of challenge-runner helpers) ------------------ */
 
+/* Blank out comment TEXT before any code analysis. The detector below takes the
+ * first declaration-shaped match, so prose could name the entry point: a
+ * starter whose docblock read "keep it a plain top-level function declaration
+ * (no export, no imports)" made the harness call declaration(...), and a
+ * learner who wrote the reference solution but kept the comment scored 0/5 with
+ * "'declaration' is not defined". String and template literals are copied
+ * through untouched — a // inside a URL is not a comment. Each comment leaves a
+ * space behind so it cannot glue two tokens together. The result is used ONLY
+ * to read identifiers; the code that RUNS is always the original source. */
+function stripComments(code) {
+  var out = "";
+  var i = 0;
+  var n = code.length;
+  while (i < n) {
+    var c = code.charAt(i);
+    if (c === "/" && code.charAt(i + 1) === "/") {
+      while (i < n && code.charAt(i) !== "\n") i++;
+      out += " ";
+      continue;
+    }
+    if (c === "/" && code.charAt(i + 1) === "*") {
+      i += 2;
+      while (i < n && !(code.charAt(i) === "*" && code.charAt(i + 1) === "/")) i++;
+      i += 2;
+      out += " ";
+      continue;
+    }
+    /* Quote openers. The third is the backtick, written as an escape because
+     * this runtime source lives inside a String.raw template on the host,
+     * where a literal backtick would end the template. */
+    if (c === '"' || c === "'" || c === "\u0060") {
+      out += c;
+      i++;
+      while (i < n) {
+        var d = code.charAt(i);
+        out += d;
+        i++;
+        if (d === "\\") { out += code.charAt(i); i++; continue; }
+        if (d === c) break;
+      }
+      continue;
+    }
+    out += c;
+    i++;
+  }
+  return out;
+}
+
 function detectFunctionName(code) {
-  var m = code.match(/(?:function\s+(\w+)\s*\(|(?:const|let|var)\s+(\w+)\s*=\s*(?:async\s*)?\()/);
+  var m = stripComments(code).match(/(?:function\s+(\w+)\s*\(|(?:const|let|var)\s+(\w+)\s*=\s*(?:async\s*)?\()/);
   return m ? (m[1] || m[2] || null) : null;
 }
 function functionHasParams(code, fnName) {
   var re = new RegExp("(?:function\\s+" + fnName + "\\s*\\(([^)]*?)\\)|(?:const|let|var)\\s+" + fnName + "\\s*=\\s*(?:async\\s*)?\\(([^)]*?)\\))");
-  var m = code.match(re);
+  var m = stripComments(code).match(re);
   if (!m) return false;
   var params = (m[1] || m[2] || "").trim();
   return params.length > 0;


### PR DESCRIPTION
Two bugs in the entry-point detection the challenge graders use to decide which
function a submission's tests should call. Both fail a correct submission
closed; neither is caught by CI, because CI only asserts that a starter fails —
which it does, for the wrong reason. Both were found by course reviews.

## 1. The Rust detector rejects `pub fn`

`detectFunctionName` in `lib/challenge/rust-executor.ts` matched
`/^fn\s+(\w+)\s*\(/gm`. No `pub fn` line can match `^fn`, so a submission
spelled the natural Rust way produced no entry point and `runRustSubmission`
returned `allFailed("No top-level function found in submission")` *without ever
calling the Playground*. Every test failed, with a message naming nothing the
learner had done wrong.

The mixed case was worse than dead: a `pub fn` entry point followed by a private
helper `fn` picked the **helper** and graded it against the entry point's
arguments — passing or failing for reasons unrelated to the submission.

This shipped. `digital-assets/m03-l1` shipped `pub fn hook_execute`, and its own
reference solution scored 0/5; the `mastering-anchor-v2` Rust challenges had to
be rewritten to bare `fn` before they would grade at all.

The detector now accepts an optional visibility modifier — `pub`, `pub(crate)`,
`pub(super)`, `pub(in path)`. Top-level-only (the `^` anchor keeps `impl`
methods out) and last-match-wins are unchanged; both are now documented in the
doc comment and pinned by tests, since authored content depends on them.

## 2. The JS/TS detector matches words in comments

`detectFunctionName` in `packages/challenge-executor/src/executor.ts` took the
first `function <name>(`-shaped match in the raw source, comments included.

`digital-assets/m02-l1`'s starter docblock reads:

```
 * keep it a plain top-level function declaration (no export, no imports).
```

`function declaration (` matches. The harness therefore called
`declaration(...)`, and the whole suite came back:

```
FAIL  exact-half-percent  'declaration' is not defined
FAIL  ceiling-rounds-up   'declaration' is not defined
...  0/5
```

This is not just a bad message on a starter. A learner who writes the exact
reference solution and leaves the docblock in place — the normal editing path —
scores 0/5 and is told a variable they never wrote is undefined. Verified by
splicing the starter's docblock onto the solution body: 0/5 before, 5/5 after.

Comment text is now blanked before the source is scanned. String and template
literals are copied through untouched (a `//` inside a URL is not a comment),
each comment leaves a space behind so it cannot glue two tokens together, and
the stripped text is used *only* to read identifiers — the code that runs is
always the original source.

## Scope

- `lib/challenge/rust-executor.ts` — the authoritative Rust grader.
- `packages/challenge-executor/src/executor.ts` — the authoritative JS/TS
  grader, also used by content-lint's gate 6.
- `components/editor/challenge-runner.tsx` — the browser mirrors of both, so the
  in-editor Run agrees with the server verdict.

## Tests

Written first, watched fail, then fixed.

- Rust: parameterised over `fn`, `pub fn`, `pub(crate) fn`, `pub(super) fn`,
  `pub(in crate::m) fn`, each asserting the Playground was actually called and
  that the detected name is the one spliced into the harness. Plus: `pub fn`
  methods inside an `impl` are still skipped, the last top-level `fn` still
  wins, and a lone `pub fn main` still fails closed. The bare-`fn` row is the
  regression guard for the content that was rewritten to work around this.
- JS/TS: the production docblock wording, a line comment, a block comment naming
  an arrow binding, and a trailing comment — all must resolve to the real entry
  point. Plus a guard in the other direction: a string literal containing
  `https://example.com/*x*/` must survive stripping intact.

```
apps/web            346 files  3464 tests  passed
content-lint         18 files   132 tests  passed   (the other executor consumer)
tsc --noEmit        web + challenge-executor  clean
next lint           no new warnings
```

End-to-end against the two courses that hit this, with the real graders (local
`rustc` substituted for the Playground):

```
m03-l1 hook-execute-gate  solution.rs (pub fn)   0/5 -> 5/5
m03-l1 hook-execute-gate  starter.rs             fails on 3 cases, as authored
m02-l1 fee-calculator     solution + docblock    0/5 -> 5/5
m02-l1 fee-calculator     starter                0/5 -> 3/5, failing on the
                                                 ceiling and cap cases it is
                                                 supposed to fail on
```

The starter still fails, so the content-lint starter-must-fail gate is unaffected.
