### PR TITLE
fix(lesson): reading lessons use the page column, not a 768px band

### DIFF
--- a/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/blocks/prose-block.tsx
+++ b/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/blocks/prose-block.tsx
@@ -134,7 +134,11 @@ export function ProseBlock({ block, ctx }: BlockRenderProps) {
   }, [ctx, t]);
 
   return (
-    <div className="prose max-w-3xl dark:prose-invert">
+    // `max-w-none` cancels the typography plugin's own 65ch cap and adds
+    // none of its own: the PARENT owns the width. On a reading lesson that is
+    // the page column; inside a challenge's instructions rail it is the rail,
+    // which is narrower than any cap this could carry.
+    <div className="prose max-w-none dark:prose-invert">
       <ReactMarkdown
         remarkPlugins={[remarkGfm]}
         rehypePlugins={[rehypeRaw, rehypeHighlight]}

--- a/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/lesson-client.tsx
+++ b/apps/web/src/app/[locale]/(platform)/courses/[slug]/lessons/[id]/lesson-client.tsx
@@ -759,7 +759,14 @@ export function LessonPageClient({
             // workspace bleeds it back out and re-applies its own 32px inset.
             // Below lg it keeps the page gutter like everything else.
             "lg:page-gutter-bleed max-w-[1600px] space-y-0 lg:-mb-8 lg:-mt-8 lg:flex lg:h-[calc(100dvh-60px)] lg:flex-col lg:px-8"
-          : "max-w-3xl space-y-6"
+          : // Reading lessons use the page's own column, the same one the
+            // course page fills (#1206). They used to sit in a 768px band
+            // centred inside it, which on a laptop left ~34% of the width
+            // empty on each side and made a lesson look narrower than the
+            // course it belongs to. The platform shell's `container` +
+            // `--page-gutter` already cap and inset the page; capping again
+            // here was the only reason the two screens disagreed.
+            "space-y-6"
       }`}
     >
       <CourseLanguageNotice

--- a/apps/web/src/components/lessons/__tests__/lesson-reading-width.test.tsx
+++ b/apps/web/src/components/lessons/__tests__/lesson-reading-width.test.tsx
@@ -1,0 +1,85 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, cleanup } from "@testing-library/react";
+import { NextIntlClientProvider } from "next-intl";
+import type { Lesson } from "@superteam-lms/types";
+import messages from "@/messages/en.json";
+import { ProseBlock } from "@/app/[locale]/(platform)/courses/[slug]/lessons/[id]/blocks/prose-block";
+import type { BlockContext } from "@/app/[locale]/(platform)/courses/[slug]/lessons/[id]/blocks/types";
+
+/**
+ * A reading lesson used to sit in a 768px band centred inside the page column
+ * the course page fills, so the same course looked narrower once you opened a
+ * lesson. Two caps stacked to produce it: the lesson shell's `max-w-3xl` and
+ * this block's own.
+ *
+ * The rule now is that the PARENT owns the width — the page column on a
+ * reading lesson, the instructions rail inside a challenge. That makes this
+ * block's contract "carry no cap of my own", which is what these pin: a cap
+ * here would silently re-narrow the reading column, and the typography
+ * plugin's own 65ch default would narrow it further still if `max-w-none`
+ * were ever dropped.
+ *
+ * jsdom has no layout engine, so the widths themselves are measured in a real
+ * browser (see the PR); what is checkable here is the class contract that
+ * produces them.
+ */
+
+const lesson = {
+  _id: "lesson-x",
+  title: "Hash everything",
+  slug: "hash-everything",
+  blocks: [],
+} as unknown as Lesson;
+
+function ctx(): BlockContext {
+  return {
+    lesson,
+    courseSlug: "course",
+    courseId: "c1",
+    locale: "en",
+    isEnrolled: true,
+    isCompleted: false,
+    lessonNumber: 2,
+    xpReward: 30,
+    earnedXp: null,
+    onEnroll: vi.fn(),
+    setProof: vi.fn(),
+    setQuizAnswered: vi.fn(),
+    setBlockDone: vi.fn(),
+    aiSuppressed: false,
+    capstoneAiOff: false,
+    buildUuid: null,
+    programKeypairSecret: null,
+    resetBuild: vi.fn(),
+  } as unknown as BlockContext;
+}
+
+function renderProse() {
+  const { container } = render(
+    <NextIntlClientProvider locale="en" messages={messages}>
+      <ProseBlock
+        block={{ _type: "prose", key: "p1", src: "Body copy." } as never}
+        ctx={ctx()}
+      />
+    </NextIntlClientProvider>
+  );
+  return container.querySelector(".prose") as HTMLElement;
+}
+
+afterEach(cleanup);
+
+describe("prose blocks take their width from the parent", () => {
+  it("cancels the typography plugin's 65ch default instead of replacing it with another cap", () => {
+    expect(renderProse().className).toContain("max-w-none");
+  });
+
+  it("carries no width cap of its own", () => {
+    const classes = renderProse().className.split(/\s+/);
+    // `max-w-none` is the cancellation, not a cap; anything else here would
+    // re-narrow a reading lesson or over-narrow a challenge's rail.
+    expect(
+      classes.filter((c) => c.startsWith("max-w-") && c !== "max-w-none")
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
A reading lesson sat in a 768px column centred inside the page, while the course page it belongs to fills that page. On a 1440 laptop the lesson used 768 of 1256 available pixels — 39% of the width empty on either side — so the same course looked narrower the moment you opened a lesson.

## Cause

Two caps stacked on the reading path:

1. `lesson-client.tsx` — the non-challenge branch of the shell carried `max-w-3xl`.
2. `blocks/prose-block.tsx` — the prose wrapper carried `max-w-3xl` of its own.

The platform shell (`.page-gutter.container`) already caps and insets every page. Capping again here was the only reason the two screens disagreed.

## Change

The shell takes the page column, and the prose block carries `max-w-none` so the **parent owns the width** — the page column on a reading lesson, the instructions rail inside a challenge. `max-w-none` is a cancellation, not a new cap: without it the typography plugin's own `max-width: 65ch` would apply and narrow the column to ~650px.

Two files, plus a test.

## Measured — content column, in a real browser

| viewport | lesson before | lesson after | course page |
|---|---|---|---|
| 1920 | 768 | **1208** | 1208 |
| 1440 | 768 | **1256** | 1256 |
| 1280 | 768 | **1152** | 1152 |

Exact parity with the course page at every breakpoint.

## Challenges are not broken — measured, not assumed

The change is on the **non-challenge branch** of the shell, so challenge geometry is untouched by construction. Confirmed by measuring the same page before and after (`git stash` for the baseline):

| viewport | split width | panes | horizontal page scroll |
|---|---|---|---|
| 1920 | 1920 → 1920 | 840 / 184 / 840 → identical | false → false |
| 1440 | 1440 → 1440 | 600 / 184 / 600 → identical | false → false |
| 1280 | 1280 → 1280 | 520 / 184 / 520 → identical | false → false |

The full-bleed split, both panes and the divider land on the same pixels. **One difference to know about:** inside the instructions rail at ≥~1700px, its prose now fills the rail's 906px content box instead of stopping at 768. The rail's own geometry does not move and it scrolls independently, so nothing overflows — I traced the ancestor chain to confirm the prose sits exactly inside the rail's padding rather than escaping it. Below ~1700px the rail is narrower than 768 anyway, so it is byte-identical there.

## The trade-off you should see before merging

Matching the course page's **column** means the paragraph **measure** also widens, and it lands wider than the course page's own body text:

| | line length |
|---|---|
| lesson before | 91 characters |
| lesson after | **137–149 characters** |
| course page body copy | 94–108 characters |

144 characters at 1440 is long for continuous prose — the usual comfortable range is 45–90. I built exactly what was asked (the space matches the course screen), and the rendered result reads fine to me because the font is 16px with generous leading, but you are the one who will read a full lesson in it.

If you want the space back without the line length, the one-line alternative is capping the reading shell at `max-w-5xl` (1024px, ~121 chars) or `max-w-4xl` (896px, ~106 chars — almost exactly the course page's own measure). Say which and it is a one-word change.

## Verification

- `pnpm typecheck` ✓ · `pnpm lint` ✓
- New `lesson-reading-width.test.tsx` (2 cases) pins the prose block's contract: it cancels the 65ch default and carries no cap of its own, so neither a reading column nor a challenge rail can be silently re-narrowed. jsdom has no layout engine, so the widths themselves are the browser measurements above.
- Full `apps/web` suite: **3520 / 3520**, no failures (the three embedded-Postgres tests that flaked under load on the last two PRs passed here too).
- Rendered at 1440 with the deployment gate locally stubbed (Supabase is unreachable from this environment; the stub is reverted and not in the diff — the diff is two component files and one test).

## Commit

Authored by David Potolski Lafetá; no co-author trailers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MJMV9QpjXQ42PVjgEeMQp4

---
_Generated by [Claude Code](https://claude.ai/code/session_01MJMV9QpjXQ42PVjgEeMQp4)_