### PR TITLE
chore: drop stale Trident references, tidy compiler-error truncation, spec notes

### DIFF
--- a/.claude/agents/anchor-engineer.md
+++ b/.claude/agents/anchor-engineer.md
@@ -18,18 +18,19 @@ You are an Anchor framework specialist with deep expertise in building secure, m
 
 ## Core Competencies
 
-| Domain | Expertise |
-|--------|-----------|
-| **Anchor Framework** | v0.32+, macros, constraints, IDL |
-| **Account Validation** | Constraints, has_one, seeds, init patterns |
-| **Error Handling** | Custom errors, error codes, descriptive messages |
-| **Testing** | Anchor test framework, TypeScript integration |
-| **IDL Generation** | Auto-generated interfaces for clients |
-| **CPI Helpers** | Built-in CPI modules, context generation |
+| Domain                 | Expertise                                        |
+| ---------------------- | ------------------------------------------------ |
+| **Anchor Framework**   | v0.32+, macros, constraints, IDL                 |
+| **Account Validation** | Constraints, has_one, seeds, init patterns       |
+| **Error Handling**     | Custom errors, error codes, descriptive messages |
+| **Testing**            | Anchor test framework, TypeScript integration    |
+| **IDL Generation**     | Auto-generated interfaces for clients            |
+| **CPI Helpers**        | Built-in CPI modules, context generation         |
 
 ## When to Use Anchor
 
 **Perfect for**:
+
 - Rapid prototyping and MVP development
 - Team projects requiring standardization
 - Programs needing auto-generated clients (IDL)
@@ -37,6 +38,7 @@ You are an Anchor framework specialist with deep expertise in building secure, m
 - Complex account validation patterns
 
 **Consider alternatives when**:
+
 - CU optimization is critical (use Pinocchio)
 - Binary size must be minimized
 - Need maximum control over every instruction
