### PR TITLE
feat(header): beta tag beside the wordmark; fix(landing): spaced random achievement ring

### DIFF
--- a/apps/web/src/components/landing/__tests__/achievement-ring.test.tsx
+++ b/apps/web/src/components/landing/__tests__/achievement-ring.test.tsx
@@ -1,0 +1,72 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import { renderToString } from "react-dom/server";
+import type { DeployedAchievement } from "@/lib/content/queries";
+import { AchievementRing } from "../achievement-ring";
+
+/**
+ * The ring is a fixed-radius circle, so the number of items IS the spacing:
+ * every extra badge divides the same circumference further. At the full
+ * catalog the arc per item fell below the width of one label and the badges
+ * ran into each other, so the ring shows a fixed-size random sample instead.
+ */
+const catalog: DeployedAchievement[] = Array.from({ length: 18 }, (_, i) => ({
+  id: `achievement-${i}`,
+  name: `Achievement ${i}`,
+  description: `Description ${i}`,
+  glyph: "01",
+  category: "progress",
+  xpReward: 10,
+  solTier: false,
+})) as unknown as DeployedAchievement[];
+
+const namesOf = (c: HTMLElement) =>
+  [...c.querySelectorAll(".ach-ring-item")].map(
+    (el) => el.querySelector(".ach-ring-name")?.textContent ?? ""
+  );
+
+describe("AchievementRing — a fixed, spaced sample of the catalog", () => {
+  it("shows fewer items than the catalog, so neighbours keep a gap", () => {
+    const { container } = render(<AchievementRing achievements={catalog} />);
+    const items = container.querySelectorAll(".ach-ring-item");
+    expect(items.length).toBeLessThan(catalog.length);
+    expect(items.length).toBe(7);
+  });
+
+  it("spreads the items evenly around the full turn", () => {
+    const { container } = render(<AchievementRing achievements={catalog} />);
+    const items = [
+      ...container.querySelectorAll<HTMLElement>(".ach-ring-item"),
+    ];
+    const step = 360 / items.length;
+    items.forEach((el, i) => {
+      expect(el.style.getPropertyValue("--ring-a")).toBe(`${i * step}deg`);
+    });
+  });
+
+  it("draws distinct achievements, all from the catalog", () => {
+    const { container } = render(<AchievementRing achievements={catalog} />);
+    const names = namesOf(container);
+    expect(new Set(names).size).toBe(names.length);
+    names.forEach((n) => expect(catalog.some((a) => a.name === n)).toBe(true));
+  });
+
+  it("renders deterministically on the server, so hydration matches", () => {
+    // The draw lands in an effect, never in a render: a server pass that
+    // shuffled would disagree with the client's first pass and blow up
+    // hydration. The server therefore emits the leading slice, in order.
+    const html = renderToString(<AchievementRing achievements={catalog} />);
+    catalog.slice(0, 7).forEach((a) => expect(html).toContain(a.name));
+    expect(html).not.toContain(">Achievement 7<");
+    expect(renderToString(<AchievementRing achievements={catalog} />)).toBe(
+      html
+    );
+  });
+
+  it("shows every achievement when the catalog is smaller than the ring", () => {
+    const few = catalog.slice(0, 3);
+    const { container } = render(<AchievementRing achievements={few} />);
+    expect(container.querySelectorAll(".ach-ring-item").length).toBe(3);
+  });
+});

--- a/apps/web/src/components/landing/achievement-ring.tsx
+++ b/apps/web/src/components/landing/achievement-ring.tsx
@@ -1,7 +1,31 @@
 "use client";
 
+import { useEffect, useMemo, useState } from "react";
 import type { DeployedAchievement } from "@/lib/content/queries";
 import { AchievementPatch3D } from "@/components/gamification/achievement-patch-3d";
