### PR TITLE
fix(challenge): grade buildable submissions against the canonical harness

### DIFF
--- a/apps/web/src/components/editor/__tests__/challenge-runner.grade-files.test.tsx
+++ b/apps/web/src/components/editor/__tests__/challenge-runner.grade-files.test.tsx
@@ -1,0 +1,91 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { NextIntlClientProvider } from "next-intl";
+import type { TestCase } from "@superteam-lms/types";
+import messages from "@/messages/en.json";
+import {
+  buildGradeFiles,
+  HARNESS_MARKER,
+  LIB_PATH,
+  VERIFY_PATH,
+} from "@/lib/challenge/harness";
+import { ChallengeRunner } from "../challenge-runner";
+
+const h = vi.hoisted(() => ({ buildProgram: vi.fn() }));
+
+vi.mock("@/lib/build-server/client", () => ({ buildProgram: h.buildProgram }));
+vi.mock("@superteam-lms/deploy", () => ({ setCachedBinary: vi.fn() }));
+
+const STARTER = [
+  "use anchor_lang::prelude::*;",
+  'declare_id!("Fg6");',
+  "// TODO (p1): add the `ping` handler here.",
+  "// ─────",
+  HARNESS_MARKER,
+  "mod verify {",
+  "    const PING: fn() = first_program::ping;",
+  "}",
+  "",
+].join("\n");
+
+/** The bypass shape: harness deleted, trailing attribute to eat what follows. */
+const CODE = 'declare_id!("Fg6");\npub fn nothing() {}\n\n#[cfg(any())]\n';
+
+const tests: TestCase[] = [
+  {
+    id: "t1",
+    description: "Program compiles successfully",
+    input: "",
+    expectedOutput: "true",
+  },
+];
+
+beforeEach(() => {
+  h.buildProgram.mockReset();
+  h.buildProgram.mockResolvedValue({ success: true, stderr: "", uuid: "u" });
+});
+
+describe("browser runner sends the same file layout as the server grader", () => {
+  it("matches buildGradeFiles, only declare_id! and the nonce differ", async () => {
+    render(
+      <NextIntlClientProvider locale="en" messages={messages}>
+        <ChallengeRunner
+          code={CODE}
+          starter={STARTER}
+          tests={tests}
+          language="rust"
+          buildType="buildable"
+          onResult={() => {}}
+          onSubmit={() => {}}
+          isComplete={false}
+          xpReward={50}
+        />
+      </NextIntlClientProvider>
+    );
+
+    fireEvent.click(screen.getByRole("button"));
+    await waitFor(() => expect(h.buildProgram).toHaveBeenCalled());
+
+    const sent = (
+      h.buildProgram.mock.calls[0]![0] as {
+        files: { path: string; content: string }[];
+      }
+    ).files;
+    const expected = buildGradeFiles(CODE, STARTER);
+
+    // Same paths, same order, plus the client's cache-busting nonce file.
+    expect(sent.map((f) => f.path)).toEqual([
+      LIB_PATH,
+      VERIFY_PATH,
+      "/src/_nonce.rs",
+    ]);
+    // The harness module is byte-identical to the server's.
+    expect(sent[1]!.content).toBe(expected[1]![1]);
+    // lib.rs differs only where the client pins the generated program id.
+    const normalise = (s: string) =>
+      s.replace(/declare_id!\s*\(\s*"[^"]*"\s*\)/, 'declare_id!("")');
+    expect(normalise(sent[0]!.content)).toBe(normalise(expected[0]![1]));
+    expect(sent[0]!.content).toContain("mod _verify;");
+  });
+});

--- a/apps/web/src/components/editor/challenge-interface.tsx
+++ b/apps/web/src/components/editor/challenge-interface.tsx
@@ -631,6 +631,7 @@ export function ChallengeInterface({
                   language={language}
                   buildType={buildType}
                   isDeployable={isDeployable}
+                  starter={initialCode}
                   onResult={handleResult}
                   onSubmit={handleSubmit}
                   isComplete={isComplete}

--- a/apps/web/src/components/editor/challenge-runner.tsx
+++ b/apps/web/src/components/editor/challenge-runner.tsx
@@ -10,6 +10,7 @@ import { setCachedBinary } from "@superteam-lms/deploy";
 import { executeRustCode } from "@/lib/rust/execute";
 import { buildProgram } from "@/lib/build-server/client";
 import { firstCompilerErrorLine } from "@/lib/challenge/compiler-error";
+import { withCanonicalHarness } from "@/lib/challenge/harness";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import type {
@@ -739,8 +740,14 @@ async function runRustChallenge(
 
 async function runBuildChallenge(
   code: string,
-  tests: TestCase[]
+  tests: TestCase[],
+  starter: string
 ): Promise<ExecutionResult> {
+  // Compile exactly what the server grader will compile: the learner's work with
+  // the lesson's canonical verification harness spliced back on. Without this an
+  // in-editor "Compilar" would go green on a submission the server then fails.
+  const graded = withCanonicalHarness(code, starter);
+
   // Generate a program keypair BEFORE building so we can inject the correct
   // declare_id!() into the source. Anchor validates that the invoked program
   // address matches declare_id at runtime — without this, every deployment
@@ -750,7 +757,7 @@ async function runBuildChallenge(
 
   // Replace any existing declare_id!("...") with the actual program pubkey.
   // The student's placeholder value doesn't matter — we always override it.
-  const buildCode = code.replace(
+  const buildCode = graded.replace(
     /declare_id!\s*\(\s*"[^"]*"\s*\)/,
     `declare_id!("${programId}")`
   );
@@ -845,6 +852,7 @@ export function ChallengeRunner({
   language,
   buildType,
   isDeployable,
+  starter,
   onResult,
   onSubmit,
   isComplete,
@@ -875,7 +883,7 @@ export function ChallengeRunner({
       try {
         if (language === "rust" && buildType === "buildable") {
           // Build path: compile Anchor/Solana program via build server
-          const result = await runBuildChallenge(code, tests);
+          const result = await runBuildChallenge(code, tests, starter ?? "");
           setAllPassed(result.success);
           onResult(result);
 

--- a/apps/web/src/components/editor/challenge-runner.tsx
+++ b/apps/web/src/components/editor/challenge-runner.tsx
@@ -10,7 +10,7 @@ import { setCachedBinary } from "@superteam-lms/deploy";
 import { executeRustCode } from "@/lib/rust/execute";
 import { buildProgram } from "@/lib/build-server/client";
 import { firstCompilerErrorLine } from "@/lib/challenge/compiler-error";
-import { withCanonicalHarness } from "@/lib/challenge/harness";
+import { buildGradeFiles, LIB_PATH } from "@/lib/challenge/harness";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import type {
@@ -744,9 +744,9 @@ async function runBuildChallenge(
   starter: string
 ): Promise<ExecutionResult> {
   // Compile exactly what the server grader will compile: the learner's work with
-  // the lesson's canonical verification harness spliced back on. Without this an
-  // in-editor "Compilar" would go green on a submission the server then fails.
-  const graded = withCanonicalHarness(code, starter);
+  // the lesson's canonical verification harness as its own module. Without this
+  // an in-editor "Compilar" would go green on a submission the server then fails.
+  const graded = buildGradeFiles(code, starter);
 
   // Generate a program keypair BEFORE building so we can inject the correct
   // declare_id!() into the source. Anchor validates that the invoked program
@@ -756,11 +756,18 @@ async function runBuildChallenge(
   const programId = programKeypair.publicKey.toBase58();
 
   // Replace any existing declare_id!("...") with the actual program pubkey.
-  // The student's placeholder value doesn't matter — we always override it.
-  const buildCode = graded.replace(
-    /declare_id!\s*\(\s*"[^"]*"\s*\)/,
-    `declare_id!("${programId}")`
-  );
+  // The student's placeholder value doesn't matter — we always override it. Only
+  // the crate root can carry it; the harness module is sent verbatim.
+  const files = graded.map(([path, content]) => ({
+    path,
+    content:
+      path === LIB_PATH
+        ? content.replace(
+            /declare_id!\s*\(\s*"[^"]*"\s*\)/,
+            `declare_id!("${programId}")`
+          )
+        : content,
+  }));
 
   // The build server uses content-addressable caching (SHA256 of all files).
   // A nonce file busts the cache so we always get a fresh binary for deployment.
@@ -768,7 +775,7 @@ async function runBuildChallenge(
   // The build server only accepts paths matching /src/<name>.rs
   const result = await buildProgram({
     files: [
-      { path: "/src/lib.rs", content: buildCode },
+      ...files,
       { path: "/src/_nonce.rs", content: `// ${crypto.randomUUID()}` },
     ],
   });
@@ -931,7 +938,7 @@ export function ChallengeRunner({
         setIsRunning(false);
       }
     }, 50);
-  }, [code, tests, language, buildType, onResult]);
+  }, [code, tests, language, buildType, starter, onResult]);
 
   const showSubmit =
     allPassed && !isComplete && !isJudging && (!isDeployable || deployComplete);

--- a/apps/web/src/components/editor/types.ts
+++ b/apps/web/src/components/editor/types.ts
@@ -60,6 +60,9 @@ export interface ChallengeRunnerProps {
   language: EditorLanguage;
   buildType?: BuildType;
   isDeployable?: boolean;
+  /** Starter source. Buildable runs splice its verification harness back on so
+   * the in-editor verdict matches the server's (see lib/challenge/harness.ts). */
+  starter?: string;
   onResult: (result: ExecutionResult) => void;
   onSubmit: () => void;
   isComplete: boolean;

--- a/apps/web/src/lib/challenge/__tests__/buildable-executor.test.ts
+++ b/apps/web/src/lib/challenge/__tests__/buildable-executor.test.ts
@@ -27,6 +27,21 @@ const tests: AdminTestCase[] = [
 
 const CODE = 'use anchor_lang::prelude::*;\ndeclare_id!("Fg6");\n';
 
+const MARKER =
+  "// VERIFICATION HARNESS — DO NOT EDIT ANYTHING BELOW THIS LINE.";
+/** A starter shaped like a real lesson's: exercise on top, harness below. */
+const STARTER = [
+  "use anchor_lang::prelude::*;",
+  'declare_id!("Fg6");',
+  "// TODO (p1): add the `ping` handler here.",
+  "// \u2500\u2500\u2500\u2500\u2500",
+  MARKER,
+  "mod verify {",
+  "    const PING: fn() = first_program::ping;",
+  "}",
+  "",
+].join("\n");
+
 /** Stub the build server. `respond` gets the parsed request body. */
 function mockBuildServer(
   respond: (body: {
@@ -72,7 +87,7 @@ describe("runBuildableSubmission — build server configured", () => {
   it("passes ALL tests when the program compiles (success: true)", async () => {
     mockBuildServer(() => ({ success: true }));
     const { runBuildableSubmission } = await loadGrader();
-    const r = await runBuildableSubmission(CODE, tests);
+    const r = await runBuildableSubmission(CODE, tests, STARTER);
     expect(r.available).toBe(true);
     expect(r).toMatchObject({ passed: true });
     if (r.available) {
@@ -87,7 +102,7 @@ describe("runBuildableSubmission — build server configured", () => {
       stderr: "error[E0425]: cannot find value `x` in this scope",
     }));
     const { runBuildableSubmission } = await loadGrader();
-    const r = await runBuildableSubmission(CODE, tests);
+    const r = await runBuildableSubmission(CODE, tests, STARTER);
     expect(r).toMatchObject({ available: true, passed: false });
     if (r.available) {
       expect(r.results[0]?.passed).toBe(false);
@@ -117,8 +132,47 @@ describe("runBuildableSubmission — build server configured", () => {
     );
     vi.stubGlobal("fetch", spy);
     const { runBuildableSubmission } = await loadGrader();
-    await runBuildableSubmission(CODE, tests);
+    await runBuildableSubmission(CODE, tests, STARTER);
     expect(spy).toHaveBeenCalledOnce();
+  });
+
+  it("compiles the submission with the starter's canonical harness", async () => {
+    let libRs = "";
+    mockBuildServer((body) => {
+      libRs = body.files.find((f) => f[0] === "/src/lib.rs")?.[1] ?? "";
+      return { success: true };
+    });
+    const { runBuildableSubmission } = await loadGrader();
+    // The exploit: delete the exercise and ship something that compiles alone.
+    await runBuildableSubmission("pub fn nothing() {}", tests, STARTER);
+    expect(libRs).toContain("pub fn nothing() {}");
+    expect(libRs).toContain("first_program::ping");
+  });
+
+  it("replaces a harness the submission tampered with", async () => {
+    let libRs = "";
+    mockBuildServer((body) => {
+      libRs = body.files.find((f) => f[0] === "/src/lib.rs")?.[1] ?? "";
+      return { success: true };
+    });
+    const { runBuildableSubmission } = await loadGrader();
+    await runBuildableSubmission(
+      `pub fn nothing() {}\n${MARKER}\n// harness deleted\n`,
+      tests,
+      STARTER
+    );
+    expect(libRs).not.toContain("// harness deleted");
+    expect(libRs).toContain("first_program::ping");
+    expect(libRs.split(MARKER)).toHaveLength(2);
+  });
+
+  it("fails closed when the starter carries no harness", async () => {
+    const spy = vi.fn();
+    vi.stubGlobal("fetch", spy);
+    const { runBuildableSubmission } = await loadGrader();
+    const r = await runBuildableSubmission(CODE, tests, "fn main() {}");
+    expect(r).toEqual({ available: false, reason: "executor_unavailable" });
+    expect(spy).not.toHaveBeenCalled();
   });
 
   it("degrades closed when the build server is unreachable", async () => {
@@ -129,14 +183,14 @@ describe("runBuildableSubmission — build server configured", () => {
       })
     );
     const { runBuildableSubmission } = await loadGrader();
-    const r = await runBuildableSubmission(CODE, tests);
+    const r = await runBuildableSubmission(CODE, tests, STARTER);
     expect(r).toEqual({ available: false, reason: "executor_unavailable" });
   });
 
   it("degrades closed on a non-2xx build-server response", async () => {
     mockBuildServer(() => ({ ok: false }));
     const { runBuildableSubmission } = await loadGrader();
-    const r = await runBuildableSubmission(CODE, tests);
+    const r = await runBuildableSubmission(CODE, tests, STARTER);
     expect(r).toEqual({ available: false, reason: "executor_unavailable" });
   });
 
@@ -145,7 +199,7 @@ describe("runBuildableSubmission — build server configured", () => {
     vi.stubGlobal("fetch", spy);
     const { runBuildableSubmission } = await loadGrader();
     const big = "// x\n".repeat(30_000); // > 100KB
-    const r = await runBuildableSubmission(big, tests);
+    const r = await runBuildableSubmission(big, tests, STARTER);
     expect(r).toMatchObject({ available: true, passed: false });
     expect(spy).not.toHaveBeenCalled();
   });
@@ -159,7 +213,7 @@ describe("runBuildableSubmission — build server NOT configured", () => {
     const { runBuildableSubmission, isBuildServerConfigured } =
       await loadGrader();
     expect(isBuildServerConfigured()).toBe(false);
-    const r = await runBuildableSubmission(CODE, tests);
+    const r = await runBuildableSubmission(CODE, tests, STARTER);
     expect(r).toEqual({ available: false, reason: "executor_unavailable" });
     expect(spy).not.toHaveBeenCalled();
   });
@@ -171,7 +225,7 @@ describe("gradeCode — buildable routing", () => {
     key: "c1",
     language: "rust" as const,
     buildType: "buildable" as const,
-    starter: "",
+    starter: STARTER,
     tests,
     solution: CODE,
   };

--- a/apps/web/src/lib/challenge/__tests__/buildable-executor.test.ts
+++ b/apps/web/src/lib/challenge/__tests__/buildable-executor.test.ts
@@ -66,6 +66,16 @@ function mockBuildServer(
   );
 }
 
+/** Stub a passing build server and record the files it was sent, by path. */
+function captureFiles(): Map<string, string> {
+  const sent = new Map<string, string>();
+  mockBuildServer((body) => {
+    for (const [path, content] of body.files) sent.set(path, content);
+    return { success: true };
+  });
+  return sent;
+}
+
 async function loadGrader() {
   vi.resetModules();
   return import("../buildable-executor");
@@ -110,7 +120,7 @@ describe("runBuildableSubmission — build server configured", () => {
     }
   });
 
-  it("sends /src/lib.rs plus a cache-busting nonce file, with the API key", async () => {
+  it("sends lib.rs + the harness module + a nonce file, with the API key", async () => {
     const spy = vi.fn(
       async (
         _url: string,
@@ -120,9 +130,14 @@ describe("runBuildableSubmission — build server configured", () => {
         expect(_url).toBe(`${URL}/build`);
         expect(init.headers["X-API-Key"]).toBe(KEY);
         const paths = body.files.map((f) => f[0]);
-        expect(paths).toContain("/src/lib.rs");
+        expect(paths.slice(0, 2)).toEqual(["/src/lib.rs", "/src/_verify.rs"]);
         expect(
-          paths.some((p) => p.endsWith(".rs") && p !== "/src/lib.rs")
+          paths.some(
+            (p) =>
+              p.endsWith(".rs") &&
+              p !== "/src/lib.rs" &&
+              p !== "/src/_verify.rs"
+          )
         ).toBe(true);
         return {
           ok: true,
@@ -137,33 +152,54 @@ describe("runBuildableSubmission — build server configured", () => {
   });
 
   it("compiles the submission with the starter's canonical harness", async () => {
-    let libRs = "";
-    mockBuildServer((body) => {
-      libRs = body.files.find((f) => f[0] === "/src/lib.rs")?.[1] ?? "";
-      return { success: true };
-    });
+    const sent = captureFiles();
     const { runBuildableSubmission } = await loadGrader();
     // The exploit: delete the exercise and ship something that compiles alone.
     await runBuildableSubmission("pub fn nothing() {}", tests, STARTER);
-    expect(libRs).toContain("pub fn nothing() {}");
-    expect(libRs).toContain("first_program::ping");
+    expect(sent.get("/src/lib.rs")).toContain("pub fn nothing() {}");
+    expect(sent.get("/src/lib.rs")).toContain("mod _verify;");
+    expect(sent.get("/src/_verify.rs")).toContain("first_program::ping");
   });
 
   it("replaces a harness the submission tampered with", async () => {
-    let libRs = "";
-    mockBuildServer((body) => {
-      libRs = body.files.find((f) => f[0] === "/src/lib.rs")?.[1] ?? "";
-      return { success: true };
-    });
+    const sent = captureFiles();
     const { runBuildableSubmission } = await loadGrader();
     await runBuildableSubmission(
       `pub fn nothing() {}\n${MARKER}\n// harness deleted\n`,
       tests,
       STARTER
     );
-    expect(libRs).not.toContain("// harness deleted");
-    expect(libRs).toContain("first_program::ping");
-    expect(libRs.split(MARKER)).toHaveLength(2);
+    expect(sent.get("/src/lib.rs")).not.toContain("// harness deleted");
+    expect(sent.get("/src/lib.rs")).not.toContain(MARKER);
+    expect(sent.get("/src/_verify.rs")).toContain("first_program::ping");
+  });
+
+  it("keeps a trailing attribute away from the harness (bypass 1)", async () => {
+    const sent = captureFiles();
+    const { runBuildableSubmission } = await loadGrader();
+    await runBuildableSubmission(
+      "pub fn nothing() {}\n\n#[cfg(any())]\n",
+      tests,
+      STARTER
+    );
+    expect(sent.get("/src/lib.rs")?.trimEnd().endsWith("#[cfg(any())]")).toBe(
+      true
+    );
+    expect(sent.get("/src/lib.rs")).not.toContain("first_program::ping");
+  });
+
+  it("pushes a crate-level inner attribute below an item (bypass 2)", async () => {
+    const sent = captureFiles();
+    const { runBuildableSubmission } = await loadGrader();
+    await runBuildableSubmission(
+      "#![cfg(any())]\npub fn nothing() {}\n",
+      tests,
+      STARTER
+    );
+    const lib = sent.get("/src/lib.rs") ?? "";
+    expect(lib.indexOf("mod _verify;")).toBeLessThan(
+      lib.indexOf("#![cfg(any())]")
+    );
   });
 
   it("fails closed when the starter carries no harness", async () => {

--- a/apps/web/src/lib/challenge/__tests__/harness.sbf.integration.test.ts
+++ b/apps/web/src/lib/challenge/__tests__/harness.sbf.integration.test.ts
@@ -1,0 +1,122 @@
+/**
+ * The string-level tests prove WHERE the harness lands; only a real compile
+ * proves the bypasses are dead. This one runs `cargo build-sbf` against the
+ * build server's own `programs/Cargo.toml` — the same manifest and toolchain
+ * prod compiles with — on the live lessons' starters and solutions.
+ *
+ * OPT-IN: needs the Solana toolchain (several minutes of cold compile), so it is
+ * skipped unless `SBF_INTEGRATION=1` and `cargo-build-sbf` is on PATH.
+ *
+ *   SBF_INTEGRATION=1 pnpm --filter web exec vitest run src/lib/challenge
+ */
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, writeFileSync, copyFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+import { lessonsById } from "@/lib/content/store";
+import { buildGradeFiles, splitHarness } from "../harness";
+
+function hasToolchain(): boolean {
+  try {
+    execFileSync("cargo-build-sbf", ["--version"], { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const ENABLED = process.env.SBF_INTEGRATION === "1" && hasToolchain();
+
+const MANIFEST = resolve(
+  __dirname,
+  "../../../../../..",
+  "apps/build-server/programs/Cargo.toml"
+);
+
+/** Compile a submission the way the grader would. Returns the build's stderr. */
+function compile(
+  submission: string,
+  starter: string
+): { ok: boolean; out: string } {
+  const dir = mkdtempSync(join(tmpdir(), "harness-sbf-"));
+  mkdirSync(join(dir, "src"));
+  copyFileSync(MANIFEST, join(dir, "Cargo.toml"));
+  for (const [path, content] of buildGradeFiles(submission, starter)) {
+    writeFileSync(join(dir, path.replace(/^\//, "")), content);
+  }
+  try {
+    const out = execFileSync(
+      "cargo",
+      [
+        "build-sbf",
+        "--manifest-path",
+        "Cargo.toml",
+        "--tools-version",
+        "v1.54",
+      ],
+      { cwd: dir, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] }
+    );
+    return { ok: true, out };
+  } catch (err) {
+    const e = err as { stdout?: string; stderr?: string };
+    return { ok: false, out: `${e.stdout ?? ""}${e.stderr ?? ""}` };
+  }
+}
+
+interface CodeBlock {
+  _type: string;
+  buildType?: string | null;
+  starter?: string;
+  solution?: string;
+}
+
+function block(lessonId: string): CodeBlock {
+  const b = (
+    lessonsById.get(lessonId)?.blocks as CodeBlock[] | undefined
+  )?.find((x) => x._type === "code" && x.buildType === "buildable");
+  if (!b) throw new Error(`no buildable block in ${lessonId}`);
+  return b;
+}
+
+const LESSONS = [
+  "lesson-b2s-your-first-solana-program",
+  "lesson-b2s-an-anchor-vault",
+];
+
+describe.skipIf(!ENABLED)(
+  "buildGradeFiles compiles as the grader intends",
+  () => {
+    for (const id of LESSONS) {
+      describe(id, () => {
+        const { starter = "", solution = "" } = block(id);
+
+        it("rejects a dangling trailing attribute (bypass 1)", () => {
+          const r = compile("pub fn nothing() {}\n\n#[cfg(any())]\n", starter);
+          expect(r.ok).toBe(false);
+          expect(r.out).toContain("expected item after attributes");
+        }, 600_000);
+
+        it("rejects a crate-level inner attribute (bypass 2)", () => {
+          const r = compile("#![cfg(any())]\npub fn nothing() {}\n", starter);
+          expect(r.ok).toBe(false);
+          expect(r.out).toContain("inner attribute is not permitted");
+        }, 600_000);
+
+        it("rejects an emptied submission", () => {
+          expect(compile("pub fn nothing() {}\n", starter).ok).toBe(false);
+        }, 600_000);
+
+        it("accepts the reference solution (harness inline)", () => {
+          expect(compile(solution, starter).ok).toBe(true);
+        }, 600_000);
+
+        it("accepts the reference solution with its harness region removed", () => {
+          expect(compile(splitHarness(solution).body, starter).ok).toBe(true);
+        }, 600_000);
+      });
+    }
+  }
+);

--- a/apps/web/src/lib/challenge/__tests__/harness.test.ts
+++ b/apps/web/src/lib/challenge/__tests__/harness.test.ts
@@ -2,7 +2,23 @@ import { describe, it, expect, vi } from "vitest";
 
 vi.mock("server-only", () => ({}));
 import { lessonsById } from "@/lib/content/store";
-import { HARNESS_MARKER, splitHarness, withCanonicalHarness } from "../harness";
+import {
+  buildGradeFiles,
+  HARNESS_MARKER,
+  LIB_PATH,
+  splitHarness,
+  VERIFY_PATH,
+} from "../harness";
+
+/** The two graded files, keyed by path. */
+function graded(submission: string, starter: string) {
+  const files = new Map(buildGradeFiles(submission, starter));
+  return {
+    files,
+    lib: files.get(LIB_PATH) ?? "",
+    verify: files.get(VERIFY_PATH) ?? "",
+  };
+}
 
 const RULE = "// ─────────────────────────────────────────";
 const STARTER = [
@@ -49,40 +65,68 @@ describe("splitHarness", () => {
   });
 });
 
-describe("withCanonicalHarness", () => {
-  it("re-attaches the harness a learner deleted", () => {
-    const spliced = withCanonicalHarness("pub fn nothing() {}", STARTER);
-    expect(spliced).toContain("pub fn nothing() {}");
-    expect(spliced).toContain("first_program::ping");
+describe("buildGradeFiles", () => {
+  it("puts the harness in its own module file, never in lib.rs", () => {
+    const { files, lib, verify } = graded("pub fn nothing() {}", STARTER);
+    expect([...files.keys()]).toEqual([LIB_PATH, VERIFY_PATH]);
+    expect(lib).toContain("pub fn nothing() {}");
+    expect(lib).not.toContain(HARNESS_MARKER);
+    expect(verify).toContain("first_program::ping");
+  });
+
+  it("declares the harness module ABOVE the learner's body", () => {
+    const { lib } = graded("pub fn nothing() {}", STARTER);
+    expect(lib.startsWith("#[allow(dead_code)]\nmod _verify;\n")).toBe(true);
+    expect(lib.indexOf("mod _verify;")).toBeLessThan(
+      lib.indexOf("pub fn nothing() {}")
+    );
+  });
+
+  it("leaves a trailing attribute dangling at EOF, not on the harness", () => {
+    // Bypass 1: `#[cfg(any())]` with nothing after it used to bind to the
+    // appended `mod verify` and delete it. Nothing follows it now.
+    const { lib } = graded("pub fn nothing() {}\n\n#[cfg(any())]\n", STARTER);
+    expect(lib.trimEnd().endsWith("#[cfg(any())]")).toBe(true);
+    expect(lib).not.toContain("first_program::ping");
+  });
+
+  it("pushes a crate-level inner attribute below an item (a hard error)", () => {
+    // Bypass 2: `#![cfg(any())]` as line 1 stripped the whole crate. With the
+    // module declaration first, rustc rejects it outright.
+    const { lib } = graded("#![cfg(any())]\npub fn nothing() {}\n", STARTER);
+    expect(lib.indexOf("mod _verify;")).toBeLessThan(
+      lib.indexOf("#![cfg(any())]")
+    );
   });
 
   it("replaces a harness the learner edited into a no-op", () => {
     const tampered = `pub fn nothing() {}\n${RULE}\n${HARNESS_MARKER}\n// nothing here\n`;
-    const spliced = withCanonicalHarness(tampered, STARTER);
-    expect(spliced).not.toContain("// nothing here");
-    expect(spliced).toContain("first_program::ping");
+    const { lib, verify } = graded(tampered, STARTER);
+    expect(lib).not.toContain("// nothing here");
+    expect(verify).toContain("first_program::ping");
   });
 
-  it("collapses a duplicated harness back to exactly one", () => {
-    const spliced = withCanonicalHarness(`${STARTER}\n${HARNESS}`, STARTER);
-    expect(spliced.split(HARNESS_MARKER)).toHaveLength(2);
+  it("strips a duplicated harness whole", () => {
+    const { lib, verify } = graded(`${STARTER}\n${HARNESS}`, STARTER);
+    expect(lib).not.toContain(HARNESS_MARKER);
+    expect(verify.split(HARNESS_MARKER)).toHaveLength(2);
   });
 
-  it("leaves an untouched submission's own harness in place, once", () => {
-    const spliced = withCanonicalHarness(STARTER, STARTER);
-    expect(spliced.split(HARNESS_MARKER)).toHaveLength(2);
-    expect(spliced).toContain("// TODO: add `ping`.");
+  it("keeps an untouched submission's own body, harness moved out", () => {
+    const { lib } = graded(STARTER, STARTER);
+    expect(lib).toContain("// TODO: add `ping`.");
+    expect(lib).not.toContain(HARNESS_MARKER);
   });
 
-  it("returns the submission unchanged when the starter has no harness", () => {
-    expect(withCanonicalHarness("pub fn nothing() {}", "fn main() {}")).toBe(
-      "pub fn nothing() {}"
-    );
+  it("returns a lone lib.rs when the starter has no harness", () => {
+    expect(buildGradeFiles("pub fn nothing() {}", "fn main() {}")).toEqual([
+      [LIB_PATH, "pub fn nothing() {}"],
+    ]);
   });
 
   it("normalises CRLF submissions", () => {
-    const crlf = "pub fn nothing() {}\r\n";
-    expect(withCanonicalHarness(crlf, STARTER)).not.toContain("\r");
+    const { lib } = graded("pub fn nothing() {}\r\n", STARTER);
+    expect(lib).not.toContain("\r");
   });
 });
 
@@ -113,24 +157,24 @@ function buildableStarter(lessonId: string): string {
 }
 
 describe("the empty-submission exploit is closed", () => {
-  it("splices ping/Ping back into a `pub fn nothing() {}` submission", () => {
-    const spliced = withCanonicalHarness(
+  it("compiles ping/Ping against a `pub fn nothing() {}` submission", () => {
+    const { verify } = graded(
       "pub fn nothing() {}",
       buildableStarter("lesson-b2s-your-first-solana-program")
     );
-    // Both symbols the deleted exercise had to define — the spliced source
+    // Both symbols the deleted exercise had to define — the graded crate
     // cannot compile without them.
-    expect(spliced).toContain("first_program::ping");
-    expect(spliced).toContain("Ping {}");
+    expect(verify).toContain("first_program::ping");
+    expect(verify).toContain("Ping {}");
   });
 
-  it("splices the bump type-check back into an emptied vault submission", () => {
-    const spliced = withCanonicalHarness(
+  it("compiles the bump type-check against an emptied vault submission", () => {
+    const { verify } = graded(
       "pub fn nothing() {}",
       buildableStarter("lesson-b2s-an-anchor-vault")
     );
-    expect(spliced).toContain("s.vault_bump");
-    expect(spliced).toContain("s.state_bump");
+    expect(verify).toContain("s.vault_bump");
+    expect(verify).toContain("s.state_bump");
   });
 
   it("every live buildable starter carries the marker", () => {

--- a/apps/web/src/lib/challenge/__tests__/harness.test.ts
+++ b/apps/web/src/lib/challenge/__tests__/harness.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+import { lessonsById } from "@/lib/content/store";
+import { HARNESS_MARKER, splitHarness, withCanonicalHarness } from "../harness";
+
+const RULE = "// ─────────────────────────────────────────";
+const STARTER = [
+  "use anchor_lang::prelude::*;",
+  "",
+  "// TODO: add `ping`.",
+  "",
+  RULE,
+  HARNESS_MARKER,
+  "// A type check.",
+  RULE,
+  "mod verify {",
+  "    const PING: fn() = first_program::ping;",
+  "}",
+  "",
+].join("\n");
+
+const HARNESS = splitHarness(STARTER).harness;
+
+describe("splitHarness", () => {
+  it("splits at the marker and keeps the rule line with the harness", () => {
+    const { body, harness } = splitHarness(STARTER);
+    expect(body).toBe("use anchor_lang::prelude::*;\n\n// TODO: add `ping`.\n");
+    expect(harness.startsWith(RULE)).toBe(true);
+    expect(harness).toContain("first_program::ping");
+  });
+
+  it("treats a source without the marker as all body", () => {
+    expect(splitHarness("pub fn nothing() {}")).toEqual({
+      body: "pub fn nothing() {}",
+      harness: "",
+    });
+  });
+
+  it("splits at the FIRST marker when the harness is duplicated", () => {
+    const dup = `${STARTER}\n${HARNESS}`;
+    expect(splitHarness(dup).body).not.toContain(HARNESS_MARKER);
+    expect(splitHarness(dup).harness.split(HARNESS_MARKER)).toHaveLength(3);
+  });
+
+  it("is insensitive to CRLF line endings", () => {
+    const crlf = STARTER.replace(/\n/g, "\r\n");
+    expect(splitHarness(crlf)).toEqual(splitHarness(STARTER));
+  });
+});
+
+describe("withCanonicalHarness", () => {
+  it("re-attaches the harness a learner deleted", () => {
+    const spliced = withCanonicalHarness("pub fn nothing() {}", STARTER);
+    expect(spliced).toContain("pub fn nothing() {}");
+    expect(spliced).toContain("first_program::ping");
+  });
+
+  it("replaces a harness the learner edited into a no-op", () => {
+    const tampered = `pub fn nothing() {}\n${RULE}\n${HARNESS_MARKER}\n// nothing here\n`;
+    const spliced = withCanonicalHarness(tampered, STARTER);
+    expect(spliced).not.toContain("// nothing here");
+    expect(spliced).toContain("first_program::ping");
+  });
+
+  it("collapses a duplicated harness back to exactly one", () => {
+    const spliced = withCanonicalHarness(`${STARTER}\n${HARNESS}`, STARTER);
+    expect(spliced.split(HARNESS_MARKER)).toHaveLength(2);
+  });
+
+  it("leaves an untouched submission's own harness in place, once", () => {
+    const spliced = withCanonicalHarness(STARTER, STARTER);
+    expect(spliced.split(HARNESS_MARKER)).toHaveLength(2);
+    expect(spliced).toContain("// TODO: add `ping`.");
+  });
+
+  it("returns the submission unchanged when the starter has no harness", () => {
+    expect(withCanonicalHarness("pub fn nothing() {}", "fn main() {}")).toBe(
+      "pub fn nothing() {}"
+    );
+  });
+
+  it("normalises CRLF submissions", () => {
+    const crlf = "pub fn nothing() {}\r\n";
+    expect(withCanonicalHarness(crlf, STARTER)).not.toContain("\r");
+  });
+});
+
+// --- The exploit, against real content ---------------------------------------
+
+interface CodeBlock {
+  _type: string;
+  buildType?: string | null;
+  starter?: string;
+}
+
+/** Every buildable code block in the live content bundle. */
+function buildableBlocks(): CodeBlock[] {
+  return [...lessonsById.values()].flatMap((lesson) =>
+    (lesson.blocks as CodeBlock[]).filter(
+      (b) => b._type === "code" && b.buildType === "buildable"
+    )
+  );
+}
+
+function buildableStarter(lessonId: string): string {
+  const lesson = lessonsById.get(lessonId);
+  const block = (lesson?.blocks as CodeBlock[] | undefined)?.find(
+    (b) => b._type === "code" && b.buildType === "buildable"
+  );
+  if (!block?.starter) throw new Error(`no buildable block in ${lessonId}`);
+  return block.starter;
+}
+
+describe("the empty-submission exploit is closed", () => {
+  it("splices ping/Ping back into a `pub fn nothing() {}` submission", () => {
+    const spliced = withCanonicalHarness(
+      "pub fn nothing() {}",
+      buildableStarter("lesson-b2s-your-first-solana-program")
+    );
+    // Both symbols the deleted exercise had to define — the spliced source
+    // cannot compile without them.
+    expect(spliced).toContain("first_program::ping");
+    expect(spliced).toContain("Ping {}");
+  });
+
+  it("splices the bump type-check back into an emptied vault submission", () => {
+    const spliced = withCanonicalHarness(
+      "pub fn nothing() {}",
+      buildableStarter("lesson-b2s-an-anchor-vault")
+    );
+    expect(spliced).toContain("s.vault_bump");
+    expect(spliced).toContain("s.state_bump");
+  });
+
+  it("every live buildable starter carries the marker", () => {
+    const blocks = buildableBlocks();
+    expect(blocks.length).toBeGreaterThan(0);
+    for (const b of blocks) {
+      expect(splitHarness(b.starter ?? "").harness).not.toBe("");
+    }
+  });
+});

--- a/apps/web/src/lib/challenge/buildable-executor.ts
+++ b/apps/web/src/lib/challenge/buildable-executor.ts
@@ -15,17 +15,21 @@
  * the browser `runBuildChallenge` (in `challenge-runner.tsx`) is a non-
  * authoritative UX pre-check; the server is the source of truth.
  *
- * GRADING RUBRIC (compilation success)
- * ------------------------------------
+ * GRADING RUBRIC (the canonical harness compiles)
+ * -----------------------------------------------
  * Every buildable lesson's tests are compilation checks. Test 0 is always
  * "Program compiles successfully"; any further tests are prose content-checks
  * ("Code contains a greet function", …) that the browser runner ALSO grades as
- * plain compile-success (it never regexes the description). We honour the same
- * contract server-side: a submission passes iff the build server reports the
- * program compiled. The build server's own `build.rs` still defers IDL parsing
- * ("no anchor-syn"), so `success: bool` is the only authoritative signal — and a
- * clean SBF compile is the realistic, non-forgeable v1 bar for these lessons.
- * (If a future lesson encodes a checkable expected result, extend here.)
+ * plain compile-success (it never regexes the description).
+ *
+ * Compilation ALONE is not a grade: the build server copies a template
+ * Cargo.toml, so `pub fn nothing() {}` compiles and the learner would pass by
+ * deleting the exercise. What makes the verdict mean something is the lesson's
+ * verification harness — a type-level check naming the symbols the exercise has
+ * to define, shipped at the bottom of `starter`. So we do not compile what the
+ * learner sent: we compile `withCanonicalHarness(code, starter)`, which strips
+ * any harness region the submission carries and re-appends the STARTER's. A
+ * submission passes iff THAT compiles.
  *
  * SECURITY — this path grants on-chain XP, so it must resist a hostile
  * submission forging a pass:
@@ -42,6 +46,10 @@
  *     failed (a bad submission, not an outage).
  *   - SIZE-CAPPED. The raw submission is rejected above `MAX_BUILDABLE_BYTES`
  *     before any network call.
+ *   - FAIL-CLOSED ON A HARNESS-LESS LESSON. If the block's starter carries no
+ *     harness there is nothing to grade against, so the grader reports
+ *     `available: false` rather than falling back to bare compilation. Content
+ *     CI (gate 22) is what keeps such a lesson from shipping.
  *
  * ⚠️ OPERATIONAL SECURITY — grading an untrusted `anchor build` runs the
  * submission's `build.rs` / proc-macros as arbitrary code on the build host; the
@@ -61,6 +69,7 @@ import type { AdminTestCase } from "@superteam-lms/types";
 import { serverEnv } from "@/lib/env.server";
 import type { ServerTestResult, SubmissionRunResult } from "./executor";
 import { firstCompilerErrorLine } from "./compiler-error";
+import { splitHarness, withCanonicalHarness } from "./harness";
 
 const BUILD_SERVER_URL = serverEnv.BUILD_SERVER_URL;
 const BUILD_SERVER_API_KEY = serverEnv.BUILD_SERVER_API_KEY;
@@ -102,9 +111,9 @@ export function isBuildServerConfigured(): boolean {
  * one learner's PASS/FAIL is never served from another submission's cached
  * entry — the grade always reflects THIS exact source.
  */
-function toBuildFiles(code: string, nonce: string): [string, string][] {
+function toBuildFiles(source: string, nonce: string): [string, string][] {
   return [
-    ["/src/lib.rs", code],
+    ["/src/lib.rs", source],
     ["/src/_grade_nonce.rs", `// ${nonce}`],
   ];
 }
@@ -151,7 +160,8 @@ function allPassed(tests: AdminTestCase[]): SubmissionRunResult {
  */
 export async function runBuildableSubmission(
   code: string,
-  tests: AdminTestCase[]
+  tests: AdminTestCase[],
+  starter: string
 ): Promise<SubmissionRunResult> {
   // Fail closed when the build server is not configured. This is the guard that
   // leaves prod (build server not deployed) unchanged — a buildable submission
@@ -164,8 +174,14 @@ export async function runBuildableSubmission(
     return allFailed(tests, "Submission too large");
   }
 
+  // No harness in the starter → nothing distinguishes a real solution from an
+  // empty file. Deny rather than grade on bare compilation.
+  if (!splitHarness(starter).harness) {
+    return { available: false, reason: "executor_unavailable" };
+  }
+
   const nonce = crypto.randomUUID();
-  const files = toBuildFiles(code, nonce);
+  const files = toBuildFiles(withCanonicalHarness(code, starter), nonce);
 
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), UPSTREAM_TIMEOUT_MS);

--- a/apps/web/src/lib/challenge/buildable-executor.ts
+++ b/apps/web/src/lib/challenge/buildable-executor.ts
@@ -27,8 +27,10 @@
  * deleting the exercise. What makes the verdict mean something is the lesson's
  * verification harness — a type-level check naming the symbols the exercise has
  * to define, shipped at the bottom of `starter`. So we do not compile what the
- * learner sent: we compile `withCanonicalHarness(code, starter)`, which strips
- * any harness region the submission carries and re-appends the STARTER's. A
+ * learner sent: we compile `buildGradeFiles(code, starter)`, which strips any
+ * harness region the submission carries and compiles the STARTER's as a separate
+ * `/src/_verify.rs` module, declared on the line ABOVE the body so nothing the
+ * learner writes can switch it off (an append could be — see `harness.ts`). A
  * submission passes iff THAT compiles.
  *
  * SECURITY — this path grants on-chain XP, so it must resist a hostile
@@ -69,7 +71,7 @@ import type { AdminTestCase } from "@superteam-lms/types";
 import { serverEnv } from "@/lib/env.server";
 import type { ServerTestResult, SubmissionRunResult } from "./executor";
 import { firstCompilerErrorLine } from "./compiler-error";
-import { splitHarness, withCanonicalHarness } from "./harness";
+import { buildGradeFiles, splitHarness } from "./harness";
 
 const BUILD_SERVER_URL = serverEnv.BUILD_SERVER_URL;
 const BUILD_SERVER_API_KEY = serverEnv.BUILD_SERVER_API_KEY;
@@ -102,20 +104,18 @@ export function isBuildServerConfigured(): boolean {
 }
 
 /**
- * The build server only accepts source paths matching `^/src/<name>.rs$`, so a
- * buildable submission is always compiled as the crate's `src/lib.rs`. It also
- * pins `declare_id!` at runtime, but for a *compile-only* grade the placeholder
- * id compiles fine, so we leave the source byte-identical (no rewrite needed).
- *
- * A per-request nonce file busts the build server's content-addressable cache so
- * one learner's PASS/FAIL is never served from another submission's cached
- * entry — the grade always reflects THIS exact source.
+ * The graded files plus a per-request nonce file, which busts the build server's
+ * content-addressable cache so one learner's PASS/FAIL is never served from
+ * another submission's cached entry — the grade always reflects THIS exact
+ * source. The build server pins `declare_id!` at runtime, but for a
+ * *compile-only* grade the placeholder id compiles fine, so the submission goes
+ * over byte-identical (no rewrite needed).
  */
-function toBuildFiles(source: string, nonce: string): [string, string][] {
-  return [
-    ["/src/lib.rs", source],
-    ["/src/_grade_nonce.rs", `// ${nonce}`],
-  ];
+function toBuildFiles(
+  graded: [string, string][],
+  nonce: string
+): [string, string][] {
+  return [...graded, ["/src/_grade_nonce.rs", `// ${nonce}`]];
 }
 
 /** Fail every test with the same reason (bad submission, not a build outage). */
@@ -181,7 +181,7 @@ export async function runBuildableSubmission(
   }
 
   const nonce = crypto.randomUUID();
-  const files = toBuildFiles(withCanonicalHarness(code, starter), nonce);
+  const files = toBuildFiles(buildGradeFiles(code, starter), nonce);
 
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), UPSTREAM_TIMEOUT_MS);

--- a/apps/web/src/lib/challenge/harness.ts
+++ b/apps/web/src/lib/challenge/harness.ts
@@ -1,5 +1,6 @@
 /**
- * Splice a buildable lesson's verification harness onto a learner submission.
+ * Build the file set a buildable submission is graded on: the learner's body in
+ * `/src/lib.rs`, the lesson's canonical verification harness in its OWN file.
  *
  * A buildable challenge is graded by compiling it (see `buildable-executor.ts`),
  * so the only thing that makes the grade mean anything is the harness the lesson
@@ -8,7 +9,21 @@
  * just text they can delete — and `pub fn nothing() {}` compiles fine against
  * the build server's template Cargo.toml. So the server grader (and, so it
  * agrees, the browser pre-check) strips whatever harness region the submission
- * carries and appends the STARTER's canonical one before compiling.
+ * carries and compiles the STARTER's canonical one alongside it.
+ *
+ * WHY A SEPARATE FILE, NOT AN APPEND. Appending the harness to the end of a file
+ * the learner fully controls lets the text just above it switch the harness off:
+ *
+ *   - a submission ending in a dangling `#[cfg(any())]` binds that attribute to
+ *     the appended `mod verify` and removes it;
+ *   - a crate-level `#![cfg(any())]` strips the whole crate, harness included.
+ *
+ * Both compiled clean and paid XP. With the harness in `/src/_verify.rs` and
+ * `mod _verify;` PREPENDED to the body, no trailing attribute can reach it (it
+ * dangles at EOF → `expected item after attributes`) and an inner attribute
+ * after the module declaration is a hard error (`an inner attribute is not
+ * permitted in this context`). A learner redefining `_verify` collides with the
+ * declaration. All three fail closed.
  *
  * Pure and dependency-free — it runs on the server grader and in the browser.
  * Line endings are normalised to LF so a CRLF submission splices identically.
@@ -20,6 +35,27 @@ export const HARNESS_MARKER =
 
 /** A `// ─────` rule line: cosmetic, and part of the harness region. */
 const RULE_LINE = /^\s*\/\/\s*[─-]+\s*$/;
+
+/** Crate root. The build server only accepts `^/src/<name>.rs$` paths. */
+export const LIB_PATH = "/src/lib.rs";
+
+/** The harness's own module file, referenced from the top of `lib.rs`. */
+export const VERIFY_PATH = "/src/_verify.rs";
+
+/**
+ * Prepended to the learner's body. `#[allow(dead_code)]` because a type-level
+ * harness defines items nothing calls; the leading `mod _verify;` is what puts
+ * the harness out of reach of anything the learner writes below it.
+ */
+const VERIFY_DECL = "#[allow(dead_code)]\nmod _verify;\n";
+
+/**
+ * The harness file's first line. Harnesses are written to sit at the bottom of
+ * `lib.rs`, so they name crate-root items directly (and their inner `mod verify`
+ * does `use super::*`). Glob-importing the crate root at the top of the module
+ * file keeps that text valid verbatim — no rewriting of the lesson's harness.
+ */
+const VERIFY_PRELUDE = "use super::*;\n";
 
 function toLines(source: string): string[] {
   return source.split(/\r?\n/);
@@ -50,18 +86,25 @@ export function splitHarness(source: string): {
 }
 
 /**
- * The source to actually compile: the learner's work with the starter's
- * canonical harness re-attached.
+ * The `[path, content]` pairs to compile for a submission: the learner's body
+ * under a prepended `mod _verify;`, plus the starter's canonical harness as that
+ * module.
  *
  * When the starter carries no harness there is nothing to enforce, so the
- * submission is returned untouched rather than truncated — the buildable grader
- * refuses to grade such a lesson at all, and gate 22 keeps it from shipping.
+ * submission is returned as a lone `lib.rs` rather than being wrapped around a
+ * module that does not exist — the buildable grader refuses to grade such a
+ * lesson at all, and gate 22 keeps it from shipping.
  */
-export function withCanonicalHarness(
+export function buildGradeFiles(
   submission: string,
   starter: string
-): string {
+): [string, string][] {
   const { harness } = splitHarness(starter);
-  if (!harness) return submission;
-  return `${splitHarness(submission).body.trimEnd()}\n\n${harness.trimEnd()}\n`;
+  if (!harness) return [[LIB_PATH, submission]];
+
+  const body = splitHarness(submission).body.trimEnd();
+  return [
+    [LIB_PATH, `${VERIFY_DECL}\n${body}\n`],
+    [VERIFY_PATH, `${VERIFY_PRELUDE}${harness.trimEnd()}\n`],
+  ];
 }

--- a/apps/web/src/lib/challenge/harness.ts
+++ b/apps/web/src/lib/challenge/harness.ts
@@ -1,0 +1,67 @@
+/**
+ * Splice a buildable lesson's verification harness onto a learner submission.
+ *
+ * A buildable challenge is graded by compiling it (see `buildable-executor.ts`),
+ * so the only thing that makes the grade mean anything is the harness the lesson
+ * ships at the bottom of its starter: a type-level check that references the
+ * symbols the exercise asks for. Left in the learner's buffer the harness is
+ * just text they can delete — and `pub fn nothing() {}` compiles fine against
+ * the build server's template Cargo.toml. So the server grader (and, so it
+ * agrees, the browser pre-check) strips whatever harness region the submission
+ * carries and appends the STARTER's canonical one before compiling.
+ *
+ * Pure and dependency-free — it runs on the server grader and in the browser.
+ * Line endings are normalised to LF so a CRLF submission splices identically.
+ */
+
+/** The line a lesson puts above its harness. Content CI (gate 22) requires it. */
+export const HARNESS_MARKER =
+  "// VERIFICATION HARNESS — DO NOT EDIT ANYTHING BELOW THIS LINE.";
+
+/** A `// ─────` rule line: cosmetic, and part of the harness region. */
+const RULE_LINE = /^\s*\/\/\s*[─-]+\s*$/;
+
+function toLines(source: string): string[] {
+  return source.split(/\r?\n/);
+}
+
+/**
+ * Split `source` at its harness marker. The harness region runs from the rule
+ * line(s) immediately above the FIRST marker to end of file — first, so a
+ * submission that duplicated the harness has every copy stripped.
+ *
+ * No marker → the whole source is the body and `harness` is empty.
+ */
+export function splitHarness(source: string): {
+  body: string;
+  harness: string;
+} {
+  const lines = toLines(source);
+  const marker = lines.findIndex((l) => l.trim() === HARNESS_MARKER);
+  if (marker === -1) return { body: lines.join("\n"), harness: "" };
+
+  let start = marker;
+  while (start > 0 && RULE_LINE.test(lines[start - 1] ?? "")) start--;
+
+  return {
+    body: lines.slice(0, start).join("\n"),
+    harness: lines.slice(start).join("\n"),
+  };
+}
+
+/**
+ * The source to actually compile: the learner's work with the starter's
+ * canonical harness re-attached.
+ *
+ * When the starter carries no harness there is nothing to enforce, so the
+ * submission is returned untouched rather than truncated — the buildable grader
+ * refuses to grade such a lesson at all, and gate 22 keeps it from shipping.
+ */
+export function withCanonicalHarness(
+  submission: string,
+  starter: string
+): string {
+  const { harness } = splitHarness(starter);
+  if (!harness) return submission;
+  return `${splitHarness(submission).body.trimEnd()}\n\n${harness.trimEnd()}\n`;
+}

--- a/apps/web/src/lib/grading/graders/code.ts
+++ b/apps/web/src/lib/grading/graders/code.ts
@@ -63,10 +63,12 @@ export async function gradeCode(
   }
   const code = proof.code;
 
-  // Buildable: compiled by the Anchor build server. An outage — or the build
-  // server simply not being configured — surfaces as `available: false` → 503.
+  // Buildable: compiled by the Anchor build server with the lesson's canonical
+  // verification harness spliced back on (the starter carries it), so a deleted
+  // exercise cannot compile. An outage — or the build server simply not being
+  // configured — surfaces as `available: false` → 503.
   if (b?.buildType === "buildable") {
-    return fromRun(await runBuildableSubmission(code, tests));
+    return fromRun(await runBuildableSubmission(code, tests, b.starter ?? ""));
   }
 
   // Plain Rust: graded via the Rust Playground.

--- a/packages/content-lint/src/__tests__/fixtures/good/courses/template/lessons/deploy/program/starter.rs
+++ b/packages/content-lint/src/__tests__/fixtures/good/courses/template/lessons/deploy/program/starter.rs
@@ -1,1 +1,11 @@
 // starter program
+
+// TODO: add the `ping` handler.
+
+// ─────────────────────────────────────────────────────────────────────────────
+// VERIFICATION HARNESS — DO NOT EDIT ANYTHING BELOW THIS LINE.
+// ─────────────────────────────────────────────────────────────────────────────
+#[allow(dead_code)]
+mod verify {
+    const PING: fn() = super::ping;
+}

--- a/packages/content-lint/src/__tests__/gate22.test.ts
+++ b/packages/content-lint/src/__tests__/gate22.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from "vitest";
+import { runLint } from "../lint";
+import "../checks/gate1-schema";
+import "../checks/gate22-harness";
+import { makeTempRepo } from "./helpers";
+
+const course = `id: course-x
+slug: x
+title: X
+difficulty: beginner
+duration: 1
+sourceLocale: en
+xpPerLesson: 10
+xpReward: 100
+modules: [{ key: m, title: M, lessons: [lesson-a] }]
+`;
+
+function lessonYaml(buildType: string) {
+  return `id: lesson-a
+slug: a
+title: A
+skills: [general]
+blocks:
+  - key: exercise
+    type: code
+    language: rust
+    buildType: ${buildType}
+    starter: exercise/starter.rs
+    solution: exercise/solution.rs
+    tests: exercise/tests.json
+`;
+}
+
+const RULE = "// ─────────────────────────────────────────";
+const MARKER =
+  "// VERIFICATION HARNESS — DO NOT EDIT ANYTHING BELOW THIS LINE.";
+
+const WITH_HARNESS = [
+  "use anchor_lang::prelude::*;",
+  "// TODO: add `ping`.",
+  RULE,
+  MARKER,
+  "// A type check.",
+  RULE,
+  "mod verify {",
+  "    const PING: fn() = first_program::ping;",
+  "}",
+  "",
+].join("\n");
+
+const NO_HARNESS = "use anchor_lang::prelude::*;\n// TODO: add `ping`.\n";
+
+const EMPTY_HARNESS = [
+  "use anchor_lang::prelude::*;",
+  RULE,
+  MARKER,
+  "// nothing but prose down here",
+  "",
+].join("\n");
+
+const tests = JSON.stringify([
+  { id: "t1", description: "compiles", input: "", expectedOutput: "true" },
+]);
+
+function tree(starter: string, buildType = "buildable") {
+  return {
+    "courses/x/course.yaml": course,
+    "courses/x/lessons/a/lesson.yaml": lessonYaml(buildType),
+    "courses/x/lessons/a/exercise/starter.rs": starter,
+    "courses/x/lessons/a/exercise/solution.rs": starter,
+    "courses/x/lessons/a/exercise/tests.json": tests,
+  };
+}
+
+function gate22(diagnostics: { gate: string; severity: string }[]) {
+  return diagnostics.filter(
+    (d) => d.gate === "gate-22" && d.severity === "error"
+  );
+}
+
+describe("gate 22 — buildable starters ship a verification harness", () => {
+  it("passes a buildable starter that carries a harness", async () => {
+    const r = await runLint(makeTempRepo(tree(WITH_HARNESS)));
+    expect(gate22(r.diagnostics)).toEqual([]);
+  });
+
+  it("errors when a buildable starter has no harness marker", async () => {
+    const r = await runLint(makeTempRepo(tree(NO_HARNESS)));
+    expect(gate22(r.diagnostics)).toHaveLength(1);
+    expect(gate22(r.diagnostics)[0]).toMatchObject({
+      gate: "gate-22",
+    });
+  });
+
+  it("errors when the harness region is only prose", async () => {
+    const r = await runLint(makeTempRepo(tree(EMPTY_HARNESS)));
+    expect(
+      r.diagnostics.some(
+        (d) => d.gate === "gate-22" && /empty/i.test(d.message)
+      )
+    ).toBe(true);
+  });
+
+  it("ignores non-buildable code blocks", async () => {
+    const r = await runLint(makeTempRepo(tree(NO_HARNESS, "standard")));
+    expect(gate22(r.diagnostics)).toEqual([]);
+  });
+});

--- a/packages/content-lint/src/checks/gate22-harness.ts
+++ b/packages/content-lint/src/checks/gate22-harness.ts
@@ -1,0 +1,96 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { registerCheck } from "../lint";
+import { type RepoModel, type LessonEntry } from "../model";
+import { diag, type Diagnostic } from "../diagnostics";
+
+/**
+ * Gate 22 — a buildable challenge must ship a verification harness.
+ *
+ * A `buildType: buildable` block is graded by compiling it, and the build
+ * server's template Cargo.toml makes almost any `lib.rs` compile. What makes
+ * that verdict mean something is the harness at the bottom of the starter: a
+ * type-level check naming the symbols the exercise has to define. The grader
+ * splices it back onto every submission (apps/web/src/lib/challenge/harness.ts)
+ * and refuses to grade a block whose starter has none — so a lesson without one
+ * is not merely weak, it is un-completable. Catch it here instead.
+ *
+ * The marker string is duplicated from that module on purpose: content-lint does
+ * not depend on the app. Keep the two in sync.
+ */
+const HARNESS_MARKER =
+  "// VERIFICATION HARNESS — DO NOT EDIT ANYTHING BELOW THIS LINE.";
+
+interface CodeBlock {
+  type: "code";
+  key: string;
+  buildType?: "standard" | "buildable";
+  starter: string;
+}
+
+/** Lines below the marker that are neither blank nor a comment. */
+function harnessCode(starter: string): string[] {
+  const lines = starter.split(/\r?\n/);
+  const marker = lines.findIndex((l) => l.trim() === HARNESS_MARKER);
+  if (marker === -1) return [];
+  return lines
+    .slice(marker + 1)
+    .map((l) => l.trim())
+    .filter((l) => l !== "" && !l.startsWith("//"));
+}
+
+export function gate22Check(model: RepoModel): Diagnostic[] {
+  const out: Diagnostic[] = [];
+
+  for (const entry of model.lessons) {
+    for (const raw of entry.lesson.blocks as Record<string, unknown>[]) {
+      if (raw.type !== "code") continue;
+      const block = raw as unknown as CodeBlock;
+      if (block.buildType !== "buildable") continue;
+
+      const where = `block "${block.key}"`;
+      let starter: string;
+      try {
+        starter = readFileSync(
+          join(model.root, entry.dir, block.starter),
+          "utf8"
+        );
+      } catch (err) {
+        out.push(
+          diag(
+            "gate-22",
+            "error",
+            entry.file,
+            `${where}: cannot read starter — ${err instanceof Error ? err.message : String(err)}`
+          )
+        );
+        continue;
+      }
+
+      const code = harnessCode(starter);
+      if (!starter.split(/\r?\n/).some((l) => l.trim() === HARNESS_MARKER)) {
+        out.push(
+          diag(
+            "gate-22",
+            "error",
+            entry.file,
+            `${where}: buildable starter has no verification harness — it must end with "${HARNESS_MARKER}" followed by a type check, or the lesson passes on bare compilation`
+          )
+        );
+      } else if (code.length === 0) {
+        out.push(
+          diag(
+            "gate-22",
+            "error",
+            entry.file,
+            `${where}: verification harness is empty — it must contain code that references the symbols the exercise asks for`
+          )
+        );
+      }
+    }
+  }
+
+  return out;
+}
+
+registerCheck(gate22Check);

--- a/packages/content-lint/src/index.ts
+++ b/packages/content-lint/src/index.ts
@@ -17,3 +17,4 @@ export * from "./checks/gate13bcd-widgets";
 export * from "./checks/gate19-skills";
 export * from "./checks/gate20-originality";
 export * from "./checks/gate21-version-currency";
+export * from "./checks/gate22-harness";


### PR DESCRIPTION
A buildable Rust lesson was graded on `data.success` alone, and the build server copies a template Cargo.toml that makes almost any `lib.rs` compile — so replacing `your-first-solana-program`'s starter with `pub fn nothing() {}` compiled, passed every test and awarded XP. What actually carries the requirement is the verification harness the lesson ships at the bottom of its starter, which the grader never required to still be there.

`lib/challenge/harness.ts` splits a source at the `VERIFICATION HARNESS` marker; `buildGradeFiles` strips whatever harness region a submission carries (deleted, edited, duplicated, CRLF) and returns two files: the learner's body under a prepended `#[allow(dead_code)] mod _verify;`, and the starter's canonical harness as `/src/_verify.rs`. `runBuildableSubmission` compiles that instead of the raw submission, and fails closed (503) on a lesson whose starter carries no harness rather than falling back to bare compilation. The browser `runBuildChallenge` sends the identical file list (it only pins `declare_id!`, in `lib.rs`) so an in-editor "Compilar" cannot go green on something the server will fail. New content gate 22 requires every `buildType: buildable` starter to carry the marker plus a non-empty harness — it caught the `good` template fixture, which shipped a two-word starter.

The first version *appended* the harness, and the gate broke it twice: a submission ending in a dangling `#[cfg(any())]` bound that attribute to the appended `mod verify` and deleted it, and a crate-level `#![cfg(any())]` stripped the whole crate. Both compiled and paid XP. With the declaration on line 1 instead, a trailing attribute dangles at EOF and an inner attribute sits below an item — each a hard error, and a learner who redefines `_verify` collides with the declaration.

## Compiles

`cargo build-sbf --manifest-path Cargo.toml --tools-version v1.54` in a scratch dir, `apps/build-server/programs/Cargo.toml` verbatim, files exactly as `buildGradeFiles` emits them. Same verdict on both live buildable lessons (`lesson-b2s-your-first-solana-program`, `lesson-b2s-an-anchor-vault`).

**(a) `pub fn nothing() {}` + a dangling `#[cfg(any())]`** — was a pass, now:

```
error: expected item after attributes
 --> src/lib.rs:6:1
  |
6 | #[cfg(any())]
  | ^^^^^^^^^^^^^

error: could not compile `academy-program` (lib) due to 1 previous error
```

**(b) `#![cfg(any())]` then `pub fn nothing() {}`** — was a pass, now:

```
error: an inner attribute is not permitted in this context
 --> src/lib.rs:4:1
  |
4 | #![cfg(any())]
  | ^^^^^^^^^^^^^^
5 | pub fn nothing() {}
  | ------------------- the inner attribute doesn't annotate this function
```

**(c) `pub fn nothing() {}` alone** — fails on the harness, as before the change:

```
error[E0412]: cannot find type `Ping` in this scope
  --> src/_verify.rs:12:22
   |
12 |     fn accounts() -> Ping {
   |                      ^^^^ not found in this scope
```

and on the vault lesson:

```
error[E0412]: cannot find type `VaultState` in this scope
  --> src/_verify.rs:12:31
   |
12 |     fn vault_state_fields(s: &VaultState) -> (Pubkey, u64, u8, u8) {
   |                               ^^^^^^^^^^ not found in this scope
```

**(d) both lessons' reference solutions** (which carry the harness inline — the region is stripped and re-supplied as the module) and **(e) the same solutions with the harness region removed**: `Finished \`release\` profile [optimized] target(s)`, exit 0. So real work still passes, with or without the harness left in the buffer.

These ten compiles are `src/lib/challenge/__tests__/harness.sbf.integration.test.ts`, opt-in behind `SBF_INTEGRATION=1` plus the toolchain (skipped otherwise). String-level unit tests cover the same shapes on `buildGradeFiles` and on the grader's request body, and a jsdom test asserts the browser runner sends byte-identical files.

Suites: 235 web tests across `components/editor`, `lib/challenge`, `lib/grading` (+10 opt-in SBF); 140 content-lint tests; `tsc --noEmit` and `pnpm lint` clean.