@@ -395,21 +397,21 @@ pub fn transfer(ctx: Context<Transfer>, amount: u64) -> Result<()> {
 
 ## Testing Framework Decision
 
-| Framework | Speed | Use Case | When to Use |
-|-----------|-------|----------|-------------|
-| **anchor test** | 🐢 Slow | Full E2E | Integration, multi-instruction flows |
-| **Mollusk** | ⚡ Fastest | Unit tests | Individual instruction testing |
-| **LiteSVM** | ⚡ Fast | Integration | Multi-instruction without validator |
-| **Surfpool** | 🚀 Fast | Realistic state | Testing with mainnet/devnet state |
-| **Trident** | 🐢 Slow | Fuzz testing | Edge case discovery, security |
+| Framework        | Speed      | Use Case        | When to Use                          |
+| ---------------- | ---------- | --------------- | ------------------------------------ |
+| **anchor test**  | 🐢 Slow    | Full E2E        | Integration, multi-instruction flows |
+| **Mollusk**      | ⚡ Fastest | Unit tests      | Individual instruction testing       |
+| **LiteSVM**      | ⚡ Fast    | Integration     | Multi-instruction without validator  |
+| **Surfpool**     | 🚀 Fast    | Realistic state | Testing with mainnet/devnet state    |
+| **litesvm fuzz** | 🐢 Slow    | Fuzz testing    | Edge case discovery, security        |
 
 ### Recommended Testing Strategy
 
 ```
 1. Mollusk (unit)     → Fast iteration during development
-2. LiteSVM (integ)    → Multi-instruction flow testing  
+2. LiteSVM (integ)    → Multi-instruction flow testing
 3. anchor test (E2E)  → Full integration before deploy
-4. Trident (fuzz)     → Security edge cases
+4. litesvm fuzz       → Security edge cases (onchain-academy/tests/fuzz)
 ```
 
 ### Anchor Test Example
@@ -454,6 +456,7 @@ describe("my_program", () => {
 ## Best Practices
 
 ### Security Checklist
+
 - [ ] All accounts validated with constraints
 - [ ] Arithmetic uses checked operations
 - [ ] PDAs use stored canonical bumps
@@ -462,12 +465,14 @@ describe("my_program", () => {
 - [ ] Tests cover all instructions and errors
 
 ### Performance Tips
+
 - Use `#[derive(InitSpace)]` for accurate space calculation
 - Store bumps to avoid recalculation (~1500 CU savings)
 - Use `close` constraint for safe account closure
 - Feature-gate debug logs: `#[cfg(feature = "debug")]`
 
 ### Code Organization
+
 ```
 programs/my-program/src/
 ├── lib.rs              # Program entry, declare_id
@@ -484,6 +489,7 @@ programs/my-program/src/
 ## When to Optimize to Pinocchio
 
 Consider switching if:
+
 - CU usage exceeds limits consistently
 - Transaction costs become significant at scale
 - Binary size is problematic

--- a/.claude/agents/solana-qa-engineer.md
+++ b/.claude/agents/solana-qa-engineer.md
@@ -1,6 +1,6 @@
 ---
 name: solana-qa-engineer
-description: "Testing and quality assurance specialist for Solana programs. Owns all testing frameworks (Mollusk, LiteSVM, Surfpool, Trident), CU profiling, security testing, and code quality standards.\n\nUse when: Writing comprehensive tests, setting up test infrastructure, debugging test failures, CU benchmarking, fuzz testing, or reviewing code quality."
+description: "Testing and quality assurance specialist for Solana programs. Owns all testing frameworks (Mollusk, LiteSVM, Surfpool, litesvm-based fuzzing), CU profiling, security testing, and code quality standards.\n\nUse when: Writing comprehensive tests, setting up test infrastructure, debugging test failures, CU benchmarking, fuzz testing, or reviewing code quality."
 model: opus
 color: yellow
 ---
@@ -17,32 +17,32 @@ You are a **solana-qa-engineer**, a testing and quality assurance specialist for
 
 ## Core Competencies
 
-| Domain | Expertise |
-|--------|-----------|
-| **Unit Testing** | Mollusk - fast, isolated instruction tests |
-| **Integration Testing** | LiteSVM - multi-instruction flows |
-| **Realistic State** | Surfpool - mainnet/devnet state locally |
-| **Fuzz Testing** | Trident - edge case and security discovery |
-| **CU Profiling** | Benchmarking, optimization verification |
-| **Code Quality** | AI slop removal, style consistency |
+| Domain                  | Expertise                                                                 |
+| ----------------------- | ------------------------------------------------------------------------- |
+| **Unit Testing**        | Mollusk - fast, isolated instruction tests                                |
+| **Integration Testing** | LiteSVM - multi-instruction flows                                         |
+| **Realistic State**     | Surfpool - mainnet/devnet state locally                                   |
+| **Fuzz Testing**        | litesvm (`onchain-academy/tests/fuzz`) - edge case and security discovery |
+| **CU Profiling**        | Benchmarking, optimization verification                                   |
+| **Code Quality**        | AI slop removal, style consistency                                        |
 
 ## Testing Framework Selection
 
-| Framework | Speed | Use Case | When to Use |
-|-----------|-------|----------|-------------|
-| **Mollusk** | ⚡ Fastest | Unit tests | Single instruction, CU measurement |
-| **LiteSVM** | ⚡ Fast | Integration | Multi-instruction, no validator |
-| **Surfpool** | 🚀 Fast | Realistic state | Testing with mainnet programs/state |
-| **Trident** | 🐢 Slow | Fuzz testing | Security, edge cases, property tests |
-| **anchor test** | 🐢 Slowest | Full E2E | Final integration before deploy |
+| Framework        | Speed      | Use Case        | When to Use                          |
+| ---------------- | ---------- | --------------- | ------------------------------------ |
+| **Mollusk**      | ⚡ Fastest | Unit tests      | Single instruction, CU measurement   |
+| **LiteSVM**      | ⚡ Fast    | Integration     | Multi-instruction, no validator      |
+| **Surfpool**     | 🚀 Fast    | Realistic state | Testing with mainnet programs/state  |
+| **litesvm fuzz** | 🐢 Slow    | Fuzz testing    | Security, edge cases, property tests |
+| **anchor test**  | 🐢 Slowest | Full E2E        | Final integration before deploy      |
 
 ## Testing Strategy by Project Phase
 
 ```
 Development:  Mollusk (fast iteration)
 Integration:  LiteSVM + Surfpool (flow testing)
-Pre-deploy:   Trident (10+ min fuzz) + anchor test
-Security:     Trident + manual audit
+Pre-deploy:   litesvm fuzz (10+ min) + anchor test
+Security:     litesvm fuzz + manual audit
 ```
 
 ## Mollusk Unit Test Pattern
@@ -65,7 +65,7 @@ mod tests {
         };
 
         let result = mollusk.process_instruction(&instruction, &[]);
-        
+
         assert!(result.program_result.is_ok());
         println!("CU consumed: {}", result.compute_units_consumed);
         assert!(result.compute_units_consumed < 10_000);
@@ -112,18 +112,23 @@ cargo test --test integration
 surfpool stop
 ```
 
-## Trident Fuzz Testing
+## litesvm Fuzz Testing
+
+The nightly fuzz harness (`onchain-academy/tests/fuzz`) drives the compiled
+pinocchio `.so` on litesvm — see `.github/workflows/fuzz.yml` and
+`onchain-academy/README.md` for the full setup.
 
 ```bash
-# Initialize fuzz tests
-trident init
+# Build the program the fuzzer targets
+cargo build-sbf --manifest-path programs/onchain-academy-pinocchio/Cargo.toml --tools-version v1.54
 
-# Run fuzz tests (minimum 10 minutes for security)
-cd trident-tests
-trident fuzz run --timeout 600
+# Build and run (minimum 10 minutes for security)
+cd tests/fuzz
+cargo build --release --bin fuzz
+FUZZ_MAX_SECONDS=600 cargo run --release --bin fuzz -- 1000000
 
 # Check for crashes
-ls hfuzz_workspace/*/crashes/
+ls crashes/
 ```
 
 ## CU Benchmarking Pattern
@@ -132,18 +137,18 @@ ls hfuzz_workspace/*/crashes/
 #[test]
 fn benchmark_cu_usage() {
     let mollusk = Mollusk::new(&program_id, "target/deploy/program.so");
-    
+
     // Test each instruction
     let instructions = vec![
         ("initialize", build_initialize_ix()),
         ("deposit", build_deposit_ix()),
         ("withdraw", build_withdraw_ix()),
     ];
-    
+
     for (name, ix) in instructions {
         let result = mollusk.process_instruction(&ix, &accounts);
         println!("{}: {} CU", name, result.compute_units_consumed);
-        
+
         // Assert CU limits
         assert!(result.compute_units_consumed < MAX_CU_LIMIT);
     }
@@ -162,15 +167,16 @@ git diff main...HEAD
 
 **Remove these patterns:**
 
-| Pattern | Example | Action |
-|---------|---------|--------|
-| Excessive comments | `// This adds the amount to balance` | Remove obvious comments |
-| Defensive over-checking | Try/catch around trusted code | Remove if abnormal for codebase |
-| Verbose error messages | Multi-line where single suffices | Simplify to match style |
-| Unnecessary logging | Debug logs in production paths | Remove or feature-gate |
-| Redundant validation | Re-checking already validated data | Remove duplicate checks |
+| Pattern                 | Example                              | Action                          |
+| ----------------------- | ------------------------------------ | ------------------------------- |
+| Excessive comments      | `// This adds the amount to balance` | Remove obvious comments         |
+| Defensive over-checking | Try/catch around trusted code        | Remove if abnormal for codebase |
+| Verbose error messages  | Multi-line where single suffices     | Simplify to match style         |
+| Unnecessary logging     | Debug logs in production paths       | Remove or feature-gate          |
+| Redundant validation    | Re-checking already validated data   | Remove duplicate checks         |
 
 **Keep these:**
+
 - Legitimate security checks
 - Comments explaining non-obvious logic
 - Error handling matching codebase patterns
@@ -189,7 +195,7 @@ git diff main...HEAD
 - [ ] All Mollusk unit tests pass
 - [ ] All LiteSVM integration tests pass
 - [ ] Surfpool tests pass (if using mainnet state)
-- [ ] Trident fuzz tests run 10+ minutes with no crashes
+- [ ] litesvm fuzz tests run 10+ minutes with no crashes
 - [ ] Error conditions tested
 - [ ] Edge cases covered (max values, zero, boundaries)
 - [ ] CU consumption within limits
@@ -197,12 +203,12 @@ git diff main...HEAD
 
 ### Coverage Targets
 
-| Test Type | Target |
-|-----------|--------|
-| Unit (Mollusk) | All instructions |
-| Integration | All user flows |
-| Fuzz | All mutable state |
-| Error paths | All error codes |
+| Test Type      | Target            |
+| -------------- | ----------------- |
+| Unit (Mollusk) | All instructions  |
+| Integration    | All user flows    |
+| Fuzz           | All mutable state |
+| Error paths    | All error codes   |
 
 ## Debugging Failed Tests
 
@@ -223,6 +229,7 @@ RUST_LOG=debug anchor test
 ## When to Use This Agent
 
 **Perfect for**:
+
 - Setting up test infrastructure
 - Writing comprehensive test suites
 - CU profiling and optimization verification
@@ -231,6 +238,7 @@ RUST_LOG=debug anchor test
 - Debugging test failures
 
 **Delegate when**:
+
 - Writing program logic → anchor-engineer or pinocchio-engineer
 - Designing architecture → solana-architect
 - Frontend testing → solana-frontend-engineer

--- a/.claude/commands/audit-solana.md
+++ b/.claude/commands/audit-solana.md
@@ -9,7 +9,7 @@ You are conducting a security audit for Solana programs. This is CRITICAL - take
 - [security.md](../skills/security.md) - Comprehensive security checklist
 - [programs-anchor.md](../skills/programs-anchor.md) - Anchor security patterns
 - [programs-pinocchio.md](../skills/programs-pinocchio.md) - Pinocchio security patterns
-- [testing.md](../skills/testing.md) - Fuzz testing with Trident
+- [testing.md](../skills/testing.md) - Fuzz testing with litesvm
 
 ## Pre-Audit Checklist
 
@@ -64,6 +64,7 @@ echo "✅ Automated analysis complete"
 **CRITICAL**: Every account MUST be validated. Check each instruction:
 
 ### Owner Checks
+
 ```rust
 // ✓ CORRECT: Validate account owner
 if *account.owner != expected_program_id {
@@ -74,6 +75,7 @@ if *account.owner != expected_program_id {
 ```
 
 ### Signer Checks
+
 ```rust
 // ✓ CORRECT: Verify signer
 if !authority.is_signer {
@@ -84,6 +86,7 @@ if !authority.is_signer {
 ```
 
 ### PDA Validation
+
 ```rust
 // ✓ CORRECT: Use stored canonical bump
 let seeds = &[
@@ -111,6 +114,7 @@ let total = amount_a + amount_b;
 ```
 
 **Checklist**:
+
 - [ ] All additions use `checked_add`
 - [ ] All subtractions use `checked_sub`
 - [ ] All multiplications use `checked_mul`
@@ -120,6 +124,7 @@ let total = amount_a + amount_b;
 ## Step 4: Common Attack Vectors
 
 ### Type Cosplay
+
 ```rust
 // ✓ CORRECT: Check discriminator
 if account.data.borrow()[0..8] != User::DISCRIMINATOR {
@@ -130,6 +135,7 @@ if account.data.borrow()[0..8] != User::DISCRIMINATOR {
 ```
 
 ### Account Revival
+
 ```rust
 // ✓ CORRECT: Zero data AND set closed discriminator
 let mut data = account.data.borrow_mut();
@@ -141,6 +147,7 @@ data[0..8].copy_from_slice(&CLOSED_ACCOUNT_DISCRIMINATOR);
 ```
 
 ### Arbitrary CPI
+
 ```rust
 // ✓ CORRECT: Validate program ID
 if cpi_program.key() != spl_token::ID {
@@ -152,6 +159,7 @@ invoke(&instruction, accounts)?;
 ```
 
 ### Missing Reload After CPI
+
 ```rust
 // ✓ CORRECT: Reload account after CPI
 token::transfer(cpi_ctx, amount)?;
@@ -163,6 +171,7 @@ token::transfer(cpi_ctx, amount)?;
 ```
 
 ### PDA Seed Collision
+
 ```rust
 // ✓ CORRECT: Unique prefixes per account type
 let user_seeds = [b"user_vault", user.key().as_ref()];
@@ -218,32 +227,35 @@ Verify comprehensive test coverage:
 - [ ] Arithmetic edge cases tested (max values, overflow)
 - [ ] PDA derivation tested
 - [ ] CPI success and failure paths tested
-- [ ] Fuzz testing with Trident (REQUIRED for mainnet)
+- [ ] Fuzz testing with litesvm (REQUIRED for mainnet)
 
-### Fuzz Testing with Trident
+### Fuzz Testing with litesvm
+
+The harness lives at `onchain-academy/tests/fuzz` and drives the compiled
+pinocchio `.so` on litesvm — see `.github/workflows/fuzz.yml` and
+`onchain-academy/README.md` for the full setup and CI wiring.
 
 ```bash
-# Setup Trident (if not already)
-if [ ! -d "trident-tests" ]; then
-    echo "Setting up Trident fuzz testing..."
-    trident init
-fi
+# Build the program the fuzzer targets
+cargo build-sbf --manifest-path programs/onchain-academy-pinocchio/Cargo.toml --tools-version v1.54
 
-# Run fuzz tests for at least 10 minutes (Trident v0.7+)
+# Run fuzz tests for at least 10 minutes
 echo "🔍 Running fuzz tests (10 minutes minimum)..."
-cd trident-tests
-trident fuzz run --timeout 600
+cd tests/fuzz
+cargo build --release --bin fuzz
+FUZZ_MAX_SECONDS=600 cargo run --release --bin fuzz -- 1000000
 
 # Review any crashes found
-if [ -d "hfuzz_workspace" ]; then
-    echo "⚠️  Review crash reports in hfuzz_workspace/"
-    ls -la hfuzz_workspace/*/crashes/ 2>/dev/null || echo "No crashes found ✅"
+if [ -d "crashes" ]; then
+    echo "⚠️  Review crash reports in crashes/"
+    ls -la crashes/ 2>/dev/null || echo "No crashes found ✅"
 fi
 
-cd ..
+cd ../..
 ```
 
 Fuzz testing discovers:
+
 - Unexpected arithmetic overflows
 - Invalid account combinations
 - Edge case panics
@@ -355,6 +367,7 @@ fi
 Go through this systematically:
 
 ### Account Security
+
 - [ ] Every account has owner check
 - [ ] Signer verification for privileged operations
 - [ ] PDA validation with canonical bumps
@@ -362,18 +375,21 @@ Go through this systematically:
 - [ ] No seed collisions possible
 
 ### Arithmetic Security
+
 - [ ] All arithmetic uses checked operations
 - [ ] Division by zero handled
 - [ ] Casting uses try_into() with errors
 - [ ] Token amounts use u64 consistently
 
 ### CPI Security
+
 - [ ] Program IDs validated before CPI
 - [ ] Signer privileges controlled
 - [ ] Accounts reloaded after modifying CPIs
 - [ ] Reentrancy considered
 
 ### Data Security
+
 - [ ] All instruction data validated
 - [ ] Account data size verified
 - [ ] Strings/vectors have length limits
@@ -391,6 +407,7 @@ Create `docs/security-audit-[date].md`:
 **Auditor**: claude-maintainer
 
 ## Summary
+
 - Total Issues: X
 - Critical: X
 - High: X
@@ -437,6 +454,7 @@ Create `docs/security-audit-[date].md`:
 ## Professional Audit Firms
 
 For mainnet deployment, consider:
+
 - OtterSec
 - Neodyme
 - Halborn

--- a/.claude/commands/setup-ci-cd.md
+++ b/.claude/commands/setup-ci-cd.md
@@ -13,6 +13,7 @@ You are setting up a CI/CD pipeline for Solana program development. Modern Solan
 ## Overview
 
 This command creates a GitHub Actions workflow that automatically:
+
 - Builds programs with verifiable builds
 - Runs comprehensive tests (unit, integration, fuzz)
 - Performs security audits (cargo audit, clippy)
@@ -149,13 +150,14 @@ jobs:
         with:
           toolchain: ${{ env.RUST_VERSION }}
 
-      - name: Install Trident
-        run: cargo install trident-cli
+      - name: Build program (.so for the fuzz SVM)
+        run: cargo build-sbf --manifest-path programs/onchain-academy-pinocchio/Cargo.toml --tools-version v1.54
 
       - name: Run Fuzz Tests
         run: |
-          cd trident-tests
-          trident fuzz run --timeout 300
+          cd tests/fuzz
+          cargo build --release --bin fuzz
+          FUZZ_MAX_SECONDS=300 cargo run --release --bin fuzz -- 1000000
         timeout-minutes: 10
         continue-on-error: true
 
@@ -164,7 +166,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: fuzz-results
-          path: trident-tests/hfuzz_workspace/
+          path: tests/fuzz/crashes/
 EOF
 
 echo "✅ GitHub Actions workflow created: .github/workflows/solana-security.yml"
@@ -394,6 +396,7 @@ After pushing, configure branch protection on GitHub:
 ## CI/CD Best Practices
 
 ### Automated Checks on Every Commit
+
 - Format validation
 - Security lints (clippy)
 - Vulnerability scanning (cargo audit)
@@ -401,12 +404,14 @@ After pushing, configure branch protection on GitHub:
 - Build verification
 
 ### Before Merging to Main
+
 - All CI checks must pass
 - Code review required
 - No security warnings
 - Test coverage maintained
 
 ### Before Deploying to Mainnet
+
 - Verifiable build succeeds
 - All tests pass (including fuzz)
 - Professional security audit completed
@@ -415,6 +420,7 @@ After pushing, configure branch protection on GitHub:
 ## Monitoring and Alerts
 
 Consider setting up:
+
 - GitHub notifications for security advisories
 - Slack/Discord integration for CI failures
 - Automated security reports
@@ -423,15 +429,18 @@ Consider setting up:
 ## Maintenance
 
 ### Weekly
+
 - Review dependabot PRs
 - Update security advisories
 
 ### Monthly
+
 - Review and update security lints
 - Audit CI/CD pipeline performance
 - Update toolchain versions
 
 ### Before Major Releases
+
 - Full security audit
 - Penetration testing
 - Third-party code review

--- a/.claude/commands/test-rust.md
+++ b/.claude/commands/test-rust.md
@@ -2,7 +2,7 @@
 description: "Run Rust tests for Solana programs and backend services"
 ---
 
-You are running Rust tests. This command covers Solana program testing (Mollusk, LiteSVM, Surfpool, Trident) and backend service testing.
+You are running Rust tests. This command covers Solana program testing (Mollusk, LiteSVM, Surfpool, litesvm-based fuzzing) and backend service testing.
 
 ## Related Skills
 
@@ -43,7 +43,7 @@ fi
 1. **Unit tests (fastest)**: Mollusk - individual instruction tests
 2. **Integration tests (fast)**: LiteSVM - multi-instruction flows
 3. **Realistic state tests**: Surfpool - mainnet/devnet state locally
-4. **Fuzz tests**: Trident - edge case discovery
+4. **Fuzz tests**: litesvm (`onchain-academy/tests/fuzz`) - edge case discovery
 
 ### Mollusk Unit Tests
 
@@ -155,42 +155,45 @@ surfpool stop
 // - Account cloning between environments
 
 // Time travel to specific slot
-await connection._rpcRequest('surfnet_timeTravel', [{
-    absoluteSlot: 250000000
-}]);
+await connection._rpcRequest("surfnet_timeTravel", [
+  {
+    absoluteSlot: 250000000,
+  },
+]);
 
 // Clone account from mainnet
-await connection._rpcRequest('surfnet_cloneProgramAccount', [{
+await connection._rpcRequest("surfnet_cloneProgramAccount", [
+  {
     source: mainnetProgramId.toString(),
     destination: localProgramId.toString(),
     account: accountPubkey.toString(),
-}]);
+  },
+]);
 ```
 
-### Trident Fuzz Tests
+### litesvm Fuzz Tests
 
-Property-based fuzzing for edge cases:
+Property-based fuzzing for edge cases against the compiled `.so`, see
+`.github/workflows/fuzz.yml` and `onchain-academy/README.md`:
 
 ```bash
-echo "🔱 Running Trident fuzz tests..."
+echo "🐢 Running litesvm fuzz tests..."
 
-# Initialize (first time only)
-if [ ! -d "trident-tests" ]; then
-    trident init
-fi
+cargo build-sbf --manifest-path programs/onchain-academy-pinocchio/Cargo.toml --tools-version v1.54
 
-cd trident-tests
+cd tests/fuzz
+cargo build --release --bin fuzz
 
-# Run fuzz tests (modern syntax)
-trident fuzz run --timeout 300
+# Run fuzz tests
+FUZZ_MAX_SECONDS=300 cargo run --release --bin fuzz -- 1000000
 
 # Check for crashes
-if [ -d "hfuzz_workspace" ]; then
+if [ -d "crashes" ]; then
     echo "📋 Checking for crash reports..."
-    find hfuzz_workspace -name "crashes" -type d -exec ls -la {} \; 2>/dev/null
+    ls -la crashes/ 2>/dev/null
 fi
 
-cd ..
+cd ../..
 ```
 
 ### Complete Solana Test Suite
@@ -213,10 +216,10 @@ cargo test --lib
 echo "📍 Integration tests..."
 cargo test --test '*'
 
-# 4. Fuzz tests (Trident) - quick run
-if [ -d "trident-tests" ]; then
+# 4. Fuzz tests (litesvm) - quick run
+if [ -d "tests/fuzz" ]; then
     echo "📍 Fuzz tests..."
-    cd trident-tests && trident fuzz run --timeout 60 && cd ..
+    (cd tests/fuzz && FUZZ_MAX_SECONDS=60 cargo run --release --bin fuzz -- 1000000)
 fi
 
 echo "✅ All Solana tests complete!"
@@ -354,13 +357,13 @@ RUST_LOG=trace RUST_BACKTRACE=full cargo test failing_test -- --nocapture --exac
 
 ## Test Framework Comparison
 
-| Framework | Speed | Use Case | Scope |
-|-----------|-------|----------|-------|
-| **Mollusk** | ⚡ Fastest | Single instruction | Unit |
-| **LiteSVM** | ⚡ Fast | Multi-instruction flows | Integration |
-| **Surfpool** | 🚀 Fast | Realistic cluster state | Integration |
-| **Trident** | 🐢 Slower | Edge case discovery | Fuzz |
-| **test-validator** | 🐢 Slowest | Full network simulation | E2E |
+| Framework          | Speed      | Use Case                | Scope       |
+| ------------------ | ---------- | ----------------------- | ----------- |
+| **Mollusk**        | ⚡ Fastest | Single instruction      | Unit        |
+| **LiteSVM**        | ⚡ Fast    | Multi-instruction flows | Integration |
+| **Surfpool**       | 🚀 Fast    | Realistic cluster state | Integration |
+| **litesvm fuzz**   | 🐢 Slower  | Edge case discovery     | Fuzz        |
+| **test-validator** | 🐢 Slowest | Full network simulation | E2E         |
 
 ## CI Test Pattern
 
@@ -400,4 +403,4 @@ Before deployment:
 
 ---
 
-**Remember**: Test at all levels. Mollusk for speed, LiteSVM for integration, Surfpool for realistic state, Trident for edge cases.
+**Remember**: Test at all levels. Mollusk for speed, LiteSVM for integration, Surfpool for realistic state, litesvm fuzz for edge cases.

--- a/apps/web/src/components/editor/challenge-runner.tsx
+++ b/apps/web/src/components/editor/challenge-runner.tsx
@@ -796,7 +796,9 @@ async function runBuildChallenge(
   // Parse compiler stderr for warnings/errors
   const stderr = result.stderr ?? "";
   const hasErrors = !result.success;
-  const cleanStderr = stderr.replace(/\x1b\[[0-9;]*m/g, "");
+  // Stripped once here for the Output tab; firstCompilerErrorLine strips
+  // internally, so it takes the raw stderr directly below.
+  const cleanStderr = stripAnsi(stderr);
 
   // For build challenges, "tests" are compilation checks:
   // - Test 0 always checks: "Program compiles successfully"
@@ -812,7 +814,7 @@ async function runBuildChallenge(
         // stays in `error` for the Output tab.
         actualOutput: result.success
           ? "Compilation successful"
-          : firstCompilerErrorLine(cleanStderr, 300),
+          : firstCompilerErrorLine(stderr, 300),
       };
     }
     // Additional tests: pass if build succeeded (future: check for specific patterns)

--- a/apps/web/src/lib/challenge/__tests__/compiler-error.test.ts
+++ b/apps/web/src/lib/challenge/__tests__/compiler-error.test.ts
@@ -66,4 +66,23 @@ describe("firstCompilerErrorLine", () => {
     expect(firstCompilerErrorLine(long)).toHaveLength(200);
     expect(firstCompilerErrorLine(long, 300)).toHaveLength(300);
   });
+
+  it("keeps the location intact and truncates only the error line", () => {
+    const stderr = [
+      `error[E0107]: ${"x".repeat(500)}`,
+      "   --> src/lib.rs:24:24",
+    ].join("\n");
+    const result = firstCompilerErrorLine(stderr, 200);
+    expect(result).toHaveLength(200);
+    expect(result.endsWith("--> src/lib.rs:24:24")).toBe(true);
+  });
+
+  it("truncates the location too when it alone exceeds maxLength", () => {
+    const stderr = [
+      "error: short",
+      `   --> ${"src/".repeat(100)}lib.rs:1:1`,
+    ].join("\n");
+    const result = firstCompilerErrorLine(stderr, 50);
+    expect(result).toHaveLength(50);
+  });
 });

--- a/apps/web/src/lib/challenge/compiler-error.ts
+++ b/apps/web/src/lib/challenge/compiler-error.ts
@@ -28,9 +28,27 @@ export function firstCompilerErrorLine(
   if (index === -1) index = lines.findIndex((l) => l.includes("error"));
   if (index === -1) return "Program did not compile";
 
-  const parts = [lines[index]!.trim()];
+  const errorLine = lines[index]!.trim();
   const next = lines[index + 1]?.trim();
-  if (next?.startsWith("-->")) parts.push(next);
+  const location = next?.startsWith("-->") ? next : undefined;
 
-  return parts.join(" ").slice(0, maxLength);
+  if (!location) return errorLine.slice(0, maxLength);
+
+  // Truncate each half on its own budget so a long diagnostic never cuts
+  // the `--> file:line:col` location mid-string — the location gets first
+  // claim on the budget, the error line takes what's left.
+  const separator = " ";
+  let truncatedLocation = location.slice(
+    0,
+    Math.max(0, maxLength - separator.length)
+  );
+  const truncatedError = errorLine.slice(
+    0,
+    Math.max(0, maxLength - separator.length - truncatedLocation.length)
+  );
+  // No room for any of the error line — give the location the full budget
+  // instead of leaving a separator's worth of space unused.
+  if (!truncatedError) truncatedLocation = location.slice(0, maxLength);
+
+  return [truncatedError, truncatedLocation].filter(Boolean).join(separator);
 }

--- a/docs/superpowers/specs/2026-09-09-embedded-wallet-deploy-design.md
+++ b/docs/superpowers/specs/2026-09-09-embedded-wallet-deploy-design.md
@@ -71,7 +71,7 @@ Resolution, mirroring `use-on-chain-enroll.ts`:
 
 **C2. Batch signing helper.** `signAllWithDynamicWallet(txs, account)` in `lib/dynamic/solana.ts`, wrapping the SDK's `signAllTransactions` (present in `@dynamic-labs-sdk/solana` 1.27.1) with the same version-boundary cast and the same `isDynamicSessionExpiredError` semantics as `signWithDynamicWallet`. Returns the signed transactions in order.
 
-**C3. Batch size follows the signer.** `deployProgram` and `resumeDeployment` in `packages/deploy/src/deploy.ts` get an optional `batchSize` (default stays 50). Every batch shares one blockhash fetched before signing, and a blockhash lives roughly 60 to 90 s on devnet. Fifty MPC signatures in one call is an unmeasured cost. The builder measures `signAllTransactions` latency for 10, 25 and 50 transactions against a real Dynamic session and picks the embedded batch size so signing finishes well inside the window (target under 20 s per batch). The number and the measurement go in the PR body. Resume uses the same size.
+**C3. Batch size follows the signer.** `deployProgram` and `resumeDeployment` in `packages/deploy/src/deploy.ts` get an optional `batchSize` (default stays 50). Every batch shares one blockhash fetched before signing, and a blockhash lives roughly 60 to 90 s on devnet. Fifty MPC signatures in one call is an unmeasured cost. The builder measures `signAllTransactions` latency for 10, 25 and 50 transactions against a real Dynamic session and picks the embedded batch size so signing finishes well inside the window (target under 20 s per batch). The number and the measurement go in the PR body. Resume uses the same size. The measured size can go stale (an SDK upgrade, a provider change on Dynamic's side) — a too-large batch then degrades to the existing resend/resume path rather than becoming a security issue.
 
 **C4. Deploy panel uses the signer.** `DeployPanel` replaces `useWallet()` with `useDeploySigner()`:
 
@@ -117,11 +117,11 @@ Resolution, mirroring `use-on-chain-enroll.ts`:
 
 ## Review
 
-PR C touches wallet signing and on-chain spend, so it gets an independent adversarial gate before merge. Points for the gate: the embedded signer cannot be used to sign for a wallet other than the session's; the cache prefix cannot collide across users; the funding card cannot target a different address than the signer; the kill switch degrades to today's behaviour; no new server route.
+PR C touches wallet signing and on-chain spend, so it gets an independent adversarial gate before merge. Points for the gate: the embedded signer cannot be used to sign for a wallet other than the session's; the cache prefix cannot collide across users; the funding card cannot target a different address than the signer; the kill switch degrades to today's behaviour; no new server route; the 1.2x cost buffer in `estimateDeployCost` (C5) holds against real devnet priority-fee spikes, not just the mocked test case.
 
 ## Rollout
 
-Behind the existing `isDynamicEnabled()` flag. Order: B (lint) and A (content) can merge any time, A's lock bump after C is live so the lesson is not exposed with a panel that still ignores embedded wallets. Verify with the owner's own account, then watch `deploy_completed` by `signerKind` for a week.
+Behind the existing `isDynamicEnabled()` flag. Order: B (lint) and A (content) can merge any time, A's lock bump after C is live so the lesson is not exposed with a panel that still ignores embedded wallets. Verify with the owner's own account, then watch `deploy_completed` by `signerKind` for a week. Once PR C lands, `docs/ARCHITECTURE.md` gets a `useDeploySigner()` mention next to the existing enroll-signing pattern.
 
 ## Alternatives considered
 

--- a/onchain-academy/tests/differential/Cargo.toml
+++ b/onchain-academy/tests/differential/Cargo.toml
@@ -1,5 +1,5 @@
 # Standalone workspace: litesvm pins its own solana-sdk line; keep it out of
-# the program workspace (same isolation pattern as tests/rust and trident-tests).
+# the program workspace (same isolation pattern as tests/rust and tests/fuzz).
 [workspace]
 
 [package]


### PR DESCRIPTION
Non-blocking follow-ups from #1211/#1212/#1213 review: rewrites Trident mentions in agent/command docs to the litesvm fuzz harness (`onchain-academy/tests/fuzz`), fixes `firstCompilerErrorLine` to truncate the error line and `-->` location separately instead of joining-then-slicing, drops the redundant local ANSI strip in `challenge-runner.tsx`, and adds three clarifying sentences to the embedded-wallet-deploy spec.

Skips `docs/AUDIT-REPORT.md` and `onchain-academy/scripts/select-program.sh`, already handled by #1214. `pnpm --filter web exec vitest run src/lib/challenge` (63/63) and `tsc --noEmit` both pass.