### PR TITLE
ci(fuzz): notify on failure, fail on hangs, warp the clock, allowlist expected errors

### DIFF
--- a/.claude/skills/superteam-academy-dev/SKILL.md
+++ b/.claude/skills/superteam-academy-dev/SKILL.md
@@ -76,7 +76,7 @@ ENROLL → COMPLETE LESSONS → FINALIZE COURSE → ISSUE CREDENTIAL → CLOSE E
 | Programs       | Anchor 0.31+, Rust 1.82+                                                        |
 | Token Standard | Token-2022 (NonTransferable, PermanentDelegate, MetadataPointer, TokenMetadata) |
 | Credentials    | Metaplex Core NFTs (soulbound via PermanentFreezeDelegate)                      |
-| Testing        | Mollusk, LiteSVM (scenarios + fuzz)                                                |
+| Testing        | Mollusk, LiteSVM (scenarios + fuzz)                                             |
 | Client         | TypeScript, @coral-xyz/anchor, @solana/web3.js                                  |
 | Frontend       | Next.js 14+, React, Tailwind CSS                                                |
 | RPC            | Helius (DAS API for XP leaderboard + credential NFT queries)                    |

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -17,8 +17,11 @@ name: Fuzz (litesvm)
 #
 # Exit-code contract (fuzz binary): 0 = all iterations clean, 98 = preflight
 # smoke failed (harness/runtime broken, no fuzzing happened), 99 = crash
-# (violated invariant or unexpected program error). Wrapped in `timeout`, so a
-# clean full-window run surfaces as 124 (or 143 = 128+SIGTERM).
+# (violated invariant or unexpected program error). The binary self-stops at
+# FUZZ_MAX_SECONDS, so a clean run always exits 0 with a `coverage:` line; the
+# `timeout` wrapper firing (124, or 143 = 128+SIGTERM) means an iteration hung
+# and is a failure, not a full window. A failing run files/nudges a tracking
+# issue so a red nightly cannot go unnoticed again.
 
 on:
   schedule:
@@ -53,6 +56,10 @@ jobs:
     runs-on: ubuntu-latest
     # Job ceiling above the fuzz window so build + the run both fit.
     timeout-minutes: 40
+    # Scoped here rather than at workflow level: only this job files the alarm.
+    permissions:
+      contents: read
+      issues: write
     env:
       SOLANA_VERSION: "3.1.10"
       # 600s floor enforced below regardless of the dispatch input.
@@ -128,30 +135,42 @@ jobs:
           # coverage summary; `timeout` is the hard backstop.
           export FUZZ_MAX_SECONDS="${DURATION}"
           # SIGTERM at DURATION+60; SIGKILL 30s later if it ignores TERM.
+          # Tee'd so the completion check below can read the summary back.
           timeout --signal=TERM --kill-after=30s "$((DURATION + 60))s" \
-            cargo run --release --bin fuzz -- "${FUZZ_ITERATIONS}"
-          CODE=$?
+            cargo run --release --bin fuzz -- "${FUZZ_ITERATIONS}" 2>&1 | tee fuzz.log
+          CODE="${PIPESTATUS[0]}"
           echo "fuzzer exit code: ${CODE}"
+
+          fail() {
+            echo "FUZZ_FAILURE=$1" >> "$GITHUB_ENV"
+            echo "::error::$1"
+            exit 1
+          }
+
           case "${CODE}" in
             0)
+              # A run that stopped early — killed, OOM, output truncated — can
+              # still exit 0 through the pipe. The coverage summary is the only
+              # proof the driver reached its end.
+              if ! grep -q '^coverage:' fuzz.log; then
+                fail "Fuzzer exited 0 without printing a coverage line — the run did not complete."
+              fi
               echo "Fuzzing completed with no crashes."
               ;;
             124|143)
