### PR TITLE
fix(complete): maxDuration covers the buildable grade

### DIFF
--- a/apps/web/src/app/api/lessons/complete/route.ts
+++ b/apps/web/src/app/api/lessons/complete/route.ts
@@ -28,6 +28,10 @@ import { scheduleQuestEvaluation } from "@/lib/gamification/quest-evaluation";
 import { isPlatformFrozen } from "@/lib/platform/freeze";
 import { platformFrozenResponse } from "@/lib/platform/freeze-http";
 
+// Grading a buildable block waits up to 130s on the build server here, then still
+// has an on-chain tx to send. 300 is the Vercel plan ceiling, as in api/build-program.
+export const maxDuration = 300;
+
 interface LessonCompleteRequest {
   lessonId: string;
   courseId: string;


### PR DESCRIPTION
`/api/lessons/complete` had no `maxDuration`, so it ran on the platform default while grading a buildable block waits up to 130s on the build server and then still sends an on-chain tx.

Set to 300, the plan ceiling already used by `api/build-program` and `api/courses/test-out`.