### PR TITLE
fix(challenge): show the compiler error, not cargo's preamble, on a failed build

### DIFF
--- a/apps/web/src/components/editor/__tests__/challenge-runner.build-error.test.tsx
+++ b/apps/web/src/components/editor/__tests__/challenge-runner.build-error.test.tsx
@@ -1,0 +1,89 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { NextIntlClientProvider } from "next-intl";
+import type { TestCase } from "@superteam-lms/types";
+import messages from "@/messages/en.json";
+import { ChallengeRunner } from "../challenge-runner";
+import type { ExecutionResult } from "../types";
+
+const h = vi.hoisted(() => ({
+  buildProgram: vi.fn(),
+}));
+
+vi.mock("@/lib/build-server/client", () => ({ buildProgram: h.buildProgram }));
+vi.mock("@superteam-lms/deploy", () => ({ setCachedBinary: vi.fn() }));
+
+/** Real cargo-build-sbf failure: the error sits well past 500 chars of preamble. */
+const STDERR = [
+  '[2026-09-08T12:00:01Z INFO  cargo_build_sbf] spawn: "/Users/x/.cache/solana/v1.43/platform-tools/rust/bin/rustc" "--version"',
+  '[2026-09-08T12:00:01Z INFO  cargo_build_sbf] spawn: "/Users/x/.cache/solana/v1.43/platform-tools/rust/bin/cargo" "build" "--release" "--target" "sbpf-solana-solana"',
+  "warning: dropping unsupported crate type `cdylib` for target `sbpf-solana-solana`",
+  "warning: two crate types defined, only the first is used",
+  "    Compiling counter v0.1.0 (/build)",
+  "error[E0107]: struct takes 4 lifetime arguments but 1 lifetime argument was supplied",
+  "   --> src/lib.rs:24:24",
+].join("\n");
+
+const tests: TestCase[] = [
+  {
+    id: "t1",
+    description: "Program compiles successfully",
+    input: "",
+    expectedOutput: "true",
+  },
+  {
+    id: "t2",
+    description: "Code contains a greet function",
+    input: "",
+    expectedOutput: "true",
+  },
+];
+
+beforeEach(() => {
+  h.buildProgram.mockReset();
+});
+
+function renderRunner(onResult: (r: ExecutionResult) => void) {
+  return render(
+    <NextIntlClientProvider locale="en" messages={messages}>
+      <ChallengeRunner
+        code={'use anchor_lang::prelude::*;\ndeclare_id!("Fg6");\n'}
+        tests={tests}
+        language="rust"
+        buildType="buildable"
+        onResult={onResult}
+        onSubmit={() => {}}
+        isComplete={false}
+        xpReward={50}
+      />
+    </NextIntlClientProvider>
+  );
+}
+
+describe("ChallengeRunner buildable failure output", () => {
+  it("shows the compiler error on test 0, not cargo's preamble", async () => {
+    h.buildProgram.mockResolvedValue({
+      success: false,
+      stderr: STDERR,
+      uuid: null,
+    });
+    const onResult = vi.fn();
+    renderRunner(onResult);
+
+    fireEvent.click(screen.getByRole("button"));
+
+    await waitFor(() => expect(onResult).toHaveBeenCalled());
+    const result = onResult.mock.calls[0]![0] as ExecutionResult;
+
+    expect(result.success).toBe(false);
+    const testResults = result.testResults ?? [];
+    expect(testResults[0]?.actualOutput).toBe(
+      "error[E0107]: struct takes 4 lifetime arguments but 1 lifetime argument was supplied --> src/lib.rs:24:24"
+    );
+    expect(testResults[0]?.actualOutput).not.toContain("INFO");
+    // Additional tests keep their generic message; full stderr stays available.
+    expect(testResults[1]?.actualOutput).toBe("Compilation failed");
+    expect(result.error).toContain("cargo_build_sbf");
+  });
+});

--- a/apps/web/src/components/editor/challenge-runner.tsx
+++ b/apps/web/src/components/editor/challenge-runner.tsx
@@ -9,6 +9,7 @@ import { Keypair } from "@solana/web3.js";
 import { setCachedBinary } from "@superteam-lms/deploy";
 import { executeRustCode } from "@/lib/rust/execute";
 import { buildProgram } from "@/lib/build-server/client";
