### PR TITLE
fix(ai-partner): applied diffs stay applied, no billed turns on a passing solution

### DIFF
--- a/apps/web/src/app/api/ai/__tests__/partner-route.test.ts
+++ b/apps/web/src/app/api/ai/__tests__/partner-route.test.ts
@@ -294,6 +294,22 @@ describe("POST /api/ai/partner", () => {
     const res = await POST(makeRequest(VALID_BODY));
     expect(res.status).toBe(502);
     expect(refundAssistTurn).not.toHaveBeenCalled();
+    // The client needs to know the turn is gone (meter) and why (copy) — the
+    // no-op is NOT refunded, because the learner controls the buffer that
+    // provokes it and a refund would be an unmetered-call lever.
+    const body = (await res.json()) as { billed?: boolean; reason?: string };
+    expect(body.billed).toBe(true);
+    expect(body.reason).toBe("no_change");
+  });
+
+  it("marks a billed 502 as billed so the client meter can follow", async () => {
+    stubGeminiFetch("not valid json {{{");
+    const { POST } = await import("../partner/route");
+    const res = await POST(makeRequest(VALID_BODY));
+    expect(res.status).toBe(502);
+    expect(refundAssistTurn).not.toHaveBeenCalled();
+    const body = (await res.json()) as { billed?: boolean };
+    expect(body.billed).toBe(true);
   });
 
   it("passes through a well-formed propose response, sealed and validated", async () => {

--- a/apps/web/src/app/api/ai/partner/route.ts
+++ b/apps/web/src/app/api/ai/partner/route.ts
@@ -626,7 +626,7 @@ export async function POST(request: NextRequest) {
         finishReason,
       });
       return NextResponse.json(
-        { error: "AI could not generate a response" },
+        { error: "AI could not generate a response", billed: true },
         { status: 502 }
       );
     }
@@ -644,7 +644,7 @@ export async function POST(request: NextRequest) {
         snippet: rawText.slice(0, 200),
       });
       return NextResponse.json(
-        { error: "AI returned an invalid response" },
+        { error: "AI returned an invalid response", billed: true },
         { status: 502 }
       );
     }
@@ -655,7 +655,7 @@ export async function POST(request: NextRequest) {
       // still parsed). NOT refunded — the tokens were billed.
       console.error("Gemini partner API returned a malformed payload");
       return NextResponse.json(
-        { error: "AI returned an invalid response" },
+        { error: "AI returned an invalid response", billed: true },
         { status: 502 }
       );
     }
@@ -679,7 +679,7 @@ export async function POST(request: NextRequest) {
           "Gemini propose edits do not apply to the learner buffer"
         );
         return NextResponse.json(
-          { error: "AI returned an invalid response" },
+          { error: "AI returned an invalid response", billed: true },
           { status: 502 }
         );
       }
@@ -691,8 +691,18 @@ export async function POST(request: NextRequest) {
       // Same failure class as an inapplicable edit — 502, billed, not refunded.
       if (applied.proposed === code) {
         console.error("Gemini propose edits are a no-op");
+        // Still NOT refunded. The learner controls the buffer the model
+        // reasons about, so "already-correct code makes the model propose
+        // nothing" is learner-reachable — refunding it would be an
+        // unmetered-call lever, not a courtesy. `reason` only lets the client
+        // say the honest thing ("nothing to change — ask for a review
+        // instead") instead of the generic error.
         return NextResponse.json(
-          { error: "AI returned an invalid response" },
+          {
+            error: "AI returned an invalid response",
+            billed: true,
+            reason: "no_change",
+          },
           { status: 502 }
         );
       }
@@ -743,7 +753,7 @@ export async function POST(request: NextRequest) {
       await refundAssistTurn(user.id, lesson._id, spend.tier);
     }
     return NextResponse.json(
-      { error: "Failed to get response" },
+      { error: "Failed to get response", billed },
       { status: 500 }
     );
   }

--- a/apps/web/src/components/editor/ai-partner/__tests__/ai-partner-pane.test.tsx
+++ b/apps/web/src/components/editor/ai-partner/__tests__/ai-partner-pane.test.tsx
@@ -6,7 +6,7 @@
 // at all while suppressed (see challenge-interface-ai-gate.test.tsx), so a
 // suppressed lesson can never surface this button.
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { NextIntlClientProvider } from "next-intl";
 import messages from "@/messages/en.json";
 import ptBR from "@/messages/pt-BR.json";
@@ -14,7 +14,7 @@ import es from "@/messages/es.json";
 import type { AssistTier } from "@/lib/ai/partner-types";
 import { AiPartnerPane } from "../ai-partner-pane";
 