+
+/**
+ * How many of the catalog's achievements ride the ring at once.
+ *
+ * The ring is a fixed-radius circle, so the count IS the spacing: every extra
+ * badge divides the same circumference further. At the full catalog the arc
+ * per item fell below the width of a single label and the badges — and worse,
+ * their names — ran into each other. This many leaves a clear gap between
+ * neighbours at every breakpoint, and the ring reads as a sample of the set
+ * rather than an inventory of it.
+ */
+const RING_SLOTS = 7;
+
+/** Draw `n` distinct items at random. Does not touch the input. */
+function sample<T>(items: readonly T[], n: number): T[] {
+  const pool = [...items];
+  const drawn: T[] = [];
+  while (drawn.length < n && pool.length > 0) {
+    const [picked] = pool.splice(Math.floor(Math.random() * pool.length), 1);
+    if (picked !== undefined) drawn.push(picked);
+  }
+  return drawn;
+}
 
 /**
  * The CTA section's rotating achievement ring (designer feedback, 19-08).
@@ -10,6 +34,12 @@ import { AchievementPatch3D } from "@/components/gamification/achievement-patch-
  * anything inside has focus), replacing the flat marquee that lived in its own
  * section: the achievements now sit between the CTA's promise and its buttons,
  * so the reward is on screen at the moment of decision.
+ *
+ * It shows a RANDOM sample rather than the whole catalog — see `RING_SLOTS`.
+ * The draw happens on mount, not during render: the server and the first
+ * client pass both render the same leading slice, so hydration matches, and
+ * the shuffle lands on the next paint while the ring is still turning into
+ * view.
  *
  * The badges are the spec's 3D patch — real thickness, six shade slices
  * between two identically-authored faces — so the ring's own orbit supplies
@@ -28,12 +58,28 @@ export function AchievementRing({
 }: {
   achievements: DeployedAchievement[];
 }) {
-  const step = 360 / achievements.length;
+  const [shown, setShown] = useState<DeployedAchievement[]>(() =>
+    achievements.slice(0, RING_SLOTS)
+  );
+
+  // Identity, not reference: the parent may hand us a fresh array on any
+  // re-render, and re-drawing the sample then would make the ring flicker.
+  const catalogKey = useMemo(
+    () => achievements.map((a) => a.id).join(","),
+    [achievements]
+  );
+
+  useEffect(() => {
+    setShown(sample(achievements, RING_SLOTS));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [catalogKey]);
+
+  const step = 360 / shown.length;
 
   return (
     <div className="ach-ring-stage" role="list">
       <div className="ach-ring">
-        {achievements.map((ach, i) => (
+        {shown.map((ach, i) => (
           <div
             key={ach.id}
             role="listitem"

--- a/apps/web/src/components/layout/beta-tag.tsx
+++ b/apps/web/src/components/layout/beta-tag.tsx
@@ -1,0 +1,20 @@
+import { useTranslations } from "next-intl";
+
+/**
+ * The header's pre-release marker (spec: Beta tag, option 1e / 2c).
+ *
+ * Built from the achievement-badge vocabulary — flat fill, full keyline, hard
+ * offset shadow — so it reads as part of the same family as the patches, chips
+ * and level bands rather than as a generic status pill. All colour lives in
+ * `.beta-tag` (globals.css); geometry, type and spacing are identical in both
+ * themes.
+ *
+ * A label, not a control: no hover, no focus, no press. It is a sibling of the
+ * wordmark rather than a child of its link, so it is neither clickable nor part
+ * of the link's accessible name — the word is real text and is announced after
+ * the lockup on its own.
+ */
+export function BetaTag() {
+  const t = useTranslations("common");
+  return <span className="beta-tag">{t("beta")}</span>;
+}

--- a/apps/web/src/components/layout/header.tsx
+++ b/apps/web/src/components/layout/header.tsx
@@ -9,6 +9,7 @@ import { House, Book, ChatCircle, Chalkboard } from "@phosphor-icons/react";
 import { cn } from "@/lib/utils";
 import { useAuth } from "@/lib/auth/auth-provider";
 import { isInstructorWallet } from "@/lib/content/client-queries";
+import { BetaTag } from "@/components/layout/beta-tag";
 import { ThemeToggle } from "@/components/layout/theme-toggle";
 import { LanguageSwitcher } from "@/components/layout/language-switcher";
 import { AuthModal, AuthTriggerButton } from "@/components/auth/auth-modal";
