### PR TITLE
docs(video): frame.md and motion grammar for Academy videos

### DIFF
--- a/docs/CUSTOMIZATION.md
+++ b/docs/CUSTOMIZATION.md
@@ -109,6 +109,12 @@ Swapping a font is an edit to the `next/font/google` import; the CSS variable is
 wired by Next's `variable` option, so neither `globals.css` nor the Tailwind
 config changes.
 
+### Video brand guide
+
+The same tokens, inverted for video: [`docs/video/frame.md`](video/frame.md) is the
+HyperFrames design spec for course primers and social cuts, with the motion rules in
+[`docs/video/MOTION.md`](video/MOTION.md).
+
 ### Theme switching
 
 `next-themes` with `attribute="data-theme"`, mounted by

--- a/docs/video/MOTION.md
+++ b/docs/video/MOTION.md
@@ -1,0 +1,25 @@
+# Motion grammar for Academy videos
+
+Paste into every HyperFrames brief alongside `frame.md`. frame.md says how a frame looks; this says how it moves.
+
+Source: hyperframes.heygen.com/prompting/motion (the eight rules) + /prompting/capstone (world-camera).
+
+Rules (each must be honoured, and the report must say where):
+
+1. Nothing ever fully stops. Every hold carries ambient idle: 1–2% breathing scale, slow drift, shimmer. The final second must NOT be a freeze: consecutive frames must differ. Write "settles into a gentle ambient idle", never "holds".
+2. The camera is an actor. One continuous camera move per scene: a 4–8% push-in, a slow orbit, or parallax (near layers travel further). Ease gently over a window slightly longer than the scene; never decay to a dead stop at the scene end.
+3. Overlapping action. No two elements share a start or end time. Stagger at irregular offsets; each offset clearly shorter than the animation it offsets. Delay supporting elements, never the focal one. Stagger what is happening, not what was already present.
+4. Compound properties only when they tell one story. Entrances ease OUT; exits ease IN; on-screen moves ease IN-OUT; impacts (stamp, press) ease IN.
+5. Overshoot and follow-through on transforms only; dragged parts (shadow, trailing panel) resolve a beat after the mover. Never overshoot a number.
+6. Depth planes. Background at a fraction of the camera rate, content at full, foreground at several times. One large blurred foreground element that actually OCCLUDES content proves the space; a second becomes decoration.
+7. Pacing by genre: 1.5–4 s per idea for showreel cuts; narrated lesson primers dwell longer but never stretch a 2-second idea to 8.
+8. Handmade imperfection stays reproducible: seed a PRNG once at composition start; step between held positions; no Math.random().
+
+Avoiding the slideshow (world-camera method):
+
+- Treat the film as one wide space the camera travels across. Name the persistent elements that survive scene boundaries (for us: the footage card, the code-rain ground, a rail/ruler that becomes the tick row).
+- Arrivals instead of cuts: the next region is already at the edge of frame before the camera reaches it; the previous exits by parallax.
+- Dwell: a genuine full stop of 1.5–2.5 s while the point lands (the alignment on "juntas", the tick snap on "ordena"), with ambient idle still running.
+- Forbid the slideshow explicitly in the brief: "no region may fade up centered, sit, and fade out while the camera waits."
+
+Test after render: extract the last 25 frames and confirm they are not bit-identical (ffmpeg -ss <end-1> … -frames:v 25, compare md5s).

--- a/docs/video/README.md
+++ b/docs/video/README.md
@@ -1,0 +1,14 @@
+# Academy video system
+
+Course primers, lesson intros and social cuts are rendered locally with
+[HyperFrames](https://hyperframes.heygen.com) (HTML compositions, deterministic MP4).
+Two files define the look and the motion:
+
+- `frame.md`: the platform design system for the camera (tokens, fonts, constructions, 3D).
+- `MOTION.md`: the eight motion rules and the world-camera method, plus the frozen-frame test.
+
+Setup: `npx skills add heygen-com/hyperframes` (core skills), then start a project with
+`/hyperframes` and copy `frame.md` into its root. Gate every render with
+`npx hyperframes check --snapshots`. Narration is the presenter's own clip (HeyGen avatar
+export, landscape) or local TTS; captions come from a local Whisper transcript as an
+on-screen rail plus a WebVTT sidecar per language.

--- a/docs/video/frame.md
+++ b/docs/video/frame.md
@@ -49,7 +49,7 @@ ground: "--bg + the .grid-bg fractal-noise tile + the hero's code rain at waterm
 
 3d:
 scene: "perspective 1000px on a stable parent, transform-style: preserve-3d on the body"
-footage-card: "continuous rotateY -6°→+6° / rotateX +3°→-3°, 14s sine - hero-card-idle"
+footage-card: "the hero card idle: rotateX 2°→-1.5°, rotateY -4°→4°, 9s ease-in-out, 1.6s delay, infinite - .hero-card-idle (globals.css); a video may widen the range for legibility, but the product's own values are these"
 builder-id: "both faces authored, back pre-rotated 180°, one 0→360 pose ladder" # achievement-patch-3d.tsx
 
 ---