-              # 124 = GNU timeout reached; 143 = 128+SIGTERM. Either means the
-              # full window elapsed without the fuzzer reporting a crash.
-              echo "Fuzzing ran the full window with no crashes."
+              # 124 = GNU timeout reached; 143 = 128+SIGTERM. The binary stops
+              # itself at FUZZ_MAX_SECONDS, so `timeout` firing DURATION+60s
+              # later means an iteration hung — never a clean window.
+              fail "Fuzzer hung: killed by timeout ${DURATION}s+60s after the budget (exit ${CODE}). No coverage line."
               ;;
             98)
-              echo "::error::Preflight smoke failed — the program never executed, so nothing was fuzzed."
-              exit 1
+              fail "Preflight smoke failed — the program never executed, so nothing was fuzzed."
               ;;
             99)
-              echo "::error::Fuzzer reported a crash (exit 99). See the log + the crash artifact."
-              exit 1
+              fail "Fuzzer reported a crash (exit 99). See the log + the crash artifact."
               ;;
             *)
-              echo "::error::Fuzzer exited unexpectedly with code ${CODE}."
-              exit "${CODE}"
+              fail "Fuzzer exited unexpectedly with code ${CODE}."
               ;;
           esac
 
@@ -163,3 +182,47 @@ jobs:
           path: onchain-academy/tests/fuzz/crashes/
           if-no-files-found: ignore
           retention-days: 14