-const review = vi.fn();
+const review = vi.fn(async () => true);
 const hookState = {
   messages: [] as unknown[],
   counts: { free: 0, metered: 0, socratic: 0 },
@@ -25,6 +25,7 @@ const hookState = {
   resetAvailableAt: null as number | null,
   loading: false,
   error: null as string | null,
+  errorKind: null as "generic" | "billed" | "noChange" | null,
   proposeFix: vi.fn(),
   ask: vi.fn(),
   review,
@@ -69,6 +70,7 @@ const sendLabel = messages.aiPartner.actions.askSend;
 
 beforeEach(() => {
   review.mockReset();
+  review.mockResolvedValue(true);
   hookState.ask.mockReset();
   hookState.proposeFix.mockReset();
   hookState.messages = [];
@@ -77,6 +79,141 @@ beforeEach(() => {
   hookState.spendCapped = false;
   hookState.loading = false;
   hookState.error = null;
+  hookState.errorKind = null;
+});
+
+describe("AiPartnerPane — propose is withdrawn once the solution passes", () => {
+  const proposeButton = () =>
+    screen.queryByRole("button", {
+      name: new RegExp(messages.aiPartner.actions.propose, "i"),
+    });
+
+  it("hides 'show me a change' on a passing solution, even though hasFailedRun is sticky", () => {
+    renderPane({ hasRunTests: true, hasFailedRun: true, solutionPassed: true });
+    expect(proposeButton()).not.toBeInTheDocument();
+    // The learner is not left without an action: review owns this state.
+    expect(
+      screen.getByRole("button", { name: messages.aiPartner.actions.review })
+    ).toBeInTheDocument();
+  });
+
+  it("still offers it while the solution is failing", () => {
+    renderPane({
+      hasRunTests: true,
+      hasFailedRun: true,
+      solutionPassed: false,
+    });
+    expect(proposeButton()).toBeEnabled();
+  });
+});
+
+describe("AiPartnerPane — review is idempotent per buffer", () => {
+  const reviewButton = () =>
+    screen.getByRole("button", { name: messages.aiPartner.actions.review });
+
+  it("disables the CTA after a review of an unchanged buffer", async () => {
+    renderPane({ solutionPassed: true });
+    fireEvent.click(reviewButton());
+    await waitFor(() => expect(reviewButton()).toBeDisabled());
+
+    fireEvent.click(reviewButton());
+    expect(review).toHaveBeenCalledTimes(1);
+    expect(
+      screen.getByText(messages.aiPartner.actions.reviewedHint)
+    ).toBeInTheDocument();
+  });
+
+  it("re-arms when the buffer changes", async () => {
+    let code = "first";
+    const pane = () => (
+      <NextIntlClientProvider locale="en" messages={messages}>
+        <AiPartnerPane
+          lessonSlug="l"
+          courseSlug="c"
+          getCode={() => code}
+          getTestSummary={() => "3/3 passing"}
+          onApply={() => {}}
+          solutionPassed
+        />
+      </NextIntlClientProvider>
+    );
+    const { rerender } = render(pane());
+
+    fireEvent.click(reviewButton());
+    await waitFor(() => expect(reviewButton()).toBeDisabled());
+
+    // The learner edits; the next render reads the new buffer and the CTA is
+    // live again (a review of DIFFERENT code is a different answer).
+    code = "second";
+    rerender(pane());
+    expect(reviewButton()).toBeEnabled();
+  });
+
+  it("stays retryable when the review itself fails", async () => {
+    review.mockResolvedValue(false);
+    renderPane({ solutionPassed: true });
+    fireEvent.click(reviewButton());
+    await waitFor(() => expect(reviewButton()).toBeEnabled());
+  });
+});
+
+describe("AiPartnerPane — error copy admits a spent turn", () => {
+  it("says the turn was used on a billed failure", () => {
+    hookState.error = "Request failed (502)";
+    hookState.errorKind = "billed";
+    renderPane();
+    expect(
+      screen.getByText(messages.aiPartner.messages.errorBilled)
+    ).toBeInTheDocument();
+  });
+
+  it("points a no-change propose at the review instead", () => {
+    hookState.error = "Request failed (502)";
+    hookState.errorKind = "noChange";
+    renderPane();
+    expect(
+      screen.getByText(messages.aiPartner.messages.errorNoChange)
+    ).toBeInTheDocument();
+  });
+
+  it("keeps the generic copy for an unbilled failure", () => {
+    hookState.error = "Network error";
+    hookState.errorKind = "generic";
+    renderPane();
+    expect(
+      screen.getByText(messages.aiPartner.messages.error)
+    ).toBeInTheDocument();
+  });
+});
+
+describe("AiPartnerPane — the metered → Socratic switch is explained", () => {
+  it("renders the transition line only on the Socratic tier", () => {
+    renderPane();
+    expect(
+      screen.queryByText(messages.aiPartner.socratic.transition)
+    ).not.toBeInTheDocument();
+
+    hookState.tier = "socratic";
+    renderPane();
+    expect(
+      screen.getByText(messages.aiPartner.socratic.transition)
+    ).toBeInTheDocument();
+  });
+
+  it("keeps the new copy keys in all three locales", () => {
+    for (const catalog of [messages, ptBR, es]) {
+      for (const value of [
+        catalog.aiPartner.socratic.transition,
+        catalog.aiPartner.actions.reviewedHint,
+        catalog.aiPartner.messages.errorBilled,
+        catalog.aiPartner.messages.errorNoChange,
+        catalog.aiPartner.diff.alreadyApplied,
+      ]) {
+        expect(typeof value).toBe("string");
+        expect(value.length).toBeGreaterThan(0);
+      }
+    }
+  });
 });
 
 describe("AiPartnerPane — daily spend cap (#591)", () => {

--- a/apps/web/src/components/editor/ai-partner/__tests__/diff-card.test.tsx
+++ b/apps/web/src/components/editor/ai-partner/__tests__/diff-card.test.tsx
@@ -620,4 +620,92 @@ describe("applied state survives the buffer it just changed", () => {
       screen.queryByRole("button", { name: /^accept$/i })
     ).not.toBeInTheDocument();
   });
+
+  // A pure-deletion edit (`replace: ""`) has no replacement text to search
+  // for, so `alreadyApplied` falls back to "the search text is gone" — the
+  // fix for the blocking review finding on #1219.
+  const DELETE_BUFFER = "fn main() {\n  debug_print();\n}";
+  const DELETED_BUFFER = "fn main() {\n}";
+  const DELETION: CodeEdit[] = [{ search: "  debug_print();\n", replace: "" }];
+
+  it('recognizes a deletion edit already applied (replace: "")', () => {
+    renderWithIntl(
+      <DiffCard
+        current={DELETED_BUFFER}
+        edits={DELETION}
+        rationale="removes the debug print"
+        check={check}
+        checkToken="tok"
+        onVerify={vi.fn()}
+        onAccept={vi.fn()}
+        onReject={() => {}}
+        stale={false}
+      />
+    );
+
+    expect(
+      screen.getByText(messages.aiPartner.diff.alreadyApplied)
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/couldn't be applied automatically/i)
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /^accept$/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it("still offers Accept for a deletion edit not yet applied", () => {
+    renderWithIntl(
+      <DiffCard
+        current={DELETE_BUFFER}
+        edits={DELETION}
+        rationale="removes the debug print"
+        check={check}
+        checkToken="tok"
+        onVerify={vi.fn()}
+        onAccept={vi.fn()}
+        onReject={() => {}}
+        stale={false}
+      />
+    );
+
+    expect(
+      screen.queryByText(messages.aiPartner.diff.alreadyApplied)
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/couldn't be applied automatically/i)
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /^accept$/i })
+    ).toBeInTheDocument();
+  });
+
+  it("recognizes a mixed set — one deletion applied and one replacement applied", () => {
+    const MIXED_APPLIED_BUFFER = "fn main() {\n  ping();\n}";
+    const MIXED: CodeEdit[] = [
+      { search: "// TODO", replace: "ping();" },
+      { search: "  debug_print();\n", replace: "" },
+    ];
+
+    renderWithIntl(
+      <DiffCard
+        current={MIXED_APPLIED_BUFFER}
+        edits={MIXED}
+        rationale="fills in the TODO and removes the debug print"
+        check={check}
+        checkToken="tok"
+        onVerify={vi.fn()}
+        onAccept={vi.fn()}
+        onReject={() => {}}
+        stale={false}
+      />
+    );
+
+    expect(
+      screen.getByText(messages.aiPartner.diff.alreadyApplied)
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/couldn't be applied automatically/i)
+    ).not.toBeInTheDocument();
+  });
 });

--- a/apps/web/src/components/editor/ai-partner/__tests__/diff-card.test.tsx
+++ b/apps/web/src/components/editor/ai-partner/__tests__/diff-card.test.tsx
@@ -1,4 +1,5 @@
 // @vitest-environment jsdom
+import { useState } from "react";
 import type { ReactElement } from "react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
@@ -19,12 +20,70 @@ const check = {
 // newline): the edit path is search/replace, not a whole-file echo.
 const ADD_B: CodeEdit[] = [{ search: "a", replace: "a\nb" }];
 
+// A real editor edit: the `search` text is CONSUMED by its own replacement, so
+// re-deriving the apply against the live buffer misses once it lands. ADD_B
+// above cannot show that — its search survives its own replacement.
+const BUFFER = "fn main() {\n  // TODO\n}";
+const APPLIED_BUFFER = "fn main() {\n  ping();\n}";
+const CONSUMING: CodeEdit[] = [{ search: "// TODO", replace: "ping();" }];
+
 function renderWithIntl(ui: ReactElement) {
   return render(
     <NextIntlClientProvider locale="en" messages={messages}>
       {ui}
     </NextIntlClientProvider>
   );
+}
+
+/**
+ * The card as the app actually mounts it: `current` is the LIVE buffer, so
+ * accepting feeds the new code straight back in as the next `current`
+ * (challenge-interface's `getCode={() => code}` / `onApply={setCode}`).
+ */
+function LiveCard({
+  initial = BUFFER,
+  edits = CONSUMING,
+  onVerify,
+  onAccept,
+  stale = false,
+}: {
+  initial?: string;
+  edits?: CodeEdit[];
+  onVerify: (
+    token: string,
+    picked: 0 | 1 | 2
+  ) => Promise<{ correct: boolean; explanation: string }>;
+  onAccept?: (proposed: string) => void;
+  stale?: boolean;
+}) {
+  const [code, setCode] = useState(initial);
+  return (
+    <DiffCard
+      current={code}
+      edits={edits}
+      rationale="fills in the TODO"
+      check={check}
+      checkToken="tok"
+      onVerify={onVerify}
+      onAccept={(proposed) => {
+        onAccept?.(proposed);
+        setCode(proposed);
+      }}
+      onReject={() => {}}
+      stale={stale}
+    />
+  );
+}
+
+async function acceptOn(
+  onVerify: ReturnType<typeof vi.fn>
+): Promise<HTMLElement> {
+  fireEvent.click(screen.getByRole("button", { name: "B" }));
+  await waitFor(() => expect(onVerify).toHaveBeenCalled());
+  const accept = await screen.findByRole("button", { name: /accept/i });
+  await waitFor(() => expect(accept).not.toBeDisabled());
+  fireEvent.click(accept);
+  return accept;
 }
 
 it("gates Accept behind a correct answer and only applies on the Accept click", async () => {
@@ -34,19 +93,10 @@ it("gates Accept behind a correct answer and only applies on the Accept click", 
     .mockResolvedValueOnce({ correct: false, explanation: "because B" })
     .mockResolvedValueOnce({ correct: true, explanation: "because B" });
 
-  renderWithIntl(
-    <DiffCard
-      current="a"
-      edits={ADD_B}
-      rationale="adds b"
-      check={check}
-      checkToken="tok"
-      onVerify={onVerify}
-      onAccept={onAccept}
-      onReject={() => {}}
-      stale={false}
-    />
-  );
+  // Rendered the way the app renders it: `current` follows the live buffer, so
+  // the post-Accept re-render is the real one (a static `current` here is what
+  // hid the P0).
+  renderWithIntl(<LiveCard onVerify={onVerify} onAccept={onAccept} />);
 
   // The check is shown immediately; Accept starts locked.
   expect(screen.getByRole("button", { name: "A" })).toBeInTheDocument();
@@ -69,7 +119,7 @@ it("gates Accept behind a correct answer and only applies on the Accept click", 
 
   // Only the explicit Accept click applies the reconstructed buffer.
   fireEvent.click(screen.getByRole("button", { name: /accept/i }));
-  expect(onAccept).toHaveBeenCalledWith("a\nb");
+  expect(onAccept).toHaveBeenCalledWith(APPLIED_BUFFER);
 
   // After applying, the card confirms and retires the action buttons.
   expect(screen.getByText(/applied to your code/i)).toBeInTheDocument();
@@ -438,5 +488,136 @@ describe("comprehension_check_answered", () => {
         attempt: 1,
       })
     );
+  });
+});
+
+// ── An applied proposal stays applied ─────────────────────────────────────
+// The card re-derives its apply from the LIVE buffer on every render, so the
+// moment its own Accept lands the `search` text is gone. Without the latch that
+// dropped the card straight into the red "couldn't be applied" branch — the
+// audit's P0, and invisible to a test that re-renders with a static buffer.
+
+describe("applied state survives the buffer it just changed", () => {
+  it("keeps the confirmation after Accept feeds the new buffer back in", async () => {
+    const onVerify = vi
+      .fn()
+      .mockResolvedValue({ correct: true, explanation: "yes" });
+
+    renderWithIntl(<LiveCard onVerify={onVerify} />);
+    await acceptOn(onVerify);
+
+    expect(
+      screen.getByText(messages.aiPartner.diff.applied)
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/couldn't be applied automatically/i)
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /^accept$/i })
+    ).not.toBeInTheDocument();
+    // The snapshot keeps the diff readable rather than blanking the card.
+    expect(screen.getByText("ping();")).toBeInTheDocument();
+    // …and a card that has been applied is never also "out of date".
+    expect(
+      screen.queryByText(messages.aiPartner.diff.stale)
+    ).not.toBeInTheDocument();
+  });
+
+  it("recognizes an edit already present in the buffer (reload / typed by hand)", () => {
+    // Reload-equivalent: the chat log rehydrates, the accepted flag does not,
+    // and the card mounts against a buffer that already carries the change.
+    renderWithIntl(
+      <DiffCard
+        current={APPLIED_BUFFER}
+        edits={CONSUMING}
+        rationale="fills in the TODO"
+        check={check}
+        checkToken="tok"
+        onVerify={vi.fn()}
+        onAccept={vi.fn()}
+        onReject={() => {}}
+        stale={false}
+      />
+    );
+
+    expect(
+      screen.getByText(messages.aiPartner.diff.alreadyApplied)
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/couldn't be applied automatically/i)
+    ).not.toBeInTheDocument();
+    // Informational only: nothing here can write to the buffer.
+    expect(
+      screen.queryByRole("button", { name: /^accept$/i })
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText(check.question)).not.toBeInTheDocument();
+  });
+
+  it("shows the neutral state on a sibling card once the other one applied it", async () => {
+    const onVerify = vi
+      .fn()
+      .mockResolvedValue({ correct: true, explanation: "yes" });
+
+    function TwoCards() {
+      const [code, setCode] = useState(BUFFER);
+      const common = {
+        edits: CONSUMING,
+        check,
+        checkToken: "tok",
+        onVerify,
+        onReject: () => {},
+        stale: false,
+        onAccept: setCode,
+      };
+      return (
+        <>
+          <DiffCard {...common} current={code} rationale="card one" />
+          <DiffCard {...common} current={code} rationale="card two" />
+        </>
+      );
+    }
+
+    renderWithIntl(<TwoCards />);
+    fireEvent.click(screen.getAllByRole("button", { name: "B" })[0]!);
+    await waitFor(() => expect(onVerify).toHaveBeenCalled());
+    const accept = screen.getAllByRole("button", { name: /accept/i })[0]!;
+    await waitFor(() => expect(accept).not.toBeDisabled());
+    fireEvent.click(accept);
+
+    expect(
+      screen.getByText(messages.aiPartner.diff.applied)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(messages.aiPartner.diff.alreadyApplied)
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/couldn't be applied automatically/i)
+    ).not.toBeInTheDocument();
+  });
+
+  it("still degrades on TRUE drift — search gone AND the change absent", () => {
+    renderWithIntl(
+      <DiffCard
+        current={"fn main() {\n  something_else();\n}"}
+        edits={CONSUMING}
+        rationale="fills in the TODO"
+        check={check}
+        checkToken="tok"
+        onVerify={vi.fn()}
+        onAccept={vi.fn()}
+        onReject={() => {}}
+        stale={false}
+      />
+    );
+
+    expect(
+      screen.getByText(/couldn't be applied automatically/i)
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(messages.aiPartner.diff.alreadyApplied)
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /^accept$/i })
+    ).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/editor/ai-partner/ai-partner-pane.tsx
+++ b/apps/web/src/components/editor/ai-partner/ai-partner-pane.tsx
@@ -123,6 +123,7 @@ export function AiPartnerPane({
     resetAvailableAt,
     loading,
     error,
+    errorKind,
     ask,
     proposeFix,
     review,
@@ -149,6 +150,19 @@ export function AiPartnerPane({
     (message?: string) => guardAction(() => void proposeFix(message)),
     [guardAction, proposeFix]
   );
+
+  // Review idempotence: a review of an unchanged buffer is the same answer for
+  // another ladder turn (the audit found ten of them in a row on one lesson).
+  // Latch the reviewed buffer and withdraw the CTA until the code actually
+  // changes; a failed review clears the latch so it stays retryable.
+  const [reviewedCode, setReviewedCode] = useState<string | null>(null);
+  const alreadyReviewed = reviewedCode !== null && reviewedCode === getCode();
+  const handleReview = useCallback(async () => {
+    const reviewing = getCode();
+    setReviewedCode(reviewing);
+    const ok = await review();
+    if (!ok) setReviewedCode(null);
+  }, [getCode, review]);
 
   // Socratic-entry analytics (#864): fire once per lesson when the ladder
   // lands on the Socratic tier (the helper session-dedupes as well).
@@ -218,6 +232,12 @@ export function AiPartnerPane({
           <p className="text-xs text-text-3">
             {disabled ? t("completed") : t("subtitle")}
           </p>
+          {/* The meter changes unit AND resets (8/8 assists → 1/20 guiding
+              turns) when the ladder reaches the Socratic rung. One sentence in
+              the header says so; the accounting is untouched. */}
+          {tier === "socratic" && (
+            <p className="text-xs text-text-3">{t("socratic.transition")}</p>
+          )}
         </button>
       </div>
 
@@ -320,7 +340,13 @@ export function AiPartnerPane({
 
       {open && error && !spendCapped && (
         <div className="shrink-0 border-t border-border px-4 py-2">
-          <p className="text-xs text-danger">{t("messages.error")}</p>
+          <p className="text-xs text-danger">
+            {errorKind === "noChange"
+              ? t("messages.errorNoChange")
+              : errorKind === "billed"
+                ? t("messages.errorBilled")
+                : t("messages.error")}
+          </p>
         </div>
       )}
 
@@ -349,15 +375,17 @@ export function AiPartnerPane({
             type="button"
             variant="secondary"
             size="sm"
-            onClick={() => review()}
-            disabled={loading || budgetExhausted}
+            onClick={() => void handleReview()}
+            disabled={loading || budgetExhausted || alreadyReviewed}
             className="w-full gap-1.5"
           >
             <MagnifyingGlass size={14} weight="duotone" aria-hidden="true" />
             {t("actions.review")}
           </Button>
           <p className="mt-1.5 text-[11px] text-text-3">
-            {t("actions.reviewHint")}
+            {alreadyReviewed
+              ? t("actions.reviewedHint")
+              : t("actions.reviewHint")}
           </p>
         </div>
       )}
@@ -378,8 +406,15 @@ export function AiPartnerPane({
             // at exhaustion where the community handoff takes over. (The
             // Composer also hard-disables it on `budgetExhausted`, so it can
             // never fire even if it were rendered in that state.)
+            // Withdrawn again once the solution passes: `hasFailedRun` is
+            // sticky by design, but on a passing buffer the model has nothing
+            // to change and the schema still forces it to invent an edit — a
+            // billed turn for a no-op or a 502. The review CTA above owns that
+            // state.
             onPropose={
-              hasFailedRun && !budgetExhausted ? proposeGuarded : undefined
+              hasFailedRun && !solutionPassed && !budgetExhausted
+                ? proposeGuarded
+                : undefined
             }
             disabled={loading || disabled}
             pending={loading}

--- a/apps/web/src/components/editor/ai-partner/diff-card.tsx
+++ b/apps/web/src/components/editor/ai-partner/diff-card.tsx
@@ -8,6 +8,7 @@ import { Button } from "@/components/ui/button";
 import { applyEdits } from "@/lib/ai/apply-edits";
 import { trackComprehensionCheckAnswered } from "@/lib/analytics/events";
 import type { ChallengeEventContext } from "@/lib/analytics/events";
+import type { ApplyEditsResult } from "@/lib/ai/apply-edits";
 import type {
   CodeEdit,
   ProposeResponse,
@@ -167,12 +168,43 @@ export function DiffCard({
   // flow; a miss (the model's snippet no longer occurs — e.g. the code changed
   // since the request) degrades to showing the edit textually, never mutating
   // the buffer.
-  const applied = useMemo(() => applyEdits(current, edits), [current, edits]);
+  const live = useMemo(() => applyEdits(current, edits), [current, edits]);
+
+  // Latch the accepted result. `current` is the LIVE buffer, so the moment the
+  // learner accepts, the `search` text is gone and `live` flips to a miss — the
+  // card would degrade into the red "couldn't be applied" banner right after
+  // applying it. Snapshotting the baseline + reconstruction at accept time
+  // keeps the confirmation on screen without loosening the apply rule: the
+  // apply itself is still evaluated against the live buffer, once.
+  const acceptedRef = useRef<{ baseline: string; proposed: string } | null>(
+    null
+  );
+  const snapshot = accepted ? acceptedRef.current : null;
+  const applied = useMemo<ApplyEditsResult>(
+    () => (snapshot ? { ok: true, proposed: snapshot.proposed } : live),
+    [snapshot, live]
+  );
+  const baseline = snapshot ? snapshot.baseline : current;
 
   const lines = useMemo(
-    () => (applied.ok ? toHunkRows(diffLines(current, applied.proposed)) : []),
-    [current, applied]
+    () => (applied.ok ? toHunkRows(diffLines(baseline, applied.proposed)) : []),
+    [baseline, applied]
   );
+
+  // The cases local state cannot cover: a reload (the log rehydrates, the
+  // accepted flag does not), the learner typing the change by hand, or a
+  // sibling card having applied the same edit. The edits no longer apply, but
+  // every replacement is already in the buffer — informational, not an error,
+  // and deliberately without an Accept button so it can never touch the code.
+  const alreadyApplied =
+    !applied.ok &&
+    edits.length > 0 &&
+    edits.every(
+      (edit) =>
+        typeof edit?.replace === "string" &&
+        edit.replace.length > 0 &&
+        current.includes(edit.replace)
+    );
 
   // The correct index/explanation are sealed server-side (`checkToken`) and
   // never shipped to the browser — grading a pick is an async round trip to
@@ -223,14 +255,39 @@ export function DiffCard({
   // Applying the change is gated on a verified-correct answer — never fires
   // otherwise, so the code only changes on an intentional, earned Accept.
   const handleAccept = () => {
-    if (!applied.ok || stale || correctPick === null || accepted) return;
-    onAccept(applied.proposed);
+    if (!live.ok || stale || correctPick === null || accepted) return;
+    acceptedRef.current = { baseline: current, proposed: live.proposed };
+    onAccept(live.proposed);
     setAccepted(true);
   };
 
   // Degrade path: the edit no longer applies to the live buffer. Show it
   // textually (search → replace) so the learner can apply it by hand — never a
   // silent no-op, never an Accept that would corrupt the buffer.
+  if (alreadyApplied) {
+    return (
+      <div
+        className={cn("card-chunky space-y-3 p-4", className)}
+        role="group"
+        aria-label={t("a11y.diffCard")}
+      >
+        <div className="flex items-center gap-2">
+          <Sparkle
+            size={16}
+            weight="duotone"
+            className="shrink-0 text-primary"
+            aria-hidden="true"
+          />
+          <p className="text-sm font-medium text-text">{rationale}</p>
+        </div>
+        <p className="flex items-center gap-1.5 text-sm font-medium text-success">
+          <Check size={16} weight="bold" aria-hidden="true" />
+          {t("diff.alreadyApplied")}
+        </p>
+      </div>
+    );
+  }
+
   if (!applied.ok) {
     return (
       <div
@@ -296,7 +353,7 @@ export function DiffCard({
     <div
       className={cn(
         "card-chunky space-y-3 p-4",
-        stale && "opacity-60",
+        stale && !accepted && "opacity-60",
         className
       )}
       role="group"
@@ -371,7 +428,7 @@ export function DiffCard({
         </pre>
       </div>
 
-      {stale && (
+      {stale && !accepted && (
         <div className="flex items-center gap-2 rounded-md border p-2 text-xs [background:var(--danger-light)] [border-color:var(--danger-border)]">
           <WarningCircle
             size={14}

--- a/apps/web/src/components/editor/ai-partner/diff-card.tsx
+++ b/apps/web/src/components/editor/ai-partner/diff-card.tsx
@@ -199,12 +199,12 @@ export function DiffCard({
   const alreadyApplied =
     !applied.ok &&
     edits.length > 0 &&
-    edits.every(
-      (edit) =>
-        typeof edit?.replace === "string" &&
-        edit.replace.length > 0 &&
-        current.includes(edit.replace)
-    );
+    edits.every((edit) => {
+      if (typeof edit?.replace !== "string") return false;
+      return edit.replace.length > 0
+        ? current.includes(edit.replace)
+        : !current.includes(edit.search);
+    });
 
   // The correct index/explanation are sealed server-side (`checkToken`) and
   // never shipped to the browser — grading a pick is an async round trip to

--- a/apps/web/src/components/editor/ai-partner/message-list.tsx
+++ b/apps/web/src/components/editor/ai-partner/message-list.tsx
@@ -79,7 +79,11 @@ export function MessageList({
   className,
 }: MessageListProps) {
   const t = useTranslations("aiPartner");
-  const [dismissed, setDismissed] = useState<Set<number>>(new Set());
+  // Keyed by the proposal's seal token, not its list position: one token is
+  // minted per proposed patch, so a dismissal follows its own card. It is still
+  // per-mount state — the rehydrated log carries no dismissed flag, so a reload
+  // brings discarded cards back; persisting that needs a field on the log entry.
+  const [dismissed, setDismissed] = useState<Set<string>>(new Set());
 
   const lastProposeIndex = messages.reduce(
     (last, message, index) =>
@@ -138,7 +142,7 @@ export function MessageList({
         const { response } = message;
 
         if (response.type === "propose") {
-          if (dismissed.has(index)) {
+          if (dismissed.has(response.checkToken)) {
             return (
               <MessageBubble
                 key={index}
@@ -176,7 +180,7 @@ export function MessageList({
                   onApply(proposed);
                 }}
                 onReject={() =>
-                  setDismissed((prev) => new Set(prev).add(index))
+                  setDismissed((prev) => new Set(prev).add(response.checkToken))
                 }
                 stale={index !== lastProposeIndex}
                 eventCtx={eventCtx}

--- a/apps/web/src/lib/ai/__tests__/assist-copy.test.ts
+++ b/apps/web/src/lib/ai/__tests__/assist-copy.test.ts
@@ -70,9 +70,10 @@ describe("#864 aiPartner copy is never paywall-shaped", () => {
         }
       ).aiPartner;
       expect(Object.keys(ai.meter).sort()).toEqual(["metered", "socratic"]);
-      // `entered` is gone with the Socratic banner (owner 2026-07-31): the tier
-      // shift is announced by the meter chip alone.
-      expect(Object.keys(ai.socratic).sort()).toEqual(["chip"]);
+      // `entered` is gone with the Socratic banner (owner 2026-07-31). The chip
+      // names the tier; `transition` is the one line that explains why the
+      // counter changed unit and restarted (8/8 assists → 1/20 guiding turns).
+      expect(Object.keys(ai.socratic).sort()).toEqual(["chip", "transition"]);
       expect(Object.keys(ai.exhausted).sort()).toEqual([
         "body",
         "communityCta",

--- a/apps/web/src/lib/ai/__tests__/use-ai-partner.test.tsx
+++ b/apps/web/src/lib/ai/__tests__/use-ai-partner.test.tsx
@@ -265,6 +265,89 @@ describe("useAiPartner", () => {
     expect(result.current.error).toBeTruthy();
   });
 
+  it("advances the meter on a BILLED failure — the turn is spent server-side", async () => {
+    vi.mocked(global.fetch).mockResolvedValue({
+      ok: false,
+      status: 502,
+      json: async () => ({
+        error: "AI returned an invalid response",
+        billed: true,
+      }),
+    } as Response);
+
+    const { result } = await renderPartner(baseProps());
+
+    await act(async () => {
+      await result.current.proposeFix();
+    });
+
+    expect(result.current.counts).toEqual({ free: 1, metered: 0, socratic: 0 });
+    expect(result.current.errorKind).toBe("billed");
+  });
+
+  it("classifies a no-op propose so the client can point at the review", async () => {
+    vi.mocked(global.fetch).mockResolvedValue({
+      ok: false,
+      status: 502,
+      json: async () => ({
+        error: "AI returned an invalid response",
+        billed: true,
+        reason: "no_change",
+      }),
+    } as Response);
+
+    const { result } = await renderPartner(baseProps());
+
+    await act(async () => {
+      await result.current.proposeFix();
+    });
+
+    expect(result.current.errorKind).toBe("noChange");
+    expect(result.current.counts.free).toBe(1);
+  });
+
+  it("leaves the meter alone on an UNBILLED failure (refunded upstream error)", async () => {
+    vi.mocked(global.fetch).mockResolvedValue({
+      ok: false,
+      status: 502,
+      json: async () => ({
+        error: "AI service unavailable",
+        upstreamStatus: 429,
+      }),
+    } as Response);
+
+    const { result } = await renderPartner(baseProps());
+
+    await act(async () => {
+      await result.current.proposeFix();
+    });
+
+    expect(result.current.counts).toEqual({ free: 0, metered: 0, socratic: 0 });
+    expect(result.current.errorKind).toBe("generic");
+  });
+
+  it("review() resolves false on a failure and true on a reply", async () => {
+    vi.mocked(global.fetch).mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: async () => ({ error: "Failed to get response", billed: false }),
+    } as Response);
+    const { result } = await renderPartner(baseProps());
+    let outcome: boolean | undefined;
+    await act(async () => {
+      outcome = await result.current.review();
+    });
+    expect(outcome).toBe(false);
+
+    vi.mocked(global.fetch).mockResolvedValue(
+      jsonResponse({ type: "review", summary: "looks good", notes: [] })
+    );
+    await act(async () => {
+      outcome = await result.current.review();
+    });
+    expect(outcome).toBe(true);
+  });
+
   it("advances counts in ladder order: free -> metered -> socratic (tier boundaries at turns 3 and 11)", async () => {
     vi.mocked(global.fetch).mockResolvedValue(
       jsonResponse({ type: "answer", text: "ok" })

--- a/apps/web/src/lib/ai/use-ai-partner.ts
+++ b/apps/web/src/lib/ai/use-ai-partner.ts
@@ -15,6 +15,15 @@ import type {
 
 export type { PartnerMessage };
 
+/**
+ * Why the last action failed, for copy that tells the truth about billing:
+ * - `generic`   — no turn was spent (network, config, refunded upstream error).
+ * - `billed`    — the model ran and the turn IS spent; the meter has advanced.
+ * - `noChange`  — a billed `propose` the model turned into a no-op (route
+ *   `reason: "no_change"`): nothing to apply, so point the learner at review.
+ */
+export type PartnerErrorKind = "generic" | "billed" | "noChange";
+
 // The ladder constants live in partner-types.ts (single source of truth,
 // shared with the server budget). The SERVER enforces every boundary via the
 // spend_assist_ladder_turn RPC; this hook only mirrors the counts for display
@@ -56,10 +65,13 @@ interface UseAiPartnerResult {
   resetAvailableAt: number | null;
   loading: boolean;
   error: string | null;
+  /** Classifies `error` so the pane can admit a spent turn (see PartnerErrorKind). */
+  errorKind: PartnerErrorKind | null;
   /** Ask for a concrete change. Optionally carries the learner's composer draft. */
   proposeFix: (message?: string) => Promise<void>;
   ask: (message: string) => Promise<void>;
-  review: () => Promise<void>;
+  /** Resolves true when the review actually came back — false on any failure. */
+  review: () => Promise<boolean>;
   /** Spend the one guarded per-lesson reset. Resolves with the server verdict. */
   requestReset: () => Promise<ResetOutcome>;
   verifyCheck: (
@@ -76,6 +88,13 @@ function isBudgetExhausted(
   reply: PartnerRouteReply
 ): reply is { budgetExhausted: true; counts?: AssistTurnCounts } {
   return "budgetExhausted" in reply && reply.budgetExhausted === true;
+}
+
+/** Shape of the route's JSON error bodies (all fields optional by design). */
+interface ErrorBody {
+  spendCapped?: boolean;
+  billed?: boolean;
+  reason?: string;
 }
 
 function isCounts(value: unknown): value is AssistTurnCounts {
@@ -115,6 +134,7 @@ export function useAiPartner({
   const [resetAvailableAt, setResetAvailableAt] = useState<number | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [errorKind, setErrorKind] = useState<PartnerErrorKind | null>(null);
 
   const tier = useMemo(() => assistTierFor(counts), [counts]);
   const budgetExhausted = serverExhausted || tier === "exhausted";
@@ -180,9 +200,10 @@ export function useAiPartner({
   // authored hint ladder is not routed through here at all: those hints render
   // as lesson-pane disclosures straight from the content bundle.
   const callPartnerRoute = useCallback(
-    async (action: PartnerAction, message?: string) => {
+    async (action: PartnerAction, message?: string): Promise<boolean> => {
       setLoading(true);
       setError(null);
+      setErrorKind(null);
       setSpendCapped(false);
       try {
         const res = await fetch(PARTNER_ROUTE, {
@@ -199,27 +220,32 @@ export function useAiPartner({
         });
 
         if (!res.ok) {
+          let body: ErrorBody = {};
+          try {
+            body = ((await res.json()) ?? {}) as ErrorBody;
+          } catch {
+            // Non-JSON error body → generic, unbilled handling below.
+          }
+
           // The daily spend cap (#591) returns 503 with `spendCapped: true`.
           // Surface it as its own state so the pane shows dedicated localized
           // copy ("tutor at capacity today") rather than the generic error.
-          if (res.status === 503) {
-            try {
-              const body: unknown = await res.json();
-              if (
-                typeof body === "object" &&
-                body !== null &&
-                "spendCapped" in body &&
-                (body as { spendCapped?: unknown }).spendCapped === true
-              ) {
-                setSpendCapped(true);
-                return;
-              }
-            } catch {
-              // Non-JSON 503 → fall through to the generic error below.
-            }
+          if (res.status === 503 && body.spendCapped === true) {
+            setSpendCapped(true);
+            return false;
+          }
+
+          // A failure the model was still billed for spends a ladder turn
+          // server-side (route: `billed: true`). Advance the mirror here too,
+          // or the meter silently lags until the next reload.
+          if (body.billed === true) {
+            setCounts(advanceCounts);
+            setErrorKind(body.reason === "no_change" ? "noChange" : "billed");
+          } else {
+            setErrorKind("generic");
           }
           setError(`Request failed (${res.status})`);
-          return;
+          return false;
         }
 
         const reply: PartnerRouteReply = await res.json();
@@ -229,13 +255,16 @@ export function useAiPartner({
           // count mirror when it reports the real numbers.
           if (isCounts(reply.counts)) setCounts(reply.counts);
           setServerExhausted(true);
-          return;
+          return false;
         }
 
         setCounts(advanceCounts);
         setMessages((prev) => [...prev, { role: "ai", response: reply }]);
+        return true;
       } catch (err: unknown) {
         setError(err instanceof Error ? err.message : "Network error");
+        setErrorKind("generic");
+        return false;
       } finally {
         setLoading(false);
       }
@@ -257,9 +286,10 @@ export function useAiPartner({
   // Post-pass idiomatic review (LX-C9). A paid action like propose/ask — it
   // spends an assist and appends the AI review to the chat. The caller gates
   // this on a passing run; the route is agnostic to that (it grades nothing).
-  const review = useCallback(async () => {
-    await callPartnerRoute("review");
-  }, [callPartnerRoute]);
+  const review = useCallback(
+    async () => await callPartnerRoute("review"),
+    [callPartnerRoute]
+  );
 
   const ask = useCallback(
     async (message: string) => {
@@ -350,6 +380,7 @@ export function useAiPartner({
     resetAvailableAt,
     loading,
     error,
+    errorKind,
     proposeFix,
     ask,
     review,

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -1097,6 +1097,8 @@
       "ai": "AI Partner",
       "loading": "Thinking...",
       "error": "Something went wrong. Try again.",
+      "errorBilled": "Something went wrong on the AI's side, and this turn was used up. Try again.",
+      "errorNoChange": "The partner found nothing to change in your code, and this turn was used up. Ask it to review your solution instead.",
       "spendCapped": "The AI Partner has reached today's usage limit. It'll be back tomorrow — meanwhile, the authored hints and tests are still here to help."
     },
     "actions": {
@@ -1106,7 +1108,8 @@
       "askLabel": "Ask the AI Partner about this challenge",
       "askSend": "Send",
       "review": "Review my solution",
-      "reviewHint": "Get idiomatic feedback on your passing solution — this doesn't change your XP."
+      "reviewHint": "Get idiomatic feedback on your passing solution — this doesn't change your XP.",
+      "reviewedHint": "You've already reviewed this solution. Change your code to get a fresh review."
     },
     "composer": {
       "empty": "Ask anything about this challenge. Authored hints for this lesson live in the Hints section above."
@@ -1126,6 +1129,7 @@
       "checkCorrect": "Correct — you can apply the change now.",
       "acceptLocked": "Answer the check correctly to apply this change.",
       "applied": "Applied to your code",
+      "alreadyApplied": "This change is already in your code.",
       "unchangedCollapsed": "{count, plural, one {# unchanged line} other {# unchanged lines}}",
       "lineAdded": "Added",
       "lineRemoved": "Removed"
@@ -1135,7 +1139,8 @@
       "diffCard": "Proposed code change"
     },
     "socratic": {
-      "chip": "Lighter tutor"
+      "chip": "Lighter tutor",
+      "transition": "Your 8 assists are used up. You now have 20 lighter guiding turns — the tutor leads with questions instead of finished changes."
     },
     "exhausted": {
       "title": "This challenge's tutor turns are used up",

--- a/apps/web/src/messages/es.json
+++ b/apps/web/src/messages/es.json
@@ -1097,6 +1097,8 @@
       "ai": "Compañero de IA",
       "loading": "Pensando...",
       "error": "Algo salió mal. Inténtalo de nuevo.",
+      "errorBilled": "Algo salió mal del lado de la IA y este turno se consumió. Inténtalo de nuevo.",
+      "errorNoChange": "El compañero no encontró nada que cambiar en tu código y este turno se consumió. Pide una revisión de tu solución.",
       "spendCapped": "El Compañero de IA alcanzó el límite de uso de hoy. Volverá mañana; mientras tanto, las pistas y las pruebas siguen disponibles para ayudarte."
     },
     "actions": {
@@ -1106,7 +1108,8 @@
       "askLabel": "Pregúntale al Compañero de IA sobre este reto",
       "askSend": "Enviar",
       "review": "Revisar mi solución",
-      "reviewHint": "Recibe comentarios idiomáticos sobre tu solución ya resuelta — esto no cambia tu XP."
+      "reviewHint": "Recibe comentarios idiomáticos sobre tu solución ya resuelta — esto no cambia tu XP.",
+      "reviewedHint": "Ya revisaste esta solución. Cambia tu código para recibir una revisión nueva."
     },
     "composer": {
       "empty": "Pregunta lo que quieras sobre este reto. Las pistas escritas para esta lección están en la sección Pistas de arriba."
@@ -1126,6 +1129,7 @@
       "checkCorrect": "Correcto — ya puedes aplicar el cambio.",
       "acceptLocked": "Responde correctamente para aplicar este cambio.",
       "applied": "Aplicado a tu código",
+      "alreadyApplied": "Este cambio ya está en tu código.",
       "unchangedCollapsed": "{count, plural, one {# línea sin cambios} other {# líneas sin cambios}}",
       "lineAdded": "Añadido",
       "lineRemoved": "Eliminado"
@@ -1135,7 +1139,8 @@
       "diffCard": "Cambio de código propuesto"
     },
     "socratic": {
-      "chip": "Tutor ligero"
+      "chip": "Tutor ligero",
+      "transition": "Tus 8 asistencias se acabaron. Ahora tienes 20 turnos de guía más ligeros — el tutor empieza con preguntas en lugar de cambios terminados."
     },
     "exhausted": {
       "title": "Se usaron los turnos del tutor en este desafío",

--- a/apps/web/src/messages/pt-BR.json
+++ b/apps/web/src/messages/pt-BR.json
@@ -1097,6 +1097,8 @@
       "ai": "Parceiro de IA",
       "loading": "Pensando...",
       "error": "Algo deu errado. Tente novamente.",
+      "errorBilled": "Algo deu errado do lado da IA, e este turno foi consumido. Tente novamente.",
+      "errorNoChange": "O parceiro não encontrou nada para mudar no seu código, e este turno foi consumido. Peça uma revisão da sua solução.",
       "spendCapped": "O Parceiro de IA atingiu o limite de uso de hoje. Ele volta amanhã; enquanto isso, as dicas e os testes continuam aqui para ajudar."
     },
     "actions": {
@@ -1106,7 +1108,8 @@
       "askLabel": "Pergunte ao Parceiro de IA sobre este desafio",
       "askSend": "Enviar",
       "review": "Revisar minha solução",
-      "reviewHint": "Receba comentários idiomáticos sobre a solução que você já concluiu — isto não altera seu XP."
+      "reviewHint": "Receba comentários idiomáticos sobre a solução que você já concluiu — isto não altera seu XP.",
+      "reviewedHint": "Você já revisou esta solução. Altere seu código para receber uma revisão nova."
     },
     "composer": {
       "empty": "Pergunte o que quiser sobre este desafio. As dicas escritas para esta lição ficam na seção Dicas acima."
@@ -1126,6 +1129,7 @@
       "checkCorrect": "Correto — agora você pode aplicar a mudança.",
       "acceptLocked": "Responda corretamente para aplicar esta mudança.",
       "applied": "Aplicado ao seu código",
+      "alreadyApplied": "Esta mudança já está no seu código.",
       "unchangedCollapsed": "{count, plural, one {# linha inalterada} other {# linhas inalteradas}}",
       "lineAdded": "Adicionado",
       "lineRemoved": "Removido"
@@ -1135,7 +1139,8 @@
       "diffCard": "Mudança de código proposta"
     },
     "socratic": {
-      "chip": "Tutor leve"
+      "chip": "Tutor leve",
+      "transition": "Suas 8 assistências acabaram. Agora você tem 20 turnos de orientação mais leves — o tutor conduz com perguntas em vez de mudanças prontas."
     },
     "exhausted": {
       "title": "Os turnos do tutor neste desafio acabaram",


### PR DESCRIPTION
The diff card re-derived its apply from the live editor buffer on every render, so accepting a proposal consumed its own `search` text and the card immediately fell into the red "couldn't be applied" branch — `diff.applied` was effectively unreachable in the app, and the existing test only passed because it re-rendered with a static buffer. The accepted result is now latched from a snapshot taken at accept time, an edit whose replacement is already in the buffer (reload, typed by hand, sibling card) renders a neutral "already in your code" state, and the red banner is left for real drift; the apply itself is still evaluated fail-closed against the live buffer.

On the billing side, "Me mostre uma mudança" is withdrawn once the solution passes (the schema forces the model to invent an edit, which is either a no-op or a 502 — both billed), and "Revisar minha solução" is disabled until the buffer changes, which is what let ten reviews of one unchanged solution burn ten turns in prod.

I did **not** refund the no-op propose. The learner sends the buffer the model reasons about, so "already-correct code makes the model propose nothing" is learner-reachable and a refund there would be an unmetered-call lever rather than a courtesy. Instead the route tags that 502 `reason: "no_change"` and tags every billed failure `billed: true`; the client advances its meter on those (it previously returned before `setCounts`, so a billed 502 silently desynced the counter until reload) and says the honest thing — the turn was used, the partner had nothing to change, ask for a review.

Also: one sentence in the header explains the metered → Socratic switch (the counter changing unit and restarting at 1/20 read as a reset), keys added in en/pt-BR/es, and card dismissal is keyed by the proposal's seal token instead of its list index — dismissals still don't survive a reload, which would need a field on the persisted log entry.

Verification: `vitest run src/lib/ai src/components/editor/ai-partner src/app/api/ai` — 297 passed; `tsc --noEmit` clean; lint clean on the touched files.
