### PR TITLE
feat(content-lint): a deployable code block needs a deployed-program-card

### DIFF
--- a/packages/content-lint/src/__tests__/fixtures/good/courses/template/lessons/deploy/lesson.yaml
+++ b/packages/content-lint/src/__tests__/fixtures/good/courses/template/lessons/deploy/lesson.yaml
@@ -13,3 +13,6 @@ blocks:
     tests: program/tests.json
     consumes: [funded-wallet]
     produces: deployed-program
+  - key: deployed
+    type: deployed-program-card
+    consumes: [deployed-program]

--- a/packages/content-lint/src/__tests__/gate13e.test.ts
+++ b/packages/content-lint/src/__tests__/gate13e.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from "vitest";
+import { runLint } from "../lint";
+import "../checks/gate1-schema";
+import "../checks/gate13e-deploy-card";
+import { makeTempRepo } from "./helpers";
+import type { Diagnostic } from "../diagnostics";
+
+const COURSE = `id: course-x
+slug: x
+title: X
+difficulty: beginner
+duration: 1
+sourceLocale: en
+xpPerLesson: 10
+xpReward: 100
+modules: [{ key: m, title: M, lessons: [lesson-deploy] }]
+`;
+
+const DEPLOYABLE = `  - key: build
+    type: code
+    language: rust
+    buildType: buildable
+    deployable: true
+    starter: program/starter.rs
+    solution: program/solution.rs
+    tests: program/tests.json
+    produces: deployed-program
+`;
+
+const CARD = `  - key: deployed
+    type: deployed-program-card
+    consumes: [deployed-program]
+`;
+
+function repo(blocks: string) {
+  return makeTempRepo({
+    "courses/x/course.yaml": COURSE,
+    "courses/x/lessons/deploy/lesson.yaml": `id: lesson-deploy
+slug: deploy
+title: Deploy
+skills: [program-deployment]
+blocks:
+${blocks}`,
+  });
+}
+
+const gate13e = (ds: Diagnostic[]) => ds.filter((d) => d.gate === "gate-13e");
+
+describe("gate 13e — a deployable block needs a deployed-program-card", () => {
+  it("passes when the card follows the deployable block", async () => {
+    const r = await runLint(repo(DEPLOYABLE + CARD));
+    expect(gate13e(r.diagnostics)).toEqual([]);
+  });
+
+  it("errors when the lesson has no card at all", async () => {
+    const r = await runLint(repo(DEPLOYABLE));
+    const [d] = gate13e(r.diagnostics);
+    expect(d?.severity).toBe("error");
+    expect(d?.message).toContain("lesson-deploy");
+    expect(d?.message).toContain("uncompletable");
+  });
+
+  it("errors when the card comes BEFORE the deployable block", async () => {
+    const r = await runLint(repo(CARD + DEPLOYABLE));
+    expect(gate13e(r.diagnostics)).toHaveLength(1);
+  });
+
+  it("ignores a code block that is not deployable", async () => {
+    const r = await runLint(
+      repo(DEPLOYABLE.replace("deployable: true", "deployable: false"))
+    );
+    expect(gate13e(r.diagnostics)).toEqual([]);
+  });
+});

--- a/packages/content-lint/src/checks/gate13e-deploy-card.ts
+++ b/packages/content-lint/src/checks/gate13e-deploy-card.ts
@@ -1,0 +1,46 @@
+import { registerCheck } from "../lint";
+import { type RepoModel } from "../model";
+import { diag, type Diagnostic } from "../diagnostics";
+
+type Block = Record<string, unknown> & { type: string; key: string };
+
+/**
+ * A `code` block with `deployable: true` is only completable when the same
+ * lesson carries a later `deployed-program-card` block.
+ *
+ * The deploy panel is mounted by that block and nothing else
+ * (`lessons/[id]/blocks/deployed-program-card-block.tsx`), and the challenge
+ * runner only reveals Submit after the panel fires `superteam:deploy-complete`.
+ * Without the card the learner reaches a green test run and then has no way to
+ * finish the lesson — for any wallet kind.
+ *
+ * Gate 13a covers the capability edge (`produces: deployed-program` →
+ * `consumes`), which is a different question: it is satisfied by a consumer in
+ * a LATER lesson, or even a later course on the same path, and it does not care
+ * about the block's type. This one is intra-lesson and type-specific.
+ */
+export function gate13eCheck(model: RepoModel): Diagnostic[] {
+  const out: Diagnostic[] = [];
+
+  for (const lesson of model.lessons) {
+    const blocks = lesson.lesson.blocks as Block[];
+    blocks.forEach((block, i) => {
+      if (block.type !== "code" || block.deployable !== true) return;
+      const hasCard = blocks
+        .slice(i + 1)
+        .some((b) => b.type === "deployed-program-card");
+      if (hasCard) return;
+      out.push(
+        diag(
+          "gate-13e",
+          "error",
+          lesson.file,
+          `lesson "${lesson.id}" block "${block.key}" is deployable but no later block in the lesson is a "deployed-program-card" — the card is what mounts the deploy panel, so the learner never gets a Submit button and the lesson is uncompletable`
+        )
+      );
+    });
+  }
+  return out;
+}
+
+registerCheck(gate13eCheck);

--- a/packages/content-lint/src/index.ts
+++ b/packages/content-lint/src/index.ts
@@ -14,6 +14,7 @@ export * from "./checks/gate6-executor";
 export * from "./checks/gate7-quiz";
 export * from "./checks/gate13a-capabilities";
 export * from "./checks/gate13bcd-widgets";
+export * from "./checks/gate13e-deploy-card";
 export * from "./checks/gate19-skills";
 export * from "./checks/gate20-originality";
 export * from "./checks/gate21-version-currency";


### PR DESCRIPTION
`deployed-program-card` is the only block that mounts the deploy panel, and the challenge runner reveals Submit only once that panel fires `superteam:deploy-complete`. So a `code` block with `deployable: true` and no card behind it in the same lesson is a lesson nobody can complete, for any wallet kind — which is exactly how `lesson-b2s-your-first-solana-program` shipped. Gate 13a doesn't catch it: it only checks the capability edge, which a consumer in a later lesson (or a later course on the path) satisfies.

No allowlist and no warning downgrade. content-lint never runs against the committed bundle — monorepo CI only runs `pnpm -r test` — so this PR's CI depends solely on the fixtures, and the `good` template fixture gets the card it was missing. The content repo's `validate-content` workflow does check out monorepo main, and against today's academy-courses this check finds two real offenders: the b2s lesson and the `_template/lessons/deploy` scaffold. Both are fixed in solanabr/academy-courses#61, which should land first or alongside.

Part of the embedded-wallet deploy work (spec section B).
