### PR TITLE
fix(teach): preview a PR's course in the reader's language

### DIFF
--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -221,6 +221,11 @@ prose and re-rendered images at their mirrored paths. Available languages are **
   `locale`; `[locale]` pages pass `params.locale`, `/api/content/*` routes derive it
   (`?locale=` → `NEXT_LOCALE` cookie → `Referer` path), request-scoped loaders use `getLocale()`.
   **No locale = source tree**: grading (`getLessonByIdForGrading`), admin and email never localize.
+- **Teacher preview** (`lib/teach/preview-store.ts`): the in-memory compile keeps its raw docs and
+  `l10n.json`; `findPreviewCourse(bundle, slug, locale)` projects through the same
+  `localizeCourseView` the live queries use, so a teacher checks each language of a bilingual PR
+  by switching the UI language. The listing stays in the source language and shows each course's
+  `availableLocales`.
 - **Fallback is to the course's own source language, never to `en`.** A course reached in a
   language it lacks still renders, in its source, and `Course.locale ≠ requested` drives the
   `CourseLanguageNotice`. An overlay is structurally unable to carry ids, `correct`, XP,

--- a/apps/web/src/app/[locale]/(platform)/teach/preview/[pr]/courses/[slug]/lessons/[id]/page.tsx
+++ b/apps/web/src/app/[locale]/(platform)/teach/preview/[pr]/courses/[slug]/lessons/[id]/page.tsx
@@ -4,6 +4,7 @@ import {
   getPreviewBundle,
   findPreviewCourse,
   findPreviewLesson,
+  previewCourseLessons,
 } from "@/lib/teach/preview-store";
 import {
   requirePreviewPage,
@@ -37,13 +38,16 @@ export default async function PreviewLessonPage({ params }: Props) {
   if (prNumber === null) notFound();
 
   const bundle = await getPreviewBundle(prNumber);
-  const course = findPreviewCourse(bundle, slug);
+  // The course, and therefore every lesson in it, in the UI language when the
+  // PR ships it — the lesson list, prev/next titles and the lesson body all
+  // come from this one localized projection.
+  const course = findPreviewCourse(bundle, slug, locale);
   if (!course) notFound();
 
-  const lesson = findPreviewLesson(bundle, course, id);
+  const lesson = findPreviewLesson(course, id);
   if (!lesson) notFound();
 
-  const allLessons = (bundle.lessonsByCourse[course._id] ?? []).map((l) => ({
+  const allLessons = previewCourseLessons(course).map((l) => ({
     _id: l._id,
     title: l.title,
     slug: l.slug,
@@ -57,6 +61,8 @@ export default async function PreviewLessonPage({ params }: Props) {
       courseSlug={course.slug}
       courseId={course._id}
       courseXpPerLesson={bundle.xpPerLessonById[course._id] ?? 0}
+      courseSourceLocale={course.sourceLocale ?? null}
+      courseAvailableLocales={course.availableLocales ?? null}
       hrefBase={previewHrefBase(locale, prNumber)}
       readOnly
     />

--- a/apps/web/src/app/[locale]/(platform)/teach/preview/[pr]/courses/[slug]/page.tsx
+++ b/apps/web/src/app/[locale]/(platform)/teach/preview/[pr]/courses/[slug]/page.tsx
@@ -35,7 +35,9 @@ export default async function PreviewCoursePage({ params }: Props) {
   if (prNumber === null) notFound();
 
   const bundle = await getPreviewBundle(prNumber);
-  const course = findPreviewCourse(bundle, slug);
+  // In the UI language when the PR ships it, its source language otherwise —
+  // switching the language picker is how a teacher checks each half.
+  const course = findPreviewCourse(bundle, slug, locale);
   if (!course) notFound();
 
   return (

--- a/apps/web/src/app/[locale]/(platform)/teach/preview/preview-client.tsx
+++ b/apps/web/src/app/[locale]/(platform)/teach/preview/preview-client.tsx
@@ -8,11 +8,13 @@ import {
   Lightning,
   Lock,
   Warning,
+  Translate,
 } from "@phosphor-icons/react";
 import { useLocale } from "next-intl";
 import { parsePrUrl } from "@/lib/teach/pr-url";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
+import { localeNames, type Locale } from "@/lib/i18n/config";
 
 interface PreviewLesson {
   _id: string;
@@ -27,6 +29,9 @@ interface PreviewCourse {
   title: string;
   description?: string;
   difficulty?: string;
+  /** The language the course is written in, and every language it ships. */
+  sourceLocale?: string;
+  availableLocales?: string[];
 }
 
 interface PreviewHead {
@@ -369,6 +374,21 @@ export function TeachPreviewClient() {
                         <span>
                           {t("course.lessons", { count: lessons.length })}
                         </span>
+                        {/* Which languages this PR ships the course in (content
+                            i18n). Open the course with the UI in each one to
+                            check that half; an untranslated locale falls back
+                            to the source with a notice, exactly as live. */}
+                        {course.availableLocales &&
+                          course.availableLocales.length > 0 && (
+                            <span className="flex items-center gap-1">
+                              <Translate size={12} weight="bold" />
+                              {t("course.languages", {
+                                list: course.availableLocales
+                                  .map((l) => localeNames[l as Locale] ?? l)
+                                  .join(" · "),
+                              })}
+                            </span>
+                          )}
                         {result.xpPerLessonById[course._id] != null && (
                           <span className="flex items-center gap-1 text-xp">
                             <Lightning size={12} weight="fill" />+

--- a/apps/web/src/lib/content/localize.ts
+++ b/apps/web/src/lib/content/localize.ts
@@ -226,3 +226,40 @@ export function localizedLessonMap(
   }
   return view;
 }
+
+// ── one course, one language ────────────────────────────────────────────────
+
+/** A course doc plus a lesson map, both already in ONE language. */
+export interface LocalizedCourseView {
+  doc: CourseDoc;
+  lessonsById: ReadonlyMap<string, LessonDoc>;
+  /** The language this view renders in — requested when the course has it, else the source. */
+  locale: string;
+  sourceLocale: string;
+  availableLocales: string[];
+}
+
+/**
+ * Resolve a course into the reader's language. Pure and store-independent so
+ * every reader of a bundle — the live query layer over the committed store,
+ * the teacher preview over an in-memory compile — resolves locale by exactly
+ * the same rule: `requested` when the course ships it (as source or overlay),
+ * the course's own source language otherwise, never English by default.
+ */
+export function localizeCourseView(
+  doc: CourseDoc,
+  overlays: Record<string, L10nCourseBundle> | undefined,
+  lessonsById: ReadonlyMap<string, LessonDoc>,
+  requested?: string
+): LocalizedCourseView {
+  const sourceLocale = docSourceLocale(doc);
+  const locale = resolveCourseLocale(requested, sourceLocale, overlays);
+  const overlay = locale === sourceLocale ? undefined : overlays?.[locale];
+  return {
+    doc: localizeCourseDoc(doc, overlay),
+    lessonsById: localizedLessonMap(lessonsById, overlay),
+    locale,
+    sourceLocale,
+    availableLocales: availableLocales(sourceLocale, overlays),
+  };
+}

--- a/apps/web/src/lib/content/queries.ts
+++ b/apps/web/src/lib/content/queries.ts
@@ -30,10 +30,10 @@ import { resolveRefs } from "./resolve-refs";
 import {
   availableLocales,
   docSourceLocale,
-  localizeCourseDoc,
+  localizeCourseView,
   localizeLessonDoc,
   localizedLessonMap,
-  resolveCourseLocale,
+  type LocalizedCourseView,
 } from "./localize";
 import {
   achievementsById,
@@ -149,26 +149,15 @@ const projectionDeps = { lessonsById };
  * Learner-facing queries take a trailing optional `locale` and route through
  * here; everything downstream (projectors, renderers) stays locale-blind.
  */
-interface LocalizedCourse {
-  doc: CourseDoc;
-  lessonsById: ReadonlyMap<string, LessonDoc>;
-  locale: string;
-  sourceLocale: string;
-  availableLocales: string[];
-}
+type LocalizedCourse = LocalizedCourseView;
 
 function localizeCourse(doc: CourseDoc, requested?: string): LocalizedCourse {
-  const overlays = l10nByCourseId.get(doc._id);
-  const sourceLocale = docSourceLocale(doc);
-  const locale = resolveCourseLocale(requested, sourceLocale, overlays);
-  const overlay = locale === sourceLocale ? undefined : overlays?.[locale];
-  return {
-    doc: localizeCourseDoc(doc, overlay),
-    lessonsById: localizedLessonMap(lessonsById, overlay),
-    locale,
-    sourceLocale,
-    availableLocales: availableLocales(sourceLocale, overlays),
-  };
+  return localizeCourseView(
+    doc,
+    l10nByCourseId.get(doc._id),
+    lessonsById,
+    requested
+  );
 }
 
 /** The locale fields a learner-facing `Course` projection carries — only when a locale was asked for. */

--- a/apps/web/src/lib/teach/__tests__/preview-l10n.test.ts
+++ b/apps/web/src/lib/teach/__tests__/preview-l10n.test.ts
@@ -1,0 +1,195 @@
+/* eslint-disable import/order -- vi.mock factories are hoisted above imports;
+   `server-only` and the env module must both be stubbed before the graph loads. */
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { gzipSync } from "node:zlib";
+import { stringify } from "yaml";
+
+vi.mock("server-only", () => ({}));
+
+const env = vi.hoisted(() => ({
+  serverEnv: { GITHUB_TOKEN: undefined as string | undefined },
+}));
+vi.mock("@/lib/env.server", () => env);
+
+import { compilePrPreview } from "../preview-compile";
+import {
+  findPreviewCourse,
+  findPreviewLesson,
+  previewCourseLessons,
+  type PreviewBundle,
+} from "../preview-store";
+import { makeTar, PNG_1X1 } from "@/lib/content/compile/__tests__/_fixtures";
+
+/**
+ * The teacher preview must let a teacher check BOTH halves of a bilingual PR
+ * before it is published. It compiles the PR in memory and used to project
+ * the raw source docs straight away, dropping the `l10n.json` the compiler
+ * had just produced — so every previewed course rendered in its source
+ * language whatever the UI locale, and never showed the language notice.
+ * These pin the preview to the live site's rule: the UI locale when the
+ * course ships it, the source otherwise, with the locale fields attached.
+ */
+
+const SHA = "e".repeat(40);
+const PR = 34;
+
+/** A PT-BR course with an EN overlay: strings, translated prose, a localized image. */
+function bilingualTarball(): Uint8Array {
+  const top = `solanabr-academy-courses-${SHA}`;
+  const course = `${top}/courses/demo`;
+  const lesson = `${course}/lessons/basics`;
+  const en = `${course}/l10n/en`;
+  const files: Record<string, string | Uint8Array> = {
+    [`${top}/skills.yaml`]: "- slug: pdas\n  label: PDAs\n",
+    [`${course}/course.yaml`]: stringify({
+      id: "course-demo",
+      slug: "demo",
+      sourceLocale: "pt-BR",
+      title: "Curso Demo",
+      description: "Descrição",
+      difficulty: "beginner",
+      duration: 1,
+      xpPerLesson: 10,
+      xpReward: 100,
+      modules: [{ key: "m", title: "Módulo", lessons: ["lesson-basics"] }],
+    }),
+    [`${course}/slots.lock.json`]: JSON.stringify({
+      version: 1,
+      slots: { "lesson-basics": 0 },
+      retired: [],
+      next: 1,
+    }),
+    [`${lesson}/lesson.yaml`]: stringify({
+      id: "lesson-basics",
+      slug: "basics",
+      title: "Fundamentos",
+      skills: ["pdas"],
+      blocks: [
+        { key: "intro", type: "prose", src: "intro.md" },
+        { key: "reflect", type: "openEnded", prompt: "O que aprendeu?" },
+      ],
+    }),
+    [`${lesson}/intro.md`]: "# Olá\n\n![d](assets/d.png)\n",
+    [`${lesson}/assets/d.png`]: new Uint8Array(PNG_1X1),
+    [`${en}/strings.yaml`]: stringify({
+      locale: "en",
+      course: { title: "Demo Course", modules: { m: { title: "Module" } } },
+      lessons: {
+        basics: {
+          title: "Basics",
+          blocks: { reflect: { prompt: "What did you learn?" } },
+        },
+      },
+    }),
+    [`${en}/lessons/basics/intro.md`]: "# Hello\n\n![d](assets/d.png)\n",
+    [`${en}/lessons/basics/assets/d.png`]: new Uint8Array(PNG_1X1),
+  };
+  return gzipSync(Buffer.from(makeTar(files)));
+}
+
+function stubGitHub(): void {
+  const tarball = bilingualTarball();
+  vi.stubGlobal(
+    "fetch",
+    vi
+      .fn()
+      .mockImplementationOnce(() =>
+        Promise.resolve(
+          new Response(
+            JSON.stringify({
+              head: { sha: SHA, ref: "feat/en" },
+              title: "Add an English translation",
+              state: "open",
+              user: { login: "someone" },
+            }),
+            { status: 200, headers: { "content-type": "application/json" } }
+          )
+        )
+      )
+      .mockImplementationOnce(() =>
+        Promise.resolve(new Response(new Uint8Array(tarball), { status: 200 }))
+      )
+      .mockImplementation(() =>
+        Promise.resolve(
+          new Response("[]", {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          })
+        )
+      )
+  );
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+async function compiled(): Promise<PreviewBundle> {
+  stubGitHub();
+  const r = await compilePrPreview(PR);
+  return r as unknown as PreviewBundle;
+}
+
+describe("teacher preview in the reader's language", () => {
+  it("keeps the PR's overlay, with its urls pointed at the preview asset route", async () => {
+    const b = await compiled();
+    const en = b.l10n["course-demo"]!.en!;
+    expect(en.course?.title).toBe("Demo Course");
+    // The localized image lives under the preview route, like every other asset.
+    expect(en.lessons!["lesson-basics"]!.blocks!.intro!.src).toContain(
+      `(/api/teach/preview/${PR}/assets/demo/l10n/en/basics/d.png)`
+    );
+    expect(b.assets.has("demo/l10n/en/basics/d.png")).toBe(true);
+  });
+
+  it("labels each listed course with the languages the PR ships", async () => {
+    const b = await compiled();
+    expect(b.courses[0]).toMatchObject({
+      title: "Curso Demo", // the listing stays in the source language
+      sourceLocale: "pt-BR",
+      availableLocales: ["pt-BR", "en"],
+    });
+  });
+
+  it("projects the course page in the UI locale when the PR ships it", async () => {
+    const b = await compiled();
+    const en = findPreviewCourse(b, "demo", "en")!;
+    expect(en.title).toBe("Demo Course");
+    expect(en.description).toBe("Descrição"); // untranslated leaf → source
+    expect(en.modules[0]!.title).toBe("Module");
+    expect(en.modules[0]!.lessons[0]!.title).toBe("Basics");
+    expect(en).toMatchObject({
+      sourceLocale: "pt-BR",
+      availableLocales: ["pt-BR", "en"],
+      locale: "en",
+    });
+  });
+
+  it("falls back to the source language, and says so, for a locale the PR lacks", async () => {
+    const b = await compiled();
+    const es = findPreviewCourse(b, "demo", "es")!;
+    expect(es.title).toBe("Curso Demo");
+    expect(es.locale).toBe("pt-BR"); // ≠ requested → the notice renders
+    const pt = findPreviewCourse(b, "demo", "pt-BR")!;
+    expect(pt.locale).toBe("pt-BR");
+    expect(findPreviewCourse(b, "nope", "en")).toBeNull();
+  });
+
+  it("the lesson page reads from the SAME localized course, so the body and the lesson list agree", async () => {
+    const b = await compiled();
+    const en = findPreviewCourse(b, "demo", "en")!;
+    const lesson = findPreviewLesson(en, "basics")!;
+    expect(lesson.title).toBe("Basics");
+    const [intro, reflect] = lesson.blocks as unknown as [
+      { src: string },
+      { prompt: string },
+    ];
+    expect(intro.src).toContain("# Hello");
+    expect(reflect.prompt).toBe("What did you learn?");
+    expect(previewCourseLessons(en).map((l) => l.title)).toEqual(["Basics"]);
+
+    const pt = findPreviewCourse(b, "demo", "pt-BR")!;
+    expect(findPreviewLesson(pt, "basics")!.title).toBe("Fundamentos");
+    expect(findPreviewLesson(pt, "nope")).toBeNull();
+  });
+});

--- a/apps/web/src/lib/teach/preview-compile.ts
+++ b/apps/web/src/lib/teach/preview-compile.ts
@@ -9,8 +9,10 @@ import {
   ASSET_PUBLIC_PREFIX,
 } from "@/lib/content/compile/compile-bundle";
 import { ContentValidationError } from "@/lib/content/compile/types";
+import type { L10nBundle } from "@/lib/content/compile/l10n";
 import { projectCourse } from "@/lib/content/project";
-import type { CourseProjectionDeps } from "@/lib/content/project";
+import { availableLocales, docSourceLocale } from "@/lib/content/localize";
+import type { CourseDoc, LessonDoc } from "@/lib/content/types";
 import { CONTENT_REPO } from "./pr-url";
 import { changedCourseDirs, changedCourseIds } from "./pr-files";
 
@@ -28,14 +30,6 @@ const API = "https://api.github.com";
 
 /** Ceiling on the tarball fetch + body read. Matches lib/content/prior-content. */
 const TARBALL_TIMEOUT_MS = 30_000;
-
-// Derived from the projector's own signature so this file needs no new exports
-// from `lib/content/project` — the doc shapes stay private to that module.
-type CourseDocT = Parameters<typeof projectCourse>[0];
-type LessonDocT =
-  CourseProjectionDeps["lessonsById"] extends ReadonlyMap<string, infer V>
-    ? V
-    : never;
 
 /**
  * `academy-courses` is PUBLIC, so every read here works unauthenticated (#830).
@@ -168,9 +162,25 @@ export async function fetchPrChangedFiles(number: number): Promise<string[]> {
  */
 export interface PreviewResult {
   head: PrHead;
+  /**
+   * Courses in their SOURCE language — the listing's view — each carrying
+   * `sourceLocale` / `availableLocales` so the teacher can see which
+   * languages the PR ships. The course and lesson preview pages do not read
+   * these: they project the raw docs below in the reader's locale through
+   * the same rule the live site uses (see `preview-store`).
+   */
   courses: Course[];
-  /** Hydrated lessons per course id, in course order. */
+  /** Hydrated lessons per course id, in course order (source language). */
   lessonsByCourse: Record<string, Lesson[]>;
+  /**
+   * The raw compiled docs and the PR's translation overlays (content i18n),
+   * with every asset url already pointed at the preview asset route. This is
+   * what lets a previewed course render in Portuguese AND English from one
+   * compile — the fix the live site got in #1199 reached the preview here.
+   */
+  rawCourses: CourseDoc[];
+  rawLessonsById: Map<string, LessonDoc>;
+  l10n: L10nBundle;
   /**
    * Per-course XP, keyed by course id. Read from the raw doc because the
    * projected `Course` does not carry it — the live lesson page fetches it
@@ -265,21 +275,25 @@ export async function compilePrPreview(
 
   // Courses reference their lessons (`_ref`), so hydration runs through the
   // projector rather than a field on the lesson — lessons carry no back-pointer.
-  const lessonsById = new Map<string, LessonDocT>();
+  const lessonsById = new Map<string, LessonDoc>();
   for (const doc of readArray(files, "lessons.json")) {
-    lessonsById.set(String(doc._id), doc as unknown as LessonDocT);
+    lessonsById.set(String(doc._id), doc as unknown as LessonDoc);
   }
 
-  const courseDocs = readArray(files, "courses.json");
-  const courses = courseDocs.map((doc) =>
-    projectCourse(
-      doc as unknown as CourseDocT,
-      { lessonsById },
-      {
-        fullLessons: true,
-      }
-    )
-  );
+  // The PR's translation overlays, url-rewritten above like every other
+  // module. `{}` when no course in the PR ships an `l10n/` folder.
+  const l10nRaw = files.get("l10n.json");
+  const l10n: L10nBundle = l10nRaw ? (JSON.parse(l10nRaw) as L10nBundle) : {};
+
+  const courseDocs = readArray(files, "courses.json") as unknown as CourseDoc[];
+  const courses = courseDocs.map((doc) => {
+    const sourceLocale = docSourceLocale(doc);
+    return {
+      ...projectCourse(doc, { lessonsById }, { fullLessons: true }),
+      sourceLocale,
+      availableLocales: availableLocales(sourceLocale, l10n[doc._id]),
+    };
+  });
 
   // Flatten each projected course's modules back into an ordered lesson list —
   // the same order the curriculum renders, so prev/next in the preview matches.
@@ -300,7 +314,7 @@ export async function compilePrPreview(
   const xpPerLessonById: Record<string, number> = {};
   for (const doc of courseDocs) {
     const xp = doc.xpPerLesson;
-    xpPerLessonById[String(doc._id)] = typeof xp === "number" ? xp : 0;
+    xpPerLessonById[doc._id] = typeof xp === "number" ? xp : 0;
   }
 
   // Scope to the PR's own courses (#831) — dir names from the changed files,
@@ -313,6 +327,9 @@ export async function compilePrPreview(
     courses,
     assets,
     lessonsByCourse,
+    rawCourses: courseDocs,
+    rawLessonsById: lessonsById,
+    l10n,
     xpPerLessonById,
     changedCourseIds: changed,
     counts,

--- a/apps/web/src/lib/teach/preview-store.ts
+++ b/apps/web/src/lib/teach/preview-store.ts
@@ -1,6 +1,10 @@
 import "server-only";
 
 import type { Course, Lesson } from "@superteam-lms/types";
+import type { L10nBundle } from "@/lib/content/compile/l10n";
+import { localizeCourseView } from "@/lib/content/localize";
+import { projectCourse } from "@/lib/content/project";
+import type { CourseDoc, LessonDoc } from "@/lib/content/types";
 import { compilePrPreview, type PrHead } from "./preview-compile";
 
 /**
@@ -19,8 +23,13 @@ import { compilePrPreview, type PrHead } from "./preview-compile";
 /** The compiled bundle, in the shapes the real page components consume. */
 export interface PreviewBundle {
   head: PrHead;
+  /** Source-language projections — the listing's view. */
   courses: Course[];
   lessonsByCourse: Record<string, Lesson[]>;
+  /** Raw docs + overlays, so the pages can project in the reader's locale. */
+  rawCourses: CourseDoc[];
+  rawLessonsById: Map<string, LessonDoc>;
+  l10n: L10nBundle;
   xpPerLessonById: Record<string, number>;
   /** Asset bytes by public rel path — served by the preview asset route (#923). */
   assets: Map<string, Uint8Array>;
@@ -62,6 +71,9 @@ export async function getPreviewBundle(
     head: r.head,
     courses: r.courses as unknown as Course[],
     lessonsByCourse: r.lessonsByCourse as unknown as Record<string, Lesson[]>,
+    rawCourses: r.rawCourses,
+    rawLessonsById: r.rawLessonsById,
+    l10n: r.l10n,
     xpPerLessonById: r.xpPerLessonById,
     assets: r.assets,
   }));
@@ -73,18 +85,51 @@ export async function getPreviewBundle(
   return value;
 }
 
+/**
+ * A previewed course in the reader's language — the same resolution the live
+ * `getCourseBySlug(slug, locale)` performs, over the PR's own overlays:
+ * `locale` when the course ships it (as source or as `l10n/<locale>/`), the
+ * source language otherwise, with the locale fields attached so the real
+ * course/lesson components show the same language notice they show live.
+ * That is what lets a teacher check both halves of a bilingual PR before it
+ * is published, by switching the UI language.
+ */
 export function findPreviewCourse(
   bundle: PreviewBundle,
-  slug: string
+  slug: string,
+  locale?: string
 ): Course | null {
-  return bundle.courses.find((c) => c.slug === slug) ?? null;
+  const doc = bundle.rawCourses.find((c) => c.slug?.current === slug);
+  if (!doc) return null;
+  const view = localizeCourseView(
+    doc,
+    bundle.l10n[doc._id],
+    bundle.rawLessonsById,
+    locale
+  );
+  return {
+    ...projectCourse(
+      view.doc,
+      { lessonsById: view.lessonsById },
+      { fullLessons: true }
+    ),
+    sourceLocale: view.sourceLocale,
+    availableLocales: view.availableLocales,
+    locale: view.locale,
+  };
 }
 
+/** A localized course's lessons in curriculum order — what prev/next follows. */
+export function previewCourseLessons(course: Course): Lesson[] {
+  return (course.modules ?? []).flatMap((m) => (m.lessons ?? []) as Lesson[]);
+}
+
+/** A lesson of an already-localized course, so it is in the same language. */
 export function findPreviewLesson(
-  bundle: PreviewBundle,
   course: Course,
   lessonSlug: string
 ): Lesson | null {
-  const lessons = bundle.lessonsByCourse[course._id] ?? [];
-  return lessons.find((l) => l.slug === lessonSlug) ?? null;
+  return (
+    previewCourseLessons(course).find((l) => l.slug === lessonSlug) ?? null
+  );
 }

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -1665,7 +1665,8 @@
       "meta": "by {author} · {branch} · {sha}"
     },
     "course": {
-      "lessons": "{count} lessons"
+      "lessons": "{count} lessons",
+      "languages": "Languages: {list}"
     },
     "issues": {
       "title": "{count} content issue(s)",

--- a/apps/web/src/messages/es.json
+++ b/apps/web/src/messages/es.json
@@ -1665,7 +1665,8 @@
       "meta": "por {author} · {branch} · {sha}"
     },
     "course": {
-      "lessons": "{count} lecciones"
+      "lessons": "{count} lecciones",
+      "languages": "Idiomas: {list}"
     },
     "issues": {
       "title": "{count} problema(s) de contenido",

--- a/apps/web/src/messages/pt-BR.json
+++ b/apps/web/src/messages/pt-BR.json
@@ -1665,7 +1665,8 @@
       "meta": "por {author} · {branch} · {sha}"
     },
     "course": {
-      "lessons": "{count} lições"
+      "lessons": "{count} lições",
+      "languages": "Idiomas: {list}"
     },
     "issues": {
       "title": "{count} problema(s) de conteúdo",


### PR DESCRIPTION
Follow-up to #1199. The teacher preview (`/teach/preview`, #828/#831) was not localizing: a bilingual PR rendered in its source language whatever the UI locale, never showed the language notice, and a teacher had no way to check the translated half before publishing — the one thing the preview exists for. Checked against current `main` first: nothing since #1199 touched the preview, so this was still open.

## Root cause

`compilePrPreview` runs the real compiler in memory, then projected the raw source docs with `projectCourse` straight away and discarded the `l10n.json` the compiler had just produced. The live site localizes in `queries.ts` (`localizeCourse` → per-leaf merge → project); the preview never went through that path.

## Fix

- **`lib/content/localize.ts`** — `localizeCourseView(doc, overlays, lessonsById, requested)`: the "one course in one language" resolution extracted from `queries.ts` into a pure, store-independent function so the live query layer and the preview share **one implementation**. `queries.ts`'s `localizeCourse` now delegates to it (no behaviour change there).
- **`lib/teach/preview-compile.ts`** — the result keeps `rawCourses`, `rawLessonsById` and the parsed `l10n` (its asset urls already rewritten to the preview asset route like every other module). The source-language `courses` listing gains `sourceLocale` / `availableLocales`.
- **`lib/teach/preview-store.ts`** — `findPreviewCourse(bundle, slug, locale)` projects the raw doc through `localizeCourseView` with `fullLessons` and attaches the locale fields; `findPreviewLesson(course, slug)` and `previewCourseLessons(course)` read from that **already-localized** course, so the lesson body, the lesson list and prev/next titles agree.
- **Preview pages** — the course page passes the route locale; the lesson page builds `allLessons` from the localized course and threads `courseSourceLocale` / `courseAvailableLocales` into `LessonPageClient`, so both pages show the same `CourseLanguageNotice` the live site shows when a course lacks the reader's language.
- **Listing** (`preview-client.tsx`) — each course shows the languages the PR ships (`teachPreview.course.languages`, added to all three message files), so the teacher knows which UI languages to try.

The rule is exactly the live one: the UI locale when the course ships it (as source or `l10n/<locale>/`), the course's own source language otherwise — never English by default — and `locale ≠ requested` drives the notice. Switching the language picker is how a teacher checks each half.

## Reviewer focus

1. `findPreviewCourse` / `findPreviewLesson` signature change — the lesson finder now takes the localized `Course`, not the bundle. Both call sites updated; nothing else called them (`grep`).
2. `localizeCourseView` extraction is behaviour-preserving for the live path — `queries-l10n.test.ts` (unchanged) still passes.
3. Overlay urls: `l10n.json` goes through the same `/content-assets/` → `/api/teach/preview/<pr>/assets/` text rewrite as the other modules, and localized images are in `bundle.assets` under `<slug>/l10n/<locale>/…`, which the asset route serves by key. Asserted in the new test.

## Verification

- New `lib/teach/__tests__/preview-l10n.test.ts` (5 cases): a PT-BR course with an EN overlay compiled through the real path — overlay kept with preview-route urls and the localized image present; listing labelled `["pt-BR","en"]`; EN projection translated per leaf with `locale: "en"`; ES falls back to source with `locale: "pt-BR"`; the lesson page's list and body come from the same localized course.
- `pnpm typecheck` ✓ · `pnpm lint` ✓ (pre-existing `import/order` warning only)
- Targeted suites (content + teach + `/api/content`): 270/270.
- Full `apps/web` suite: **3515 / 3518** — the 3 failures are the same `src/lib/supabase/__tests__/*-execution.test.ts` embedded-Postgres migration tests that time out under the full parallel run and pass in isolation (confirmed 39/39 on #1199); nothing here touches them. **Reviewer: please confirm CI.**
- Not rendered in a browser: the preview compiles a live GitHub PR, and `api.github.com` is unreachable from this environment. The behaviour is covered end-to-end by the test above through the shipped compile path.

## Commit

Authored by David Potolski Lafetá; no co-author trailers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MJMV9QpjXQ42PVjgEeMQp4

---
_Generated by [Claude Code](https://claude.ai/code/session_01MJMV9QpjXQ42PVjgEeMQp4)_