--- a/docs/video/frame.md
+++ b/docs/video/frame.md
@@ -1,0 +1,76 @@
+<!-- HyperFrames design spec ("frame.md"): the platform's design system inverted for the
+     camera. Copy this file into the root of a HyperFrames project (or point the
+     /hyperframes-creative skill at it) and every scene is composed from these tokens.
+     Regenerate the token block from apps/web/src/styles/globals.css when the app changes;
+     the code is the source of truth, this file is the video-facing view of it. -->
+
+---
+
+version: 1
+name: Superteam Academy (video frame layer)
+description: >
+Not a brand-pack system: this is the PRODUCT's own design system, lifted by value from
+apps/web. Light theme, paper-white ground, ink-outlined white plates with hard offset
+shadows, one amber emphasis bar, deep-green primary. Nothing here was invented that the
+platform does not already ship.
+unit: the frame - 1920×1080
+source-of-truth: apps/web (globals.css, src/fonts, landing/hero-showcase.tsx, gamification/achievement-patch-3d.tsx)
+
+tokens: # apps/web/src/styles/globals.css, `:root` (light theme)
+bg: "#fafaf7"
+card: "#ffffff"
+card-alt: "rgba(0,0,0,.02)"
+text: "#1c1917"
+text-2: "#57534e"
+text-3: "#a8a29e"
+primary: "#0a7055"
+primary-hover: "#08604a"
+accent: "#f59e0b"
+ink-line: "#19231b"
+xpbar-fill: "#2ecc8e"
+lv-band-learner: "#fde68a"
+sol-grad: "linear-gradient(135deg,#9945ff,#00c2ff 50%,#14f195)"
+
+typography: # apps/web/src/fonts/\*.woff2, inlined base64
+display: { family: Nunito, weight: 800-900 } # headings
+body: { family: Plus Jakarta Sans, weight: 400-800 }
+mono: { family: JetBrains Mono, weight: 500-800 } # micro-labels, terminal chips
+
+constructions:
+plate: "background --card · 2px solid --ink-line · 0 3px 0 0 --ink-line" # .btn-ink
+press: "translateY(2px) on land" # .btn-ink:active
+chip-alt: "the plate with a --card-alt fill"
+chip-primary: "--primary fill, white label, --primary-hover outline + hard shadow"
+micro-label: "JetBrains Mono, uppercase, 0.22em tracking, --text-2"
+underline: "one --accent bar under a headline - the ONLY emphasis mark; never a coloured word"
+level-badge: "two clipped hexagons + drop-shadow filter" # level-badge.tsx
+xp-bar: "4px ink border, --xpbar-track ground, mint fill" # .dash-xp-track
+ground: "--bg + the .grid-bg fractal-noise tile + the hero's code rain at watermark contrast"
+
+3d:
+scene: "perspective 1000px on a stable parent, transform-style: preserve-3d on the body"
+footage-card: "continuous rotateY -6°→+6° / rotateX +3°→-3°, 14s sine - hero-card-idle"
+builder-id: "both faces authored, back pre-rotated 180°, one 0→360 pose ladder" # achievement-patch-3d.tsx
+
+---
+
+# Superteam Academy - Platform frame
+
+Read the source files, not this file, when they disagree. `hero-showcase.tsx` owns the
+Builder ID card, the loot chips and the code rain; `achievement-patch-3d.tsx` owns the
+two-faced 3D construction; `globals.css` owns every token, `.btn-ink`, `.lv-badge`,
+`.dash-xp-track` and `.grid-bg`; `layout.tsx` + `src/fonts/` own the three faces.
+
+## Rules
+
+- **Ground** - `#fafaf7` everywhere. No blobs. No brand-pack cream. No pure black; ink is `#1c1917`.
+- **Depth is real** - CSS `perspective` + `preserve-3d`, never a scale fake. Every card
+  carries the ink system's hard `0 3px 0 0` offset, which is the platform's own flat depth.
+- **Emphasis** - the amber bar, once. Never a coloured headline word.
+- **Type** - display Nunito 900; body/labels Plus Jakarta Sans; micro-labels and terminal
+  chips JetBrains Mono, uppercase, wide-tracked.
+- **No text over any shape or card edge** - the frame is audited by `hyperframes check`
+  and every remaining collision is an explicit, justified opt-out.
+- **Ragged left, off-grid** - the right rail carries the words; nothing is centred.
+- **Micro-labels run at `--text-2`, not `--text-3`.** The platform's own `--text-3` on
+  white is 2.5:1 and fails the render gate's WCAG AA check at video scale.


### PR DESCRIPTION
HyperFrames treats a frame.md as the brand guide for video. This adds the platform's, lifted by value from globals.css, src/fonts and the hero/achievement components, plus the motion rules the lesson primers follow and a short README on the local render loop. Linked from the theming section of CUSTOMIZATION.md. Docs only.