+import { firstCompilerErrorLine } from "@/lib/challenge/compiler-error";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import type {
@@ -806,9 +807,12 @@ async function runBuildChallenge(
       return {
         testCase: tc,
         passed: result.success,
+        // On failure show the compiler diagnostic, not the head of stderr —
+        // that is always cargo-build-sbf's INFO/WARN preamble. Full stderr
+        // stays in `error` for the Output tab.
         actualOutput: result.success
           ? "Compilation successful"
-          : cleanStderr.slice(0, 500),
+          : firstCompilerErrorLine(cleanStderr, 300),
       };
     }
     // Additional tests: pass if build succeeded (future: check for specific patterns)

--- a/apps/web/src/lib/challenge/__tests__/compiler-error.test.ts
+++ b/apps/web/src/lib/challenge/__tests__/compiler-error.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import { firstCompilerErrorLine } from "../compiler-error";
+
+/** A real `cargo-build-sbf` failure: long INFO/WARN preamble, then the error. */
+const CARGO_STDERR = [
+  '[2026-09-08T12:00:01Z INFO  cargo_build_sbf] spawn: "/Users/x/.cache/solana/v1.43/platform-tools/rust/bin/rustc" "--version"',
+  '[2026-09-08T12:00:01Z INFO  cargo_build_sbf] spawn: "/Users/x/.cache/solana/v1.43/platform-tools/rust/bin/cargo" "build" "--release" "--target" "sbpf-solana-solana"',
+  "warning: dropping unsupported crate type `cdylib` for target `sbpf-solana-solana`",
+  "warning: `counter` (lib) generated 1 warning",
+  "    Compiling counter v0.1.0 (/build)",
+  "warning: two crate types defined, only the first is used",
+  "error[E0107]: struct takes 4 lifetime arguments but 1 lifetime argument was supplied",
+  "   --> src/lib.rs:24:24",
+  "    |",
+  "24  |     pub fn increment(ctx: Context<'info, Increment>) -> Result<()> {",
+  "    |                                    ^^^^^^^^^ expected 4 lifetime arguments",
+  "error: could not compile `counter` (lib) due to 1 previous error",
+].join("\n");
+
+describe("firstCompilerErrorLine", () => {
+  it("skips the cargo preamble and returns the error with its location", () => {
+    expect(firstCompilerErrorLine(CARGO_STDERR)).toBe(
+      "error[E0107]: struct takes 4 lifetime arguments but 1 lifetime argument was supplied --> src/lib.rs:24:24"
+    );
+  });
+
+  it("falls back when stderr holds no error line", () => {
+    const warningsOnly = [
+      "[INFO cargo_build_sbf] spawn: rustc --version",
+      "warning: unused variable: `ctx`",
+    ].join("\n");
+    expect(firstCompilerErrorLine(warningsOnly)).toBe(
+      "Program did not compile"
+    );
+    expect(firstCompilerErrorLine("")).toBe("Program did not compile");
+  });
+
+  it("strips ANSI colour codes", () => {
+    const coloured =
+      "\x1b[1m\x1b[32m   Compiling\x1b[0m counter v0.1.0\n" +
+      "\x1b[1m\x1b[31merror[E0425]\x1b[0m\x1b[1m: cannot find value `x` in this scope\x1b[0m\n" +
+      "\x1b[1m\x1b[34m   -->\x1b[0m src/lib.rs:9:5";
+    expect(firstCompilerErrorLine(coloured)).toBe(
+      "error[E0425]: cannot find value `x` in this scope --> src/lib.rs:9:5"
+    );
+  });
+
+  it("prefers a diagnostic line over an incidental 'error' match", () => {
+    const stderr = [
+      "   Compiling thiserror v1.0.63",
+      "error: linking with `cc` failed",
+    ].join("\n");
+    expect(firstCompilerErrorLine(stderr)).toBe(
+      "error: linking with `cc` failed"
+    );
+  });
+
+  it("still surfaces an incidental match when no diagnostic line exists", () => {
+    expect(firstCompilerErrorLine("  some error happened somewhere")).toBe(
+      "some error happened somewhere"
+    );
+  });
+
+  it("truncates to maxLength", () => {
+    const long = `error: ${"x".repeat(500)}`;
+    expect(firstCompilerErrorLine(long)).toHaveLength(200);
+    expect(firstCompilerErrorLine(long, 300)).toHaveLength(300);
+  });
+});

--- a/apps/web/src/lib/challenge/buildable-executor.ts
+++ b/apps/web/src/lib/challenge/buildable-executor.ts
@@ -58,8 +58,9 @@
  */
 
 import type { AdminTestCase } from "@superteam-lms/types";
-import type { ServerTestResult, SubmissionRunResult } from "./executor";
 import { serverEnv } from "@/lib/env.server";
+import type { ServerTestResult, SubmissionRunResult } from "./executor";
+import { firstCompilerErrorLine } from "./compiler-error";
 
 const BUILD_SERVER_URL = serverEnv.BUILD_SERVER_URL;
 const BUILD_SERVER_API_KEY = serverEnv.BUILD_SERVER_API_KEY;
@@ -85,9 +86,6 @@ interface BuildServerResponse {
   uuid: string | null;
   binary_b64?: string;
 }
-
-const ANSI_REGEX = /\x1b\[[0-9;]*m/g;
-const stripAnsi = (s: string): string => s.replace(ANSI_REGEX, "");
 
 /** Whether the build server is configured (and therefore grading can run). */
 export function isBuildServerConfigured(): boolean {
@@ -202,14 +200,8 @@ export async function runBuildableSubmission(
 
   // Explicit compile failure: a bad submission, not an outage. Surface the first
   // real compiler error line as a short, non-sensitive diagnostic (no answer
-  // key). Prefer a diagnostic line (`error[E1234]:` / `error:`) over incidental
-  // matches like a crate named "…-error" in cargo's "Compiling …" progress.
-  const lines = stripAnsi(data.stderr ?? "").split("\n");
-  const firstError =
-    lines.find((l) => /^\s*error(\[|:)/.test(l)) ??
-    lines.find((l) => l.includes("error")) ??
-    "Program did not compile";
-  return allFailed(tests, firstError.trim().slice(0, 200));
+  // key).
+  return allFailed(tests, firstCompilerErrorLine(data.stderr ?? ""));
 }
 
 /** Result of running a single test case — re-exported for callers/tests. */

--- a/apps/web/src/lib/challenge/compiler-error.ts
+++ b/apps/web/src/lib/challenge/compiler-error.ts
@@ -1,0 +1,36 @@
+/**
+ * Pick the line a learner actually needs out of a cargo build's stderr.
+ *
+ * `cargo-build-sbf` prints a long INFO/WARN preamble (`spawn: "…/rustc"
+ * --version`, the "two crate types defined" LTO warning) before it reaches the
+ * diagnostics, so the first N characters of stderr never contain the error.
+ * Shared by the server grader (`buildable-executor.ts`) and the browser runner
+ * (`challenge-runner.tsx`) so the in-editor Run agrees with the server verdict.
+ * Deliberately dependency-free: the runner is a client component.
+ */
+
+const ANSI_REGEX = /\x1b\[[0-9;]*m/g;
+
+/**
+ * The first real compiler diagnostic, plus its ` --> file:line:col` location
+ * when cargo printed one. Prefers a diagnostic line (`error[E0425]:` /
+ * `error:`) over incidental matches like a crate named "…-error" in cargo's
+ * "Compiling …" progress. Falls back to a generic message when stderr holds no
+ * error at all.
+ */
+export function firstCompilerErrorLine(
+  stderr: string,
+  maxLength = 200
+): string {
+  const lines = stderr.replace(ANSI_REGEX, "").split("\n");
+
+  let index = lines.findIndex((l) => /^\s*error(\[|:)/.test(l));
+  if (index === -1) index = lines.findIndex((l) => l.includes("error"));
+  if (index === -1) return "Program did not compile";
+
+  const parts = [lines[index]!.trim()];
+  const next = lines[index + 1]?.trim();
+  if (next?.startsWith("-->")) parts.push(next);
+
+  return parts.join(" ").slice(0, maxLength);
+}


### PR DESCRIPTION
On a failed buildable challenge the test panel showed the first 500 characters of cargo's stderr, which is always `cargo_build_sbf`'s INFO/WARN preamble (rustc --version spawns, the LTO warning) — the actual `error[E0107]: ...` line sits further down, so the learner saw nothing useful.

Test 0 now shows the first compiler diagnostic plus its `-->` location, capped at 300 chars; full stderr still goes to `error` for the Output tab, and the later tests keep their generic message. The selection logic the server grader already used moves into `lib/challenge/compiler-error.ts` so the in-editor Run and the server verdict agree (the helper is import-free, since the runner is a client component).

Unit tests cover a real cargo sample, ANSI colouring, no-error stderr and truncation, plus a runner-level test that clicks Run with a mocked build server and asserts the panel no longer shows the preamble.