### PR TITLE
fix(ai-partner): reject no-op propose edits instead of billing an unchanged diff

### DIFF
--- a/apps/web/src/app/api/ai/__tests__/partner-route.test.ts
+++ b/apps/web/src/app/api/ai/__tests__/partner-route.test.ts
@@ -249,6 +249,53 @@ describe("POST /api/ai/partner", () => {
     expect(res.status).toBe(502);
   });
 
+  it("502s a propose whose single edit replaces the buffer with itself", async () => {
+    // Owner-reported 2026-09-08: `search` byte-identical to `replace`. The
+    // search DOES occur, so the applicability check passed and the client
+    // rendered a diff card that changed nothing — for a billed turn.
+    stubGeminiFetch(
+      JSON.stringify({
+        type: "propose",
+        rationale: "The learner code is already correct.",
+        edits: [{ search: "let x = 1;", replace: "let x = 1;" }],
+        check: {
+          question: "Why?",
+          options: ["A", "B", "C"],
+          correctIndex: 0,
+          explanation: "Because.",
+        },
+      })
+    );
+    const { POST } = await import("../partner/route");
+    const res = await POST(makeRequest(VALID_BODY));
+    expect(res.status).toBe(502);
+    // Same class as an inapplicable edit: billed, not refunded.
+    expect(refundAssistTurn).not.toHaveBeenCalled();
+  });
+
+  it("502s a propose whose edits individually differ but net out to the input buffer", async () => {
+    stubGeminiFetch(
+      JSON.stringify({
+        type: "propose",
+        rationale: "Shuffle it around.",
+        edits: [
+          { search: "let x = 1;", replace: "let y = 1;" },
+          { search: "let y = 1;", replace: "let x = 1;" },
+        ],
+        check: {
+          question: "Why?",
+          options: ["A", "B", "C"],
+          correctIndex: 0,
+          explanation: "Because.",
+        },
+      })
+    );
+    const { POST } = await import("../partner/route");
+    const res = await POST(makeRequest(VALID_BODY));
+    expect(res.status).toBe(502);
+    expect(refundAssistTurn).not.toHaveBeenCalled();
+  });
+
   it("passes through a well-formed propose response, sealed and validated", async () => {
     stubGeminiFetch(PROPOSE_GEMINI_TEXT);
 

--- a/apps/web/src/app/api/ai/partner/route.ts
+++ b/apps/web/src/app/api/ai/partner/route.ts
@@ -133,10 +133,13 @@ interface ValidatedProposeResponse {
 }
 
 // Narrow the Gemini `edits` array. Each entry must be an object with a NON-empty
-// string `search` (empty is unlocatable) and a string `replace` (empty is a
-// valid deletion). Rejects a missing/empty/oversized list. The route does not
-// apply the edits — the client does, against the live buffer — but it still
-// enforces shape so a malformed payload 502s here rather than reaching the UI.
+// string `search` (empty is unlocatable), a string `replace` (empty is a valid
+// deletion), and `replace` must DIFFER from `search` — an edit that rewrites a
+// span to itself is as useless as an unlocatable one (owner-reported
+// 2026-09-08: it renders a diff card with nothing but unchanged lines).
+// Rejects a missing/empty/oversized list. The route does not apply the edits —
+// the client does, against the live buffer — but it still enforces shape so a
+// malformed payload 502s here rather than reaching the UI.
 function validateEdits(value: unknown): CodeEdit[] | null {
   if (!Array.isArray(value) || value.length === 0) return null;
   if (value.length > MAX_PROPOSE_EDITS) return null;
@@ -146,6 +149,7 @@ function validateEdits(value: unknown): CodeEdit[] | null {
     const e = item as Record<string, unknown>;
     if (typeof e.search !== "string" || e.search.length === 0) return null;
     if (typeof e.replace !== "string") return null;
+    if (e.replace === e.search) return null;
     edits.push({ search: e.search, replace: e.replace });
   }
   return edits;
@@ -669,10 +673,24 @@ export async function POST(request: NextRequest) {
       // as the guard for post-request buffer drift, which remains legitimate.
       // applyEdits is the exact sequential-replace the diff card runs, so the
       // server verdict and the client verdict can never disagree.
-      if (!applyEdits(code, validated.edits).ok) {
+      const applied = applyEdits(code, validated.edits);
+      if (!applied.ok) {
         console.error(
           "Gemini propose edits do not apply to the learner buffer"
         );
+        return NextResponse.json(
+          { error: "AI returned an invalid response" },
+          { status: 502 }
+        );
+      }
+      // Owner-reported 2026-09-08: the same dead card, reached the other way —
+      // edits that DO apply but leave the buffer byte-identical (the model
+      // "confirming" already-correct code by rewriting a span to itself). Each
+      // individual edit is now rejected by validateEdits, so what survives to
+      // here is the compound case: edits that differ one by one but cancel out.
+      // Same failure class as an inapplicable edit — 502, billed, not refunded.
+      if (applied.proposed === code) {
+        console.error("Gemini propose edits are a no-op");
         return NextResponse.json(
           { error: "AI returned an invalid response" },
           { status: 502 }


### PR DESCRIPTION
Gemini can return a propose whose edit has `search` byte-identical to `replace`. The search text does occur in the buffer, so the existing applicability check passed, the client rendered a diff card of nothing but unchanged lines, and the learner burned an assist (owner saw assists_used go 2 -> 3 of 8) for a click that changed nothing.

`validateEdits` now rejects any edit where `replace === search`, and the route additionally 502s when the edits apply but leave the buffer identical — the compound case where individual edits differ but cancel out. Distinct log line ("Gemini propose edits are a no-op") so the two are separable in logs.

Not refunded, matching the existing "edits do not apply to the learner buffer" branch directly above it: Gemini returned a 2xx and billed the tokens, so the assist stays spent. Same failure class, same billing treatment — no new billing path.

Two tests added to `partner-route.test.ts` (single identical edit, and two edits netting back to the input); both fail on main and pass here, and they assert `refundAssistTurn` is not called.