### PR TITLE
fix(layout): fluid page gutter so laptop widths stop running edge-to-edge

### DIFF
--- a/apps/web/src/app/[locale]/(marketing)/landing-client.tsx
+++ b/apps/web/src/app/[locale]/(marketing)/landing-client.tsx
@@ -446,7 +446,7 @@ export function LandingPageClient({
             />
           </div>
 
-          <div className="container w-full px-4 pb-10 pt-8 sm:pb-12 sm:pt-10 md:pb-14 md:pt-14">
+          <div className="page-gutter container w-full pb-10 pt-8 sm:pb-12 sm:pt-10 md:pb-14 md:pt-14">
             <div className="mx-auto grid max-w-6xl items-center gap-12 md:grid-cols-2 md:gap-16">
               <div>
                 <div
@@ -556,7 +556,7 @@ export function LandingPageClient({
 
         {/* ── How it works: build → earn → prove ── */}
         <section className="border-y-[2.5px] border-border bg-subtle">
-          <div className="container px-4 py-12 sm:py-20 md:py-28">
+          <div className="page-gutter container py-12 sm:py-20 md:py-28">
             <Reveal>
               <div className="mb-10 flex items-end justify-between sm:mb-16">
                 <h2 className="font-display text-2xl font-black tracking-[-0.5px] sm:text-3xl md:text-4xl">
@@ -692,7 +692,7 @@ export function LandingPageClient({
             aria-hidden="true"
           />
 
-          <div className="container relative px-4 py-16 text-center sm:py-20 md:py-28">
+          <div className="page-gutter container relative py-16 text-center sm:py-20 md:py-28">
             <h2 className="mb-4 font-display text-3xl font-black tracking-[-1px] text-white sm:text-4xl md:text-6xl">
               {t("ctaTitle")}
             </h2>

--- a/apps/web/src/app/[locale]/(marketing)/roadmap/page.tsx
+++ b/apps/web/src/app/[locale]/(marketing)/roadmap/page.tsx
@@ -33,7 +33,7 @@ export default async function RoadmapPage({
   return (
     <div className="flex min-h-screen flex-col">
       <main className="flex-1">
-        <div className="container max-w-4xl px-4 py-12 sm:py-16 md:py-24">
+        <div className="page-gutter container max-w-4xl py-12 sm:py-16 md:py-24">
           <h1 className="font-display text-3xl font-black tracking-tight sm:text-5xl">
             {t("title")}
           </h1>

--- a/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/lesson-client.tsx
+++ b/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/lesson-client.tsx
@@ -753,7 +753,12 @@ export function LessonPageClient({
             // negative margins and become a fixed-height flex column
             // (100dvh minus the fixed header's 60px offset). Top bar is
             // shrink-0; the IDE flex-fills the rest.
-            "max-w-[1600px] space-y-0 lg:-mb-8 lg:-mt-8 lg:flex lg:h-[calc(100dvh-60px)] lg:flex-col"
+            //
+            // The same trick horizontally at lg: the fluid --page-gutter would
+            // otherwise shrink the editor by ~34px a side on a laptop, so the
+            // workspace bleeds it back out and re-applies its own 32px inset.
+            // Below lg it keeps the page gutter like everything else.
+            "lg:page-gutter-bleed max-w-[1600px] space-y-0 lg:-mb-8 lg:-mt-8 lg:flex lg:h-[calc(100dvh-60px)] lg:flex-col lg:px-8"
           : "max-w-3xl space-y-6"
       }`}
     >

--- a/apps/web/src/app/[locale]/(platform)/layout.tsx
+++ b/apps/web/src/app/[locale]/(platform)/layout.tsx
@@ -26,7 +26,7 @@ export default function PlatformLayout({
           its hook throws outside a DynamicContextProvider, so it must never
           be a sibling. */}
       <DynamicWalletProvider>
-        <div className="container px-4 pb-20 pt-6 sm:px-6 md:pt-8 lg:px-8 lg:pb-8">
+        <div className="page-gutter container pb-20 pt-6 md:pt-8 lg:pb-8">
           {children}
         </div>
         <GamificationOverlays />

--- a/apps/web/src/components/layout/footer.tsx
+++ b/apps/web/src/components/layout/footer.tsx
@@ -13,7 +13,7 @@ export function Footer() {
 
   return (
     <footer className="border-t-[2.5px] border-border bg-subtle">
-      <div className="container px-4 py-10 sm:px-8 md:py-12">
+      <div className="page-gutter container py-10 md:py-12">
         <div className="flex flex-col items-center gap-6 md:flex-row md:justify-between">
           <div className="flex flex-col items-center gap-3 md:items-start">
             {/* Academy lockup leads; Superteam Brasil is the "Powered by"

--- a/apps/web/src/components/layout/header.tsx
+++ b/apps/web/src/components/layout/header.tsx
@@ -190,7 +190,7 @@ export function Header() {
   return (
     <header className="fixed left-0 right-0 top-0 z-[200]">
       <div className="relative bg-transparent backdrop-blur-md">
-        <div className="relative mx-auto flex h-[56px] max-w-[1600px] items-center px-[16px]">
+        <div className="page-gutter relative mx-auto flex h-[56px] max-w-[1600px] items-center">
           {/* Left: Logo (desktop lg+) */}
           {/* The Beta tag is a SIBLING of the wordmark's link, not a child:
               it belongs to the lockup but is neither clickable nor part of the

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -151,6 +151,13 @@
        chrome. The bar itself is 56px; the extra 4px is the gap under it. */
     --header-h: 60px;
 
+    /* The page's horizontal gutter. The `container` cap (1400px at 2xl) sits
+       at or above a typical laptop viewport, so on a ~1324px window the only
+       thing holding content off the edges was a fixed 16-32px padding. This
+       scales instead: ~20px on a phone, ~66px at 1324, capped at 96px so it
+       stops growing once the cap takes over. */
+    --page-gutter: clamp(1rem, 5vw, 6rem);
+
     /* ── Shadows ── */
     --shadow: 0 1px 3px rgba(0, 0, 0, 0.06), 0 2px 0 0 rgba(0, 0, 0, 0.06);
     --shadow-hover: 0 4px 0 0 rgba(0, 0, 0, 0.08);
@@ -1188,6 +1195,18 @@
      because the size modifier has to override the variant's shadow, and two
      arbitrary `shadow-[...]` utilities resolve by stylesheet order, not by the
      order they appear in the class string. */
+  /* ── Page gutter ──────────────────────────────────────────────
+     The horizontal padding every page-level shell uses, and its inverse for
+     the one element that must stay as wide as it is today (the lesson
+     workspace, which already cancels the platform shell's vertical padding
+     the same way). */
+  .page-gutter {
+    padding-inline: var(--page-gutter);
+  }
+  .page-gutter-bleed {
+    margin-inline: calc(-1 * var(--page-gutter));
+  }
+
   .btn-ink {
     --btn-line: var(--ink-line);
     border: 2px solid var(--btn-line);


### PR DESCRIPTION
On a 1324px laptop window the landing page kept only ~36px of gutter and the platform shell ~54px, so content ran almost edge to edge — the container cap (1400px at 2xl) sits at or above that viewport, leaving a fixed 16-32px padding as the only side margin. This adds a `--page-gutter: clamp(1rem, 5vw, 6rem)` token next to `--header-h` plus a `.page-gutter` utility, and swaps the hardcoded `px-*` on every page-level shell for it: the platform layout, the three landing sections, roadmap, the footer, and the header's inner bar (so the wordmark now tracks the content gutter instead of sitting 16px in). The lesson workspace is exempt — it already cancels the shell's vertical padding at lg, and now cancels the gutter horizontally the same way via `.page-gutter-bleed` before re-applying its own `lg:px-8`, so the editor keeps exactly the width it has today; below lg it picks up the normal gutter. Config `container.padding` is left as-is since it is already overridden everywhere. Browser screenshots at 1324 and 1440 follow in a comment.
