### PR TITLE
copy: keep the second half of the hero wedge, not the first

### DIFF
--- a/apps/web/src/app/[locale]/(marketing)/__tests__/landing-client.test.tsx
+++ b/apps/web/src/app/[locale]/(marketing)/__tests__/landing-client.test.tsx
@@ -125,10 +125,10 @@ describe("LandingPageClient — LX-A1 deep-link CTAs", () => {
     expect(intake).toHaveAttribute("href", "/en/start");
   });
 
-  it("keeps the trimmed wedge as the hero line (owner 2026-08-24: one sentence, AI helps you understand it)", () => {
+  it("keeps the trimmed wedge as the hero line (owner 2026-08-24: one sentence, AI helps you understand why it works — #1174 trimmed the wrong half)", () => {
     renderLanding();
     expect(
-      screen.getAllByText(/AI helps you understand it/i).length
+      screen.getAllByText(/AI helps you understand why it works/i).length
     ).toBeGreaterThanOrEqual(1);
   });
 

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -111,7 +111,7 @@
   "landing": {
     "poweredBy": "Powered by",
     "heroTitle": "Learn Solana <hl>by building it</hl>.",
-    "heroWedge": "AI helps you understand it.",
+    "heroWedge": "AI helps you understand why it works.",
     "heroSubtitle": "Real code in your browser. XP for every lesson. A credential that lives in your wallet.",
     "exploreCourses": "Start building",
     "notSureWhereToStart": "Not sure where to start? Answer 4 taps",

--- a/apps/web/src/messages/es.json
+++ b/apps/web/src/messages/es.json
@@ -111,7 +111,7 @@
   "landing": {
     "poweredBy": "Con el apoyo de",
     "heroTitle": "Aprende Solana <hl>construyendo</hl>.",
-    "heroWedge": "La IA te ayuda a entender.",
+    "heroWedge": "La IA te ayuda a entender por qué el código funciona.",
     "heroSubtitle": "Código real en tu navegador. XP por cada lección. Una credencial que vive en tu wallet.",
     "exploreCourses": "A construir",
     "notSureWhereToStart": "¿No sabes por dónde empezar? Son 4 toques",

--- a/apps/web/src/messages/pt-BR.json
+++ b/apps/web/src/messages/pt-BR.json
@@ -111,7 +111,7 @@
   "landing": {
     "poweredBy": "Com apoio de",
     "heroTitle": "Aprenda Solana <hl>construindo</hl>.",
-    "heroWedge": "A IA te ajuda a entender.",
+    "heroWedge": "A IA te ajuda a entender por que o código funciona.",
     "heroSubtitle": "Código de verdade no navegador. XP a cada lição. Credencial que mora na sua wallet.",
     "exploreCourses": "Bora construir",
     "notSureWhereToStart": "Não sabe por onde começar? São 4 toques",


### PR DESCRIPTION
#1174 cut the AI hero wedge to one sentence but kept the wrong half: "A IA te ajuda a entender." reads as a slogan about AI in general, because the pt-BR/es headline has no "it" for the verb to point at. This restores the second sentence of the original line in all three locales, spelling out "o código" / "el código" where the dropped first sentence used to carry it. Guard test updated to the new English string.