+
+      # A red nightly nobody sees is a nightly that does not exist — Trident was
+      # red for seven weeks. Same pattern as bcb-561-reverify-alarm.yml: the
+      # preinstalled `gh` CLI against the default token, no action to SHA-pin.
+      - name: File or nudge the failure issue
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          # Stable marker — the idempotency key. Never change it without
+          # closing the issue it currently tracks.
+          TITLE: "[alarm] nightly fuzz (litesvm) is failing"
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          REASON: ${{ env.FUZZ_FAILURE || 'The job failed before the fuzzer ran (build, preflight tests or setup).' }}
+        run: |
+          set -euo pipefail
+
+          # printf rather than an indented heredoc: YAML block-scalar indentation
+          # would otherwise land in the issue body as markdown code blocks.
+          summary="$(printf 'Run: %s\nReason: %s\n\nExit-code contract: **98** preflight smoke failed (the program never executed — nothing was fuzzed), **99** the fuzzer found a crash (invariant violation or unexpected program error; the fuzz-crashes artifact carries the seed and the instruction sequence), **124/143** the fuzzer hung past its budget, anything else an unexpected driver failure.' "$RUN_URL" "$REASON")"
+
+          # Client-side title match, not --search: the search index is
+          # eventually consistent and idempotency must not depend on it.
+          existing="$(gh issue list \
+            --repo "$GITHUB_REPOSITORY" \
+            --state all --limit 1000 \
+            --json number,state,title \
+            --jq "[.[] | select(.title == \"$TITLE\")][0] // empty")"
+
+          if [ -n "$existing" ]; then
+            num="$(echo "$existing" | jq -r '.number')"
+            state="$(echo "$existing" | jq -r '.state | ascii_downcase')"
+            if [ "$state" != "open" ]; then
+              echo "Tracking issue #$num is closed — reopening for a fresh failure."
+              gh issue reopen "$num" --repo "$GITHUB_REPOSITORY"
+            fi
+            gh issue comment "$num" --repo "$GITHUB_REPOSITORY" \
+              --body "$(printf 'Nightly fuzz failed again.\n\n%s' "$summary")"
+            echo "Nudged #$num."
+            exit 0
+          fi
+
+          gh issue create --repo "$GITHUB_REPOSITORY" --title "$TITLE" \
+            --body "$(printf 'The nightly fuzz job (.github/workflows/fuzz.yml) failed.\n\n%s\n\nClose this issue once the nightly is green again; it is reopened and nudged on the next failure.' "$summary")"
+          echo "Filed the tracking issue."

--- a/docs/AUDIT-REPORT.md
+++ b/docs/AUDIT-REPORT.md
@@ -207,7 +207,7 @@ Kani toolchain is provisioned (not installed in this environment).
 ## 6. Deploy readiness
 
 - All gates green post-hardening: host parity (§4), dual-VM differential,
-  unmodified TS acceptance suite, bounded proofs, Trident fuzz smoke.
+  unmodified TS acceptance suite, bounded proofs, litesvm fuzz smoke.
 - Measured CU after hardening: **−39.2%** total vs Anchor
   ([tests/CU_COMPARISON.md](../onchain-academy/tests/CU_COMPARISON.md)); binary
   −70% (672 KB → 202 KB).

--- a/onchain-academy/scripts/select-program.sh
+++ b/onchain-academy/scripts/select-program.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Active-slot installer: everything downstream (Trident, the CU harness) loads
+# Active-slot installer: everything downstream (the CU harness) loads
 # target/deploy/onchain_academy.so. This script installs the pinocchio build
 # into that slot.
 #

--- a/onchain-academy/tests/fuzz/src/lib.rs
+++ b/onchain-academy/tests/fuzz/src/lib.rs
@@ -4,7 +4,10 @@
 //! 09-2026) with the same coverage: one iteration initializes the platform and
 //! creates a course with fuzzed economics, then runs a random sequence of
 //! `enroll` / `complete_lesson` / `finalize_course` flows and checks the same
-//! two invariants.
+//! two invariants. Two flows the Trident harness never had were added in
+//! 09-2026 — `close_enrollment` (unenroll) and a close/recreate of the course —
+//! along with a seeded clock warp between flows, without which every
+//! time-dependent branch in the program was unreachable.
 //!
 //! Everything is derived from a single u64 seed: given the seed the exact same
 //! instruction sequence replays, so a crash file is a reproduction recipe.
@@ -93,24 +96,62 @@ pub struct Crash {
 
 pub type FuzzResult<T> = Result<T, Crash>;
 
-/// Program errors that are *findings*, not valid rejections.
+/// Error codes the fuzzer explicitly tracks so the coverage line can prove the
+/// time-dependent branches were reached (F-3).
+pub const ERR_UNENROLL_COOLDOWN: u32 = 6008;
+pub const ERR_STALE_ENROLLMENT: u32 = 6034;
+
+/// Is this transaction error an *expected* rejection of fuzzed input?
 ///
-/// A fuzzed instruction is expected to be refused all the time — a `Custom(n)`
-/// error is the program working. These variants instead mean the program
-/// aborted, ran away with compute, or could not be executed at all. The last
-/// one is what seven weeks of red Trident nightlies actually were.
-fn is_unexpected(err: &TransactionError) -> bool {
+/// Allowlist, not denylist: a fuzzer that treats "anything I have not seen" as
+/// normal cannot report the errors that matter. Only these mean "the runtime or
+/// the program refused a badly-shaped input"; everything else — the runtime
+/// guards (`UnbalancedInstruction`, `ModifiedProgramId`,
+/// `ExternalAccountDataModified`, `PrivilegeEscalation`), an abort
+/// (`ProgramFailedToComplete`), a runaway (`ComputationalBudgetExceeded`), a
+/// program that will not execute at all (`UnsupportedProgramId`, the seven-week
+/// Trident outage) — is a finding.
+fn is_expected_rejection(err: &TransactionError) -> bool {
+    let TransactionError::InstructionError(_, ie) = err else {
+        // Transaction-level failures (fee payer, blockhash, account locks) are
+        // harness bugs, not program behavior. Surface them.
+        return false;
+    };
     matches!(
-        err,
-        TransactionError::InstructionError(
-            _,
-            InstructionError::ProgramFailedToComplete
-                | InstructionError::ComputationalBudgetExceeded
-                | InstructionError::ProgramEnvironmentSetupFailure
-                | InstructionError::UnsupportedProgramId
-                | InstructionError::InvalidError
-        )
+        ie,
+        // The program's own AcademyError codes — a rejection is it working.
+        InstructionError::Custom(_)
+            // Fuzzed instruction data that does not parse.
+            | InstructionError::InvalidInstructionData
+            | InstructionError::InvalidArgument
+            // An account of the wrong type, owner or size for the handler.
+            | InstructionError::InvalidAccountData
+            | InstructionError::InvalidAccountOwner
+            | InstructionError::UninitializedAccount
+            // A PDA the fuzzer asked to create twice (re-enroll, re-create).
+            | InstructionError::AccountAlreadyInitialized
+            // A required signer the fuzzed account set did not carry.
+            | InstructionError::MissingRequiredSignature
+            | InstructionError::MissingAccount
+            // A fuzzed learner short of rent/lamports for the account it opens.
+            | InstructionError::InsufficientFunds
+            // System-program create against a non-system-owned address.
+            | InstructionError::IllegalOwner
     )
+}
+
+/// Inverse of [`is_expected_rejection`] — kept as a named predicate because the
+/// send path reads better as "is this a finding".
+fn is_unexpected(err: &TransactionError) -> bool {
+    !is_expected_rejection(err)
+}
+
+/// The `Custom` code of a rejection, for the per-code counters.
+fn custom_code(err: &TransactionError) -> Option<u32> {
+    match err {
+        TransactionError::InstructionError(_, InstructionError::Custom(c)) => Some(*c),
+        _ => None,
+    }
 }
 
 /// Success counters per flow. Printed by the driver at the end of a run: a run
@@ -122,6 +163,14 @@ pub struct Stats {
     pub enrollments: u64,
     pub lessons_completed: u64,
     pub finalizations: u64,
+    pub unenrollments: u64,
+    pub course_recreations: u64,
+    /// Rejections with `UnenrollCooldown` (6008) — unreachable before the
+    /// clock started moving.
+    pub cooldown_rejections: u64,
+    /// Rejections with `StaleEnrollment` (6034) — unreachable before the
+    /// course-recreate flow existed.
+    pub stale_rejections: u64,
 }
 
 impl Stats {
@@ -130,6 +179,10 @@ impl Stats {
         self.enrollments += other.enrollments;
         self.lessons_completed += other.lessons_completed;
         self.finalizations += other.finalizations;
+        self.unenrollments += other.unenrollments;
+        self.course_recreations += other.course_recreations;
+        self.cooldown_rejections += other.cooldown_rejections;
+        self.stale_rejections += other.stale_rejections;
     }
 }
 
@@ -195,6 +248,11 @@ impl Session {
                 }
             }
             Err(failed) => {
+                match custom_code(&failed.err) {
+                    Some(ERR_UNENROLL_COOLDOWN) => self.stats.cooldown_rejections += 1,
+                    Some(ERR_STALE_ENROLLMENT) => self.stats.stale_rejections += 1,
+                    _ => {}
+                }
                 self.sequence
                     .push(format!("{label} -> err {:?}", failed.err));
                 let TransactionMetadata { logs, .. } = failed.meta;
@@ -242,7 +300,18 @@ impl Session {
         if !self.initialize()?.ok {
             return Ok(false);
         }
+        let created = self.create_fuzzed_course("create_course")?;
 
+        // creator (== authority) ATA, target of finalize creator-reward mints.
+        let authority = self.authority.pubkey();
+        let mint = self.xp_mint;
+        let ata = ixs::create_ata_idempotent(&authority, &authority, &mint);
+        self.send_checked("create_ata(creator)", &[ata], &[])?;
+        Ok(created)
+    }
+
+    /// One `create_course` with fuzzed economics under [`COURSE_ID`].
+    fn create_fuzzed_course(&mut self, label: &str) -> FuzzResult<bool> {
         // Bounded fuzzed economics: difficulty must be 1..=3 and lesson_count
         // >= 1 or create_course rejects it (a valid rejection, but we want a
         // usable course most iterations).
@@ -282,22 +351,16 @@ impl Session {
             creator_reward_xp,
             collection: None,
         };
-        let created = self
+        Ok(self
             .send_checked(
                 &format!(
-                    "create_course(lessons={lesson_count}, difficulty={difficulty}, \
+                    "{label}(lessons={lesson_count}, difficulty={difficulty}, \
                      xp_per_lesson={xp_per_lesson}, creator_reward_xp={creator_reward_xp})"
                 ),
                 &[ixs::create_course(&authority, &params)],
                 &[],
             )?
-            .ok;
-
-        // creator (== authority) ATA, target of finalize creator-reward mints.
-        let mint = self.xp_mint;
-        let ata = ixs::create_ata_idempotent(&authority, &authority, &mint);
-        self.send_checked("create_ata(creator)", &[ata], &[])?;
-        Ok(created)
+            .ok)
     }
 
     /// Enroll a brand-new learner, then provision its XP ATA.
@@ -374,6 +437,19 @@ impl Session {
         // the active_lessons mask. Nothing here retires a slot, so the course
         // stays dense and this equals the lesson_count used at creation.
         let Some(course) = self.course() else {
+            // A rejected `recreate_course` can leave the PDA freed; that is the
+            // fuzzer's own doing, not layout drift. Only a *populated* account
+            // that will not decode is a finding.
+            let pda = ixs::course_pda(COURSE_ID);
+            if self
+                .h
+                .svm
+                .get_account(&pda)
+                .is_none_or(|a| a.data.len() < 8)
+            {
+                self.sequence.push("finalize -> skipped (no course)".into());
+                return Ok(());
+            }
             return Err(Crash {
                 kind: "harness",
                 detail: "Course account could not be decoded — layout drift?".into(),
@@ -427,13 +503,104 @@ impl Session {
         Ok(())
     }
 
-    /// One random flow, as the Trident flow executor did.
-    pub fn step(&mut self) -> FuzzResult<()> {
-        match self.rng.gen_range(0..3u8) {
-            0 => self.flow_enroll(),
-            1 => self.flow_complete_lesson(),
-            _ => self.flow_finalize(),
+    /// Unenroll: `close_enrollment` reclaims the rent and frees the PDA.
+    ///
+    /// Gated on the 24h `UNENROLL_COOLDOWN_SECS`, so before the clock started
+    /// moving this flow could only ever have produced `UnenrollCooldown`
+    /// (6008). With [`Session::warp_clock`] both sides are reachable.
+    ///
+    /// Invariant: on success the Enrollment PDA is gone.
+    pub fn flow_close_enrollment(&mut self) -> FuzzResult<()> {
+        let Some((idx, learner)) = self.pick_learner() else {
+            self.sequence
+                .push("close_enrollment -> skipped (no learners)".into());
+            return Ok(());
+        };
+        let signer = self.learners[idx].insecure_clone();
+        let ix = ixs::close_enrollment(COURSE_ID, &learner);
+        let out = self.send_checked(
+            &format!("close_enrollment(learner#{idx})"),
+            &[ix],
+            &[&signer],
+        )?;
+        if !out.ok {
+            return Ok(());
         }
+        self.stats.unenrollments += 1;
+        // The learner no longer has an enrollment; drop it so later flows keep
+        // working against live ones.
+        self.learners.swap_remove(idx);
+
+        let pda = ixs::enrollment_pda(COURSE_ID, &learner);
+        if self
+            .h
+            .svm
+            .get_account(&pda)
+            .is_some_and(|a| !a.data.is_empty())
+        {
+            return Err(Crash {
+                kind: "invariant violated",
+                detail: "close_enrollment succeeded but the Enrollment PDA still has data"
+                    .to_string(),
+                logs: out.logs,
+            });
+        }
+        Ok(())
+    }
+
+    /// Close the course and recreate it under the same id, which claims the
+    /// next `Config.course_generation`. Every enrollment made before the
+    /// recreate is now superseded — the only way to reach `StaleEnrollment`
+    /// (6034) from `complete_lesson` / `finalize_course`.
+    pub fn flow_recreate_course(&mut self) -> FuzzResult<()> {
+        let authority = self.authority.pubkey();
+        let closed = self
+            .send_checked(
+                "close_course",
+                &[ixs::close_course(&authority, COURSE_ID)],
+                &[],
+            )?
+            .ok;
+        // Always recreate, even if the close was rejected, so the course PDA is
+        // never left freed for the following flows.
+        let recreated = self.create_fuzzed_course("recreate_course")?;
+        if closed && recreated {
+            self.stats.course_recreations += 1;
+        }
+        Ok(())
+    }
+
+    /// One random flow, as the Trident flow executor did.
+    ///
+    /// Weighted so the three original flows keep the coverage they had: the
+    /// recreate flow tears the course down, so it stays rare.
+    pub fn step(&mut self) -> FuzzResult<()> {
+        self.warp_clock();
+        match self.rng.gen_range(0..64u8) {
+            0..=17 => self.flow_enroll(),
+            18..=35 => self.flow_complete_lesson(),
+            36..=53 => self.flow_finalize(),
+            54..=62 => self.flow_close_enrollment(),
+            _ => self.flow_recreate_course(),
+        }
+    }
+
+    /// Advance the VM clock by a seeded delta before each flow.
+    ///
+    /// litesvm starts at `unix_timestamp = 0` and nothing moved it, so every
+    /// time-dependent branch in the program was unreachable. Most hops stay
+    /// inside the 24h unenroll cooldown (the 6008 rejection path); one in four
+    /// clears it (the success path).
+    fn warp_clock(&mut self) {
+        const UNENROLL_COOLDOWN_SECS: i64 = 86_400;
+        let delta = if self.rng.gen_bool(0.25) {
+            self.rng
+                .gen_range(UNENROLL_COOLDOWN_SECS + 1..=UNENROLL_COOLDOWN_SECS * 3)
+        } else {
+            self.rng.gen_range(1..=3_600)
+        };
+        self.h.warp(delta);
+        self.sequence.push(format!("warp(+{delta}s)"));
     }
 
     fn pick_learner(&mut self) -> Option<(usize, Pubkey)> {

--- a/onchain-academy/tests/fuzz/src/main.rs
+++ b/onchain-academy/tests/fuzz/src/main.rs
@@ -120,7 +120,17 @@ fn main() {
         started.elapsed().as_secs_f64()
     );
     println!(
-        "coverage: {} transactions, {} enrollments, {} lessons completed, {} finalizations",
-        stats.transactions, stats.enrollments, stats.lessons_completed, stats.finalizations
+        "coverage: {} transactions, {} enrollments, {} lessons completed, {} finalizations, \
+         {} unenrollments, {} course recreations",
+        stats.transactions,
+        stats.enrollments,
+        stats.lessons_completed,
+        stats.finalizations,
+        stats.unenrollments,
+        stats.course_recreations
+    );
+    println!(
+        "time-dependent rejections: {} UnenrollCooldown (6008), {} StaleEnrollment (6034)",
+        stats.cooldown_rejections, stats.stale_rejections
     );
 }

--- a/onchain-academy/tests/fuzz/tests/smoke.rs
+++ b/onchain-academy/tests/fuzz/tests/smoke.rs
@@ -16,12 +16,21 @@ fn same_seed_replays_the_same_sequence() {
     let run = |seed: u64| {
         let mut s = Session::new(seed);
         s.init_iteration().expect("init");
-        for _ in 0..8 {
+        // Long enough to draw every flow, including the rare recreate, and the
+        // per-flow clock warp — all of which must stay seed-derived.
+        for _ in 0..40 {
             s.step().expect("step");
         }
-        s.sequence
+        (s.sequence, s.stats)
     };
-    assert_eq!(run(42), run(42));
+    let (seq_a, stats_a) = run(42);
+    let (seq_b, stats_b) = run(42);
+    assert_eq!(seq_a, seq_b);
+    assert_eq!(format!("{stats_a:?}"), format!("{stats_b:?}"));
+    assert!(
+        seq_a.iter().any(|s| s.starts_with("warp(+")),
+        "the clock never moved"
+    );
 }
 
 /// Every flow must reach the program's success path. Without this a harness
@@ -46,4 +55,38 @@ fn flows_reach_their_success_paths() {
         "no complete_lesson succeeded: {stats:?}"
     );
     assert!(stats.finalizations > 0, "no finalize succeeded: {stats:?}");
+    assert!(
+        stats.unenrollments > 0,
+        "no close_enrollment succeeded: {stats:?}"
+    );
+    assert!(
+        stats.course_recreations > 0,
+        "no course recreate succeeded: {stats:?}"
+    );
+}
+
+/// The two branches the fixed clock made unreachable. Both are pure rejections,
+/// so they only show up if the clock moves (6008) and if a course generation is
+/// superseded (6034) — a regression on either silently deletes coverage.
+#[test]
+fn time_dependent_branches_are_reached() {
+    let mut stats = Stats::default();
+    for seed in 0..12u64 {
+        let mut s = Session::new(seed);
+        if !s.init_iteration().expect("init") {
+            continue;
+        }
+        for _ in 0..40 {
+            s.step().expect("step");
+        }
+        stats.merge(s.stats);
+    }
+    assert!(
+        stats.cooldown_rejections > 0,
+        "UnenrollCooldown (6008) never reached: {stats:?}"
+    );
+    assert!(
+        stats.stale_rejections > 0,
+        "StaleEnrollment (6034) never reached: {stats:?}"
+    );
 }


### PR DESCRIPTION
The four follow-ups the adversarial gate raised on #1212.

The substantive one is the clock: litesvm starts at `unix_timestamp = 0` and nothing moved it, so `UnenrollCooldown` (6008) and `StaleEnrollment` (6034) were unreachable and the coverage line overstated what the nightly exercised. The harness now warps by a seeded delta before each flow, and two new flows drive those branches — `close_enrollment` (unenroll, gated on the 24h cooldown) and a close/recreate of the course, which supersedes every prior enrollment's generation. A seeded 2000-iteration run reaches both: `1453 UnenrollCooldown (6008), 10253 StaleEnrollment (6034)`, printed alongside the coverage line, with a new test asserting it.

`is_unexpected` is now the inverse of an allowlist — `Custom(n)` plus ten validation-class `InstructionError`s are expected rejections, so a runtime guard (`UnbalancedInstruction`, `ModifiedProgramId`, `ExternalAccountDataModified`, `PrivilegeEscalation`) or a transaction-level failure is a finding instead of reading as a valid refusal. 142k transactions across that run produced no false positive.

On the workflow: `timeout` firing no longer reads as a clean full window. The binary self-stops at `FUZZ_MAX_SECONDS`, so 124/143 means an iteration hung; the exit-0 branch additionally requires a `coverage:` line in the log before declaring the run clean. Any failure files (or reopens and nudges) one tracking issue keyed on a stable title marker, via `gh` with `issues: write` scoped to the job — no new action to pin. `actionlint` clean, `scripts/check-action-pins.sh` green.

Verification: `cargo build-sbf --tools-version v1.54` exit 0; 4/4 tests pass; `FUZZ_SEED=20260909 FUZZ_MAX_SECONDS=60 … -- 2000` clean in 37.0s (142280 transactions, 16780 enrollments, 2161 lessons, 4273 finalizations, 2119 unenrollments, 953 recreations); `cargo fmt --check` and `cargo clippy -- -W clippy::all` clean. `onchain-academy/programs/**` untouched.