@@ -191,30 +192,34 @@ export function Header() {
       <div className="relative bg-transparent backdrop-blur-md">
         <div className="relative mx-auto flex h-[56px] max-w-[1600px] items-center px-[16px]">
           {/* Left: Logo (desktop lg+) */}
-          <Link
-            href={`/${locale}`}
-            className="relative z-10 mr-auto hidden shrink-0 lg:flex"
-          >
-            {/* Academy lockup is the primary mark (brand guide §02). h-6 renders
+          {/* The Beta tag is a SIBLING of the wordmark's link, not a child:
+              it belongs to the lockup but is neither clickable nor part of the
+              link's accessible name. `items-center` centres it on the lockup
+              box rather than on the 56px header band. */}
+          <div className="relative z-10 mr-auto hidden shrink-0 items-center gap-[10px] lg:flex">
+            <Link href={`/${locale}`} className="flex shrink-0">
+              {/* Academy lockup is the primary mark (brand guide §02). h-6 renders
                 it ~126px wide — above the 110px minimum, so the lockup (not the
                 mark) is the correct variant here. */}
-            <Image
-              src="/brand/academy-lockup-forest.svg"
-              alt="Superteam Academy"
-              width={157}
-              height={30}
-              priority
-              className="h-6 w-auto dark:hidden"
-            />
-            <Image
-              src="/brand/academy-lockup-green.svg"
-              alt="Superteam Academy"
-              width={157}
-              height={30}
-              priority
-              className="hidden h-6 w-auto dark:block"
-            />
-          </Link>
+              <Image
+                src="/brand/academy-lockup-forest.svg"
+                alt="Superteam Academy"
+                width={157}
+                height={30}
+                priority
+                className="h-6 w-auto dark:hidden"
+              />
+              <Image
+                src="/brand/academy-lockup-green.svg"
+                alt="Superteam Academy"
+                width={157}
+                height={30}
+                priority
+                className="hidden h-6 w-auto dark:block"
+              />
+            </Link>
+            <BetaTag />
+          </div>
 
           {/* Center: nav pill bar (desktop lg+) */}
           {authLoading ? (
@@ -349,27 +354,30 @@ export function Header() {
 
           {/* Mobile/tablet top bar (< lg) — logo + compact utils */}
           <div className="flex flex-1 items-center justify-between gap-3 lg:hidden">
-            <Link
-              href={user ? `/${locale}/dashboard` : `/${locale}`}
-              className="flex min-h-[44px] items-center"
-            >
-              <Image
-                src="/brand/academy-lockup-forest.svg"
-                alt="Superteam Academy"
-                width={157}
-                height={30}
-                priority
-                className="h-6 w-auto dark:hidden"
-              />
-              <Image
-                src="/brand/academy-lockup-green.svg"
-                alt="Superteam Academy"
-                width={157}
-                height={30}
-                priority
-                className="hidden h-6 w-auto dark:block"
-              />
-            </Link>
+            <div className="flex items-center gap-[10px]">
+              <Link
+                href={user ? `/${locale}/dashboard` : `/${locale}`}
+                className="flex min-h-[44px] shrink-0 items-center"
+              >
+                <Image
+                  src="/brand/academy-lockup-forest.svg"
+                  alt="Superteam Academy"
+                  width={157}
+                  height={30}
+                  priority
+                  className="h-6 w-auto dark:hidden"
+                />
+                <Image
+                  src="/brand/academy-lockup-green.svg"
+                  alt="Superteam Academy"
+                  width={157}
+                  height={30}
+                  priority
+                  className="hidden h-6 w-auto dark:block"
+                />
+              </Link>
+              <BetaTag />
+            </div>
 
             <div className="flex items-center gap-2">
               <LanguageSwitcher />

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -1,6 +1,7 @@
 {
   "common": {
     "appName": "Superteam Academy",
+    "beta": "Beta",
     "tagline": "Learn Solana Development",
     "loading": "Loading...",
     "error": "Something went wrong",

--- a/apps/web/src/messages/es.json
+++ b/apps/web/src/messages/es.json
@@ -1,6 +1,7 @@
 {
   "common": {
     "appName": "Superteam Academy",
+    "beta": "Beta",
     "tagline": "Aprende Desarrollo Solana",
     "loading": "Cargando...",
     "error": "Algo salió mal",

--- a/apps/web/src/messages/pt-BR.json
+++ b/apps/web/src/messages/pt-BR.json
@@ -1,6 +1,7 @@
 {
   "common": {
     "appName": "Superteam Academy",
+    "beta": "Beta",
     "tagline": "Aprenda Desenvolvimento Solana",
     "loading": "Carregando...",
     "error": "Algo deu errado",

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -6717,3 +6717,48 @@ textarea.set-input {
   --patch-ink: #19231b;
   box-shadow: 0 var(--lift) 0 0 #19231b;
 }
+
+/* ══ Beta tag ═════════════════════════════════════════════════════════════
+   The header's pre-release marker (spec: Beta tag, option 1e / 2c). It is
+   built from the achievement-badge vocabulary — flat fill, full keyline, hard
+   offset shadow — so it belongs to the same family as the patches, chips and
+   level bands instead of reading as a generic status pill.
+
+   Geometry, type and spacing are identical in both themes; only the fill, the
+   keyline and the label change. The keyline and the shadow are always the same
+   colour as each other.
+
+   Light does NOT carry the dark theme's warm cream across: cream on the
+   #FAFAF7 page is a 1.06:1 difference, so the chip would lose its shape and
+   stop reading as a patch. Amber keeps the flat-fill-plus-keyline language
+   intact on cream. That amber is also the Learner band fill and first place on
+   the leaderboard; in the header it is spatially far from both, so the
+   collision is accepted — revisit if amber ever picks up a stricter meaning.
+   ───────────────────────────────────────────────────────────────────────── */
+.beta-tag {
+  display: inline-block;
+  font-family: var(--font-display), "Nunito", sans-serif;
+  font-weight: 900;
+  font-size: 12px;
+  line-height: 1;
+  letter-spacing: 1.2px;
+  text-transform: uppercase;
+  /* Asymmetric: optical centring for the uppercase cap-height. */
+  padding: 4px 10px 3px;
+  border: 1.5px solid var(--ink-dark);
+  border-radius: 5px;
+  color: var(--ink-dark);
+  background: #fde68a;
+  box-shadow: 0 2px 0 var(--ink-dark);
+  /* The 2px shadow makes the visual box taller than the border box. It is
+     allowed to overhang — no compensating margin. */
+  user-select: none;
+}
+[data-theme="dark"] .beta-tag {
+  /* A warmer cream than the system's #fafaf7 surface, picked so the tag does
+     not read as a floating card against the dark header. */
+  background: #f1e9d2;
+  border-color: var(--keyline);
+  box-shadow: 0 2px 0 var(--keyline);
+  color: #33312c;
+}


### PR DESCRIPTION
Two independent frontend changes, one commit each. Both are CSS + a small component; neither touches data, auth, or the program.

## 1. Beta tag in the header (`7271ff23`)

Implements the **Beta tag** design handoff (option **1e** on dark, **2c** on light): a small static "Beta" marker to the right of the Academy lockup, flagging the platform as pre-release. It is built from the achievement-badge vocabulary — flat fill, full keyline, hard 2px offset shadow — so it reads as part of the same family as the patches, chips and level bands rather than as a generic status pill.

**Files**
- `apps/web/src/components/layout/beta-tag.tsx` — new. A `<span class="beta-tag">` rendering `t("common.beta")`. Label only, no interaction.
- `apps/web/src/components/layout/header.tsx` — both lockups (desktop `lg+` and the `<lg` top bar) gain a flex brand container: `<div flex items-center gap-[10px]><Link>…lockup…</Link><BetaTag/></div>`. The tag is a **sibling** of the link, not a child.
- `apps/web/src/styles/globals.css` — `.beta-tag` + `[data-theme="dark"] .beta-tag`, appended at the end of the file with the other unlayered chrome.
- `apps/web/src/messages/{en,es,pt-BR}.json` — `common.beta = "Beta"`, inserted after `appName`. Same word in all three locales; uppercase is CSS, not typed.

**Spec conformance** — measured by computed style in Chromium, both themes, 1280 and 390 wide:

| property | spec | measured |
|---|---|---|
| dark fill / label / keyline+shadow | `#F1E9D2` / `#33312C` / `#55524C` | ✓ |
| light fill / label / keyline+shadow | `#FDE68A` / `#19231B` / `#19231B` | ✓ |
| type | Nunito 900 · 12px · lh 1 · ls 1.2px · uppercase | ✓ |
| radius · padding · shadow | 5px · `4px 10px 3px` · `0 2px 0` | ✓ |
| gap from wordmark | 10px | 10px |
| vertical centre | on the lockup box, not the 56px band | 0px offset |
| visible instances per breakpoint | 1 | 1 |

**Decisions worth a reviewer's eye**
- **Theme direction is inverted from the handoff CSS.** The handoff writes dark as the default and `[data-theme="light"]` as the override; this codebase is light-on-`:root` and `[data-theme="dark"]` as the override. Values are identical, only the cascade is flipped.
- **Tokens vs literals.** Dark keyline/shadow read `var(--keyline)` and light keyline/label/shadow read `var(--ink-dark)` — both are exact matches to existing tokens, so the tag stays in step with the rest of the chrome. The two fills (`#f1e9d2`, `#fde68a`) and the dark label (`#33312c`) are literals: the handoff asked to reuse a warm-cream token if one existed (none does), and `#fde68a` exists only as `--gold-hi` / `--lv-band`, whose semantics the tag should not be coupled to. `#33312c` exists only as `--keyline-disabled` — different role, not reused.
- **Sibling, not child, of the link.** Keeps the tag out of the link's hit area and accessible name, so "Beta" is announced once, after "Superteam Academy", as the handoff's a11y section asks. The `alt` on the lockup image is unchanged.
- **Border is authored at 1.5px** as specced. At 1× DPR Chromium snaps the *used* value to 1px; it renders at 1.5px on retina. Same behaviour as the existing 2.5px `.nav-pill` and 1.5px `.avatar-ink`.
- **Amber collision, accepted per handoff:** `#FDE68A` is also the Learner band fill and leaderboard first place. In the header it is spatially far from both. Revisit if amber picks up a stricter meaning.
- The handoff's **optional link variant** (hover/press/focus) is **not** built — it says to confirm with design first.
- The handoff's "collapse to cap glyph" rule doesn't apply: both header lockups render the full wordmark at every breakpoint.

## 2. Achievement ring: fixed, spaced random sample (`d989fcf1`)

The CTA panel's 3D achievement ring showed the whole catalog (18). The ring is a fixed-radius circle, so the item count *is* the spacing — at 18 the arc per item fell below the width of one label and badges and names ran into each other at every breakpoint.

**Files**
- `apps/web/src/components/landing/achievement-ring.tsx` — `RING_SLOTS = 7`; renders a random sample of that size.
- `apps/web/src/components/landing/__tests__/achievement-ring.test.tsx` — new, 5 cases.

**Why seven.** Worst-case gap between *adjacent front-facing* neighbours, sampled across a full 360° turn at each breakpoint (far-side items are separated by depth and excluded):

| slots | mobile 390 | tablet 768 | desktop 1280 |
|---|---|---|---|
| 18 (before) | −85px | −41px | −10px |
| 9 | +2px | +27px | +37px |
| **7** | **+23px** | **+56px** | **+83px** |
| 6 | +41px | +84px | +111px |

Mobile is the binding constraint; 7 is the largest count that leaves a real gap there.

**Hydration safety — please check this specifically.** The draw runs in `useEffect`, never in render. `useState` is initialised with the catalog's *leading slice*, so the server pass and the client's first pass emit identical markup; the shuffle lands on the next paint. The effect keys off a joined-ids string (`catalogKey`) rather than the array reference, so a parent re-render handing down a fresh array cannot reshuffle the ring under the reader. There is an `eslint-disable-next-line react-hooks/exhaustive-deps` on that effect for exactly this reason — it is deliberate.

`sample()` draws distinct items via `splice` rather than a Fisher–Yates swap, because `noUncheckedIndexedAccess` makes the swap form need casts.

The "Unlock 18 achievements" copy below the ring is untouched and still correct — it counts the whole catalog; the ring is a sample of it.

## Verification

- `pnpm typecheck` ✓ · `pnpm lint` ✓ (one pre-existing `import/order` warning in an unrelated file)
- New ring test file: 5/5.
- Full `vitest run`: **3455 / 3456**. One failure I did not get to identify — the run was interrupted before I could capture the name. A prior full run on the identical ring change came back 3456/3456 after an earlier flake of 3, and nothing here reaches outside its own component, but I am not calling it verified. **Reviewer: please confirm CI is green, and if the same test fails, flag it.**
- Beta tag: rendered and measured in both themes at 1280/390 (table above).
- Ring: measured in-browser with the landing page temporarily pointed at `getAllAchievements()` (the deployed query needs on-chain data this environment can't reach). That stub is **not** in the diff.

## Commits

Both authored by David Potolski Lafetá; no co-author trailers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MJMV9QpjXQ42PVjgEeMQp4

---
_Generated by [Claude Code](https://claude.ai/code/session_01MJMV9QpjXQ42PVjgEeMQp4)_