### PR TITLE
feat(deploy): sign and fund through the embedded wallet

### DIFF
--- a/apps/web/src/components/deploy/__tests__/deploy-panel-funding-gate.test.tsx
+++ b/apps/web/src/components/deploy/__tests__/deploy-panel-funding-gate.test.tsx
@@ -1,0 +1,112 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { NextIntlClientProvider } from "next-intl";
+import { Keypair, LAMPORTS_PER_SOL } from "@solana/web3.js";
+import messages from "@/messages/en.json";
+import { DeployPanel } from "../deploy-panel";
+
+/**
+ * The funding gate on the ADAPTER path. The main adapter suite switches the
+ * gate off wholesale (`getCachedBinaryLength: () => null`), so without this the
+ * one behaviour this PR changed for extension learners had no coverage.
+ */
+const ADAPTER = Keypair.generate().publicKey;
+const COST_LAMPORTS = 1.5 * LAMPORTS_PER_SOL;
+
+const h = vi.hoisted(() => {
+  const getBalance = vi.fn();
+  return {
+    getBalance,
+    connection: { getBalance },
+    balanceLamports: 0,
+    estimateDeployCost: vi.fn(),
+  };
+});
+
+vi.mock("@solana/wallet-adapter-react", () => ({
+  useWallet: () => ({
+    publicKey: ADAPTER,
+    signTransaction: vi.fn(),
+    signAllTransactions: vi.fn(),
+  }),
+  useConnection: () => ({ connection: h.connection }),
+}));
+
+vi.mock("@/lib/auth/auth-provider", () => ({
+  useAuth: () => ({
+    profile: { wallet_address: ADAPTER.toBase58() },
+    isLoading: false,
+  }),
+}));
+
+vi.mock("@superteam-lms/deploy", () => ({
+  deployProgram: vi.fn(),
+  resumeDeployment: vi.fn(),
+  // A real cached binary — this is what turns the gate on.
+  getCachedBinaryLength: () => 66_704,
+  estimateDeployCost: h.estimateDeployCost,
+  createAirdropRequest: vi.fn(async () => ({ success: false, error: "no" })),
+}));
+
+vi.mock("@/lib/gamification/celebration", () => ({ celebrate: vi.fn() }));
+
+function renderPanel() {
+  return render(
+    <NextIntlClientProvider locale="en" messages={messages}>
+      <DeployPanel
+        buildUuid="build-uuid-123"
+        lessonId="lesson-1"
+        courseSlug="solana-101"
+        courseId="course-solana-101"
+      />
+    </NextIntlClientProvider>
+  );
+}
+
+beforeEach(() => {
+  h.balanceLamports = 0;
+  h.getBalance.mockReset();
+  h.getBalance.mockImplementation(async () => h.balanceLamports);
+  h.estimateDeployCost.mockReset();
+  h.estimateDeployCost.mockResolvedValue({ totalLamports: COST_LAMPORTS });
+  localStorage.clear();
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (_url: string, init?: RequestInit) => {
+      if (!init || init.method !== "POST") {
+        return { ok: true, json: async () => ({ deployed: false }) };
+      }
+      return { ok: true, status: 200, json: async () => ({}) };
+    })
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("DeployPanel — funding gate on the adapter path", () => {
+  it("blocks the deploy and offers funding when the extension wallet is short", async () => {
+    h.balanceLamports = 0.4 * LAMPORTS_PER_SOL;
+    renderPanel();
+
+    const button = await screen.findByRole("button", {
+      name: /Not enough SOL/,
+    });
+    expect(button).toBeDisabled();
+    expect(await screen.findByText("Fund Your Wallet")).toBeInTheDocument();
+  });
+
+  it("leaves the deploy enabled when the extension wallet covers the estimate", async () => {
+    h.balanceLamports = 2 * LAMPORTS_PER_SOL;
+    renderPanel();
+
+    const button = await screen.findByRole("button", {
+      name: "Deploy to Devnet",
+    });
+    await waitFor(() => expect(button).toBeEnabled());
+    expect(screen.queryByText("Fund Your Wallet")).not.toBeInTheDocument();
+    expect(h.estimateDeployCost).toHaveBeenCalledWith(h.connection, 66_704);
+  });
+});

--- a/apps/web/src/components/deploy/__tests__/deploy-panel-signer.test.tsx
+++ b/apps/web/src/components/deploy/__tests__/deploy-panel-signer.test.tsx
@@ -1,0 +1,233 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { NextIntlClientProvider } from "next-intl";
+import { Keypair, LAMPORTS_PER_SOL, PublicKey } from "@solana/web3.js";
+import { EMBEDDED_BATCH_SIZE } from "@/hooks/use-deploy-signer";
+import messages from "@/messages/en.json";
+import { DeployPanel } from "../deploy-panel";
+
+/**
+ * The embedded-wallet deploy path: a learner with no wallet-adapter key and no
+ * SOL. The suite next to this one covers the adapter path, which must not
+ * change.
+ */
+const EMBEDDED = Keypair.generate().publicKey.toBase58();
+const PROGRAM_ID = "GDDMwNyyx8uB6zrqwBFHjLLG3TBYk2F8Az4yrQC5RzMp";
+
+const h = vi.hoisted(() => ({
+  status: "ready" as "resolving" | "none" | "expired" | "ready",
+  kind: "embedded" as "adapter" | "embedded" | null,
+  publicKey: null as unknown,
+  batchSize: undefined as number | undefined,
+  startReauth: vi.fn(),
+  signTransaction: vi.fn(),
+  signAllTransactions: vi.fn(),
+  deployProgram: vi.fn(),
+  binaryLength: null as number | null,
+  estimateDeployCost: vi.fn(),
+  balanceLamports: 0,
+  trackEvent: vi.fn(),
+  isSessionExpired: vi.fn(() => false),
+}));
+
+vi.mock("@/hooks/use-deploy-signer", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/hooks/use-deploy-signer")>()),
+  useDeploySigner: () => ({
+    status: h.status,
+    kind: h.status === "ready" ? h.kind : null,
+    signer:
+      h.status === "ready"
+        ? {
+            publicKey: h.publicKey,
+            signTransaction: h.signTransaction,
+            signAllTransactions: h.signAllTransactions,
+          }
+        : null,
+    batchSize: h.status === "ready" ? h.batchSize : undefined,
+    startReauth: h.startReauth,
+  }),
+}));
+
+vi.mock("@solana/wallet-adapter-react", () => ({
+  useWallet: () => ({ publicKey: null }),
+  useConnection: () => ({
+    connection: { getBalance: async () => h.balanceLamports },
+  }),
+}));
+
+vi.mock("@/lib/auth/auth-provider", () => ({
+  useAuth: () => ({
+    profile: { wallet_address: EMBEDDED, wallet_kind: "embedded" },
+    isLoading: false,
+  }),
+}));
+
+vi.mock("@superteam-lms/deploy", () => ({
+  deployProgram: h.deployProgram,
+  resumeDeployment: vi.fn(),
+  getCachedBinaryLength: () => h.binaryLength,
+  estimateDeployCost: h.estimateDeployCost,
+  createAirdropRequest: vi.fn(async () => ({ success: false, error: "no" })),
+}));
+
+vi.mock("@/lib/gamification/celebration", () => ({ celebrate: vi.fn() }));
+vi.mock("@/lib/analytics", () => ({ trackEvent: h.trackEvent }));
+vi.mock("@/lib/dynamic/solana", () => ({
+  isDynamicSessionExpiredError: h.isSessionExpired,
+}));
+
+function renderPanel() {
+  return render(
+    <NextIntlClientProvider locale="en" messages={messages}>
+      <DeployPanel
+        buildUuid="build-uuid-123"
+        lessonId="lesson-1"
+        courseSlug="btc-to-sol-evolution"
+        courseId="course-btc-to-sol"
+      />
+    </NextIntlClientProvider>
+  );
+}
+
+beforeEach(() => {
+  h.status = "ready";
+  h.kind = "embedded";
+  h.publicKey = new PublicKey(EMBEDDED);
+  h.batchSize = EMBEDDED_BATCH_SIZE;
+  h.binaryLength = null;
+  h.balanceLamports = 0;
+  h.startReauth.mockReset();
+  h.deployProgram.mockReset();
+  h.deployProgram.mockResolvedValue({
+    programId: PROGRAM_ID,
+    programIdPubkey: new PublicKey(PROGRAM_ID),
+    totalChunks: 3,
+    durationMs: 1000,
+    rentLamports: 0,
+  });
+  h.estimateDeployCost.mockReset();
+  h.trackEvent.mockReset();
+  h.isSessionExpired.mockReset();
+  h.isSessionExpired.mockReturnValue(false);
+  localStorage.clear();
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (_url: string, init?: RequestInit) => {
+      if (!init || init.method !== "POST") {
+        return { ok: true, json: async () => ({ deployed: false }) };
+      }
+      return { ok: true, status: 200, json: async () => ({}) };
+    })
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("DeployPanel — signer resolution", () => {
+  it("disables the button while the wallet is still resolving, without asking to connect", async () => {
+    h.status = "resolving";
+    renderPanel();
+
+    const button = await screen.findByRole("button", {
+      name: "Checking your wallet…",
+    });
+    expect(button).toBeDisabled();
+  });
+
+  it("offers Dynamic re-auth — not the connect modal — for an expired session", async () => {
+    h.status = "expired";
+    renderPanel();
+
+    expect(
+      await screen.findByRole("button", { name: /google/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Deploy to Devnet" })
+    ).not.toBeInTheDocument();
+  });
+
+  it("deploys with the embedded signer and its batch size", async () => {
+    renderPanel();
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Deploy to Devnet" })
+    );
+
+    await waitFor(() => expect(h.deployProgram).toHaveBeenCalledTimes(1));
+    const call = h.deployProgram.mock.calls[0]![0];
+    expect(call.batchSize).toBe(EMBEDDED_BATCH_SIZE);
+    expect(call.wallet.publicKey.toBase58()).toBe(EMBEDDED);
+    expect(h.trackEvent).toHaveBeenCalledWith("deploy_started", {
+      signerKind: "embedded",
+      batchSize: EMBEDDED_BATCH_SIZE,
+    });
+  });
+
+  it("takes the mismatch check from the signer's key, not the adapter's", async () => {
+    h.publicKey = Keypair.generate().publicKey; // != the linked wallet
+    renderPanel();
+
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent("wallet mismatch");
+  });
+
+  it("a session that expires mid-deploy pauses for re-auth instead of erroring", async () => {
+    h.deployProgram.mockRejectedValue(new Error("session gone"));
+    h.isSessionExpired.mockReturnValue(true);
+    renderPanel();
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Deploy to Devnet" })
+    );
+
+    expect(
+      await screen.findByRole("button", { name: /google/i })
+    ).toBeInTheDocument();
+    expect(screen.getByText("Deployment paused")).toBeInTheDocument();
+    expect(h.trackEvent).toHaveBeenCalledWith("deploy_session_expired", {
+      signerKind: "embedded",
+      phase: "deploy",
+    });
+  });
+});
+
+describe("DeployPanel — funding gate", () => {
+  beforeEach(() => {
+    h.binaryLength = 4_500;
+    h.estimateDeployCost.mockResolvedValue({
+      bufferRent: 0,
+      programRent: 0,
+      programDataRent: 0,
+      feeLamports: 0,
+      totalLamports: 2 * LAMPORTS_PER_SOL,
+    });
+  });
+
+  it("blocks the deploy and shows the funding card when the balance is short", async () => {
+    renderPanel();
+
+    const button = await screen.findByRole("button", {
+      name: /Not enough SOL/,
+    });
+    expect(button).toBeDisabled();
+    expect(screen.getByText("Fund Your Wallet")).toBeInTheDocument();
+    expect(h.trackEvent).toHaveBeenCalledWith(
+      "deploy_funding_required",
+      expect.objectContaining({ signerKind: "embedded" })
+    );
+  });
+
+  it("enables the deploy once the balance covers the estimate", async () => {
+    h.balanceLamports = 3 * LAMPORTS_PER_SOL;
+    renderPanel();
+
+    const button = await screen.findByRole("button", {
+      name: "Deploy to Devnet",
+    });
+    expect(button).toBeEnabled();
+    expect(screen.queryByText("Fund Your Wallet")).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/deploy/__tests__/deploy-panel.test.tsx
+++ b/apps/web/src/components/deploy/__tests__/deploy-panel.test.tsx
@@ -3,8 +3,8 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { NextIntlClientProvider } from "next-intl";
 import { PublicKey } from "@solana/web3.js";
-import { DeployPanel } from "../deploy-panel";
 import messages from "@/messages/en.json";
+import { DeployPanel } from "../deploy-panel";
 
 const CONNECTED = "B7o8NfV81HzjuZFWQTTx3Xdvh77Dqoajwib3kWEnvzJF";
 const OTHER_WALLET = "9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM";
@@ -41,6 +41,11 @@ vi.mock("@/lib/auth/auth-provider", () => ({
 vi.mock("@superteam-lms/deploy", () => ({
   deployProgram: h.deployProgram,
   resumeDeployment: vi.fn(),
+  // No binary is cached in this suite, so the funding gate reads nothing and
+  // never runs — these tests describe the panel with funding already settled.
+  getCachedBinaryLength: () => null,
+  estimateDeployCost: vi.fn(),
+  createAirdropRequest: vi.fn(),
 }));
 
 vi.mock("@/lib/gamification/celebration", () => ({ celebrate: h.celebrate }));

--- a/apps/web/src/components/deploy/__tests__/generic-program-explorer.test.tsx
+++ b/apps/web/src/components/deploy/__tests__/generic-program-explorer.test.tsx
@@ -1,0 +1,120 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { NextIntlClientProvider } from "next-intl";
+import { Keypair } from "@solana/web3.js";
+import messages from "@/messages/en.json";
+import { GenericProgramExplorer } from "../generic-program-explorer";
+
+const WALLET = Keypair.generate().publicKey;
+const PROGRAM_ID = "GDDMwNyyx8uB6zrqwBFHjLLG3TBYk2F8Az4yrQC5RzMp";
+const COURSE_SLUG = "btc-to-sol-evolution";
+
+const IDL = JSON.stringify({
+  address: PROGRAM_ID,
+  metadata: { name: "ping_program", version: "0.1.0", spec: "0.1.0" },
+  instructions: [
+    {
+      name: "ping",
+      discriminator: [1, 2, 3, 4, 5, 6, 7, 8],
+      accounts: [{ name: "signer", signer: true, writable: false }],
+      args: [],
+    },
+  ],
+  accounts: [],
+  types: [],
+});
+
+const h = vi.hoisted(() => ({
+  signTransaction: vi.fn(),
+  startReauth: vi.fn(),
+}));
+
+vi.mock("@/hooks/use-deploy-signer", () => ({
+  useDeploySigner: () => ({
+    status: "ready",
+    kind: "embedded",
+    signer: {
+      publicKey: WALLET,
+      signTransaction: h.signTransaction,
+      signAllTransactions: vi.fn(),
+    },
+    batchSize: 15,
+    startReauth: h.startReauth,
+  }),
+}));
+
+vi.mock("@solana/wallet-adapter-react", () => ({
+  useWallet: () => ({
+    publicKey: null,
+    disconnect: vi.fn(),
+    wallet: null,
+    select: vi.fn(),
+  }),
+  useConnection: () => ({
+    connection: {
+      getLatestBlockhash: async () => ({
+        blockhash: "11111111111111111111111111111111",
+        lastValidBlockHeight: 1,
+      }),
+      sendRawTransaction: vi.fn(),
+      confirmTransaction: vi.fn(),
+      getTransaction: vi.fn(),
+      getAccountInfo: async () => null,
+    },
+  }),
+}));
+
+vi.mock("@solana/wallet-adapter-react-ui", () => ({
+  useWalletModal: () => ({ setVisible: vi.fn() }),
+}));
+
+function renderExplorer() {
+  return render(
+    <NextIntlClientProvider locale="en" messages={messages}>
+      <GenericProgramExplorer
+        idlJson={IDL}
+        courseSlug={COURSE_SLUG}
+        courseId="course-btc-to-sol"
+      />
+    </NextIntlClientProvider>
+  );
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  localStorage.setItem(
+    `program-${WALLET.toBase58().slice(0, 8)}-${COURSE_SLUG}`,
+    PROGRAM_ID
+  );
+  h.signTransaction.mockReset();
+  h.startReauth.mockReset();
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => ({ ok: true, json: async () => ({ deployed: false }) }))
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("GenericProgramExplorer — expired Dynamic session", () => {
+  it("routes a mid-execute expiry to the re-auth card, not a raw error", async () => {
+    const expired = new Error("session expired");
+    expired.name = "UnauthorizedError";
+    h.signTransaction.mockRejectedValue(expired);
+
+    renderExplorer();
+
+    fireEvent.click(await screen.findByText("Ping"));
+    fireEvent.click(await screen.findByRole("button", { name: /Execute/ }));
+
+    // The reauth card takes over the whole widget: an embedded learner has no
+    // extension to reconnect, so "Reconnect Wallet" would be a dead end.
+    expect(
+      await screen.findByRole("button", { name: /Google/i })
+    ).toBeInTheDocument();
+    expect(screen.queryByText("session expired")).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/deploy/__tests__/wallet-funding-card-loop.test.tsx
+++ b/apps/web/src/components/deploy/__tests__/wallet-funding-card-loop.test.tsx
@@ -1,0 +1,98 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, act } from "@testing-library/react";
+import { NextIntlClientProvider } from "next-intl";
+import { Keypair } from "@solana/web3.js";
+import messages from "@/messages/en.json";
+import { WalletFundingCard } from "../wallet-funding-card";
+
+/**
+ * The card with the REAL `useDeploySigner` behind it. The sibling suite mocks
+ * the hook, which is exactly why it could not see the render loop that shipped
+ * in the first cut of this PR: `parseWalletAddress` minted a new `PublicKey`
+ * per render, `refreshBalance` was rebuilt per render, and the effect that
+ * calls it fired again — 1559 `getBalance` calls in 1.28 s.
+ */
+const EMBEDDED = Keypair.generate().publicKey;
+
+const h = vi.hoisted(() => {
+  const getBalance = vi.fn();
+  return {
+    getBalance,
+    // One object for the whole suite, like the real ConnectionProvider's
+    // context value — the card is only asked to survive its OWN churn.
+    connection: { getBalance },
+    account: null as { address: string } | null,
+  };
+});
+
+vi.mock("@solana/wallet-adapter-react", () => ({
+  useWallet: () => ({ publicKey: null }),
+  useConnection: () => ({ connection: h.connection }),
+}));
+
+vi.mock("@/lib/dynamic/solana", () => ({
+  signWithDynamicWallet: vi.fn(),
+  signAllWithDynamicWallet: vi.fn(),
+}));
+vi.mock("@/lib/dynamic/social", () => ({
+  startDynamicSocialSignIn: vi.fn(),
+}));
+vi.mock("@/lib/dynamic/config", () => ({ isDynamicEnabled: () => true }));
+vi.mock("@/hooks/use-dynamic-session-state", () => ({
+  // A fresh account object per call, like `getDynamicSolanaAccount` returns.
+  useDynamicSessionState: () => ({
+    status: h.account ? "valid" : "none",
+    account: h.account ? { ...h.account } : null,
+  }),
+}));
+
+vi.mock("@superteam-lms/deploy", () => ({
+  createAirdropRequest: vi.fn(),
+}));
+
+function renderCard() {
+  return render(
+    <NextIntlClientProvider locale="en" messages={messages}>
+      <WalletFundingCard />
+    </NextIntlClientProvider>
+  );
+}
+
+beforeEach(() => {
+  h.account = { address: EMBEDDED.toBase58() };
+  h.getBalance.mockReset();
+  h.getBalance.mockResolvedValue(0);
+});
+
+describe("WalletFundingCard — balance reads are bounded", () => {
+  it("does not re-read the balance forever", async () => {
+    const { rerender } = renderCard();
+    await screen.findByText("Fund Your Wallet");
+
+    for (let i = 0; i < 5; i++) {
+      rerender(
+        <NextIntlClientProvider locale="en" messages={messages}>
+          <WalletFundingCard />
+        </NextIntlClientProvider>
+      );
+    }
+
+    // Bounded flushes rather than a sleep: a self-sustaining effect loop
+    // starves the timer queue, so a sleep would fail by timeout instead of by
+    // assertion.
+    for (let i = 0; i < 10; i++) {
+      await act(async () => {
+        await Promise.resolve();
+      });
+    }
+
+    expect(h.getBalance.mock.calls.length).toBeLessThanOrEqual(2);
+  });
+
+  it("reads the balance for the session's own address", async () => {
+    renderCard();
+    await screen.findByText("Fund Your Wallet");
+    expect(h.getBalance.mock.calls[0]![0].toBase58()).toBe(EMBEDDED.toBase58());
+  });
+});

--- a/apps/web/src/components/deploy/__tests__/wallet-funding-card.test.tsx
+++ b/apps/web/src/components/deploy/__tests__/wallet-funding-card.test.tsx
@@ -1,0 +1,118 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { NextIntlClientProvider } from "next-intl";
+import { Keypair, LAMPORTS_PER_SOL } from "@solana/web3.js";
+import messages from "@/messages/en.json";
+import { WalletFundingCard } from "../wallet-funding-card";
+
+const EMBEDDED = Keypair.generate().publicKey;
+
+const h = vi.hoisted(() => ({
+  publicKey: null as unknown,
+  balanceLamports: 0,
+  createAirdropRequest: vi.fn(),
+}));
+
+vi.mock("@/hooks/use-deploy-signer", () => ({
+  useDeploySigner: () => ({
+    status: h.publicKey ? "ready" : "none",
+    kind: h.publicKey ? "embedded" : null,
+    signer: h.publicKey
+      ? {
+          publicKey: h.publicKey,
+          signTransaction: vi.fn(),
+          signAllTransactions: vi.fn(),
+        }
+      : null,
+    batchSize: undefined,
+    startReauth: vi.fn(),
+  }),
+}));
+
+vi.mock("@solana/wallet-adapter-react", () => ({
+  useConnection: () => ({
+    connection: { getBalance: async () => h.balanceLamports },
+  }),
+}));
+
+vi.mock("@superteam-lms/deploy", () => ({
+  createAirdropRequest: h.createAirdropRequest,
+}));
+
+function renderCard(props?: {
+  requiredLamports?: number;
+  onBalance?: (lamports: number) => void;
+}) {
+  return render(
+    <NextIntlClientProvider locale="en" messages={messages}>
+      <WalletFundingCard {...props} />
+    </NextIntlClientProvider>
+  );
+}
+
+beforeEach(() => {
+  h.publicKey = EMBEDDED;
+  h.balanceLamports = 0;
+  h.createAirdropRequest.mockReset();
+  h.createAirdropRequest.mockResolvedValue({ success: true, newBalance: 2 });
+});
+
+describe("WalletFundingCard", () => {
+  it("renders for an embedded signer with no wallet-adapter wallet", async () => {
+    renderCard();
+    expect(await screen.findByText("Fund Your Wallet")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        `${EMBEDDED.toBase58().slice(0, 4)}...${EMBEDDED.toBase58().slice(-4)}`
+      )
+    ).toBeInTheDocument();
+  });
+
+  it("airdrops to the signer's own address", async () => {
+    renderCard();
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Request Airdrop" })
+    );
+
+    await waitFor(() =>
+      expect(h.createAirdropRequest).toHaveBeenCalledTimes(1)
+    );
+    expect(h.createAirdropRequest.mock.calls[0]![1]).toBe(EMBEDDED);
+  });
+
+  it("measures against the deploy estimate when one is given", async () => {
+    h.balanceLamports = 0.5 * LAMPORTS_PER_SOL;
+    renderCard({ requiredLamports: 1.5 * LAMPORTS_PER_SOL });
+
+    // 1.5 needed, 0.5 held — the shortfall is the estimate's, not a flat 5 SOL.
+    expect(await screen.findByText("Need ~1.00 more SOL")).toBeInTheDocument();
+  });
+
+  it("reports each balance read so the panel's gate can re-evaluate", async () => {
+    const onBalance = vi.fn();
+    h.balanceLamports = 3 * LAMPORTS_PER_SOL;
+    renderCard({ onBalance });
+
+    await waitFor(() =>
+      expect(onBalance).toHaveBeenCalledWith(3 * LAMPORTS_PER_SOL)
+    );
+  });
+
+  it("shows a copyable address when the faucet rate-limits the airdrop", async () => {
+    h.createAirdropRequest.mockResolvedValue({
+      success: false,
+      rateLimited: true,
+    });
+    renderCard();
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Request Airdrop" })
+    );
+
+    const copyButton = await screen.findByRole("button", {
+      name: new RegExp(EMBEDDED.toBase58()),
+    });
+    expect(copyButton).toHaveTextContent("Copy address");
+  });
+});

--- a/apps/web/src/components/deploy/__tests__/wallet-funding-card.test.tsx
+++ b/apps/web/src/components/deploy/__tests__/wallet-funding-card.test.tsx
@@ -78,7 +78,11 @@ describe("WalletFundingCard", () => {
     await waitFor(() =>
       expect(h.createAirdropRequest).toHaveBeenCalledTimes(1)
     );
-    expect(h.createAirdropRequest.mock.calls[0]![1]).toBe(EMBEDDED);
+    // By address, not by object identity: the card re-derives the key from the
+    // signer's address so its `refreshBalance` effect cannot self-sustain.
+    expect(h.createAirdropRequest.mock.calls[0]![1].toBase58()).toBe(
+      EMBEDDED.toBase58()
+    );
   });
 
   it("measures against the deploy estimate when one is given", async () => {

--- a/apps/web/src/components/deploy/deploy-panel.tsx
+++ b/apps/web/src/components/deploy/deploy-panel.tsx
@@ -1,28 +1,36 @@
 "use client";
 
 import { useState, useEffect, useCallback, useRef } from "react";
-import { useWallet, useConnection } from "@solana/wallet-adapter-react";
+import { useConnection } from "@solana/wallet-adapter-react";
 import { LAMPORTS_PER_SOL, PublicKey } from "@solana/web3.js";
 import {
   deployProgram,
+  estimateDeployCost,
+  getCachedBinaryLength,
   resumeDeployment,
   type DeploymentCallbacks,
   type DeploymentState,
   type DeployResult,
   type DeployStep,
+  type WalletAdapter,
 } from "@superteam-lms/deploy";
 import { useTranslations } from "next-intl";
 import { celebrate } from "@/lib/gamification/celebration";
 import { useAuth } from "@/lib/auth/auth-provider";
+import { trackEvent } from "@/lib/analytics";
+import { isDynamicSessionExpiredError } from "@/lib/dynamic/solana";
 import {
   saveDeploymentWithRetry,
   type SaveStatus,
 } from "@/lib/deploy/save-deployment";
+import { useDeploySigner } from "@/hooks/use-deploy-signer";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Progress } from "@/components/ui/progress";
+import { LinkedWalletPrompt } from "@/components/wallet/linked-wallet-prompt";
 import { cn } from "@/lib/utils";
 import { DeploySaveStatus } from "./deploy-save-status";
+import { WalletFundingCard } from "./wallet-funding-card";
 import { WalletMismatchWarning } from "./wallet-mismatch-warning";
 
 // ---------------------------------------------------------------------------
@@ -101,6 +109,29 @@ function formatDuration(ms: number): string {
   return `${minutes}m ${remaining}s`;
 }
 
+/**
+ * The signer, with per-batch signing time logged outside production.
+ *
+ * EMBEDDED_BATCH_SIZE is provisional: MPC signing latency for N transactions
+ * against a real Dynamic session cannot be measured from a test environment.
+ * This is how it gets measured on a real session — without shipping a console
+ * line to learners.
+ */
+function instrumentSigner(base: WalletAdapter): WalletAdapter {
+  if (process.env.NODE_ENV === "production") return base;
+  const signAllTransactions: WalletAdapter["signAllTransactions"] = async (
+    txs
+  ) => {
+    const started = Date.now();
+    const signed = await base.signAllTransactions(txs);
+    console.debug(
+      `[deploy] signAllTransactions(${txs.length}) took ${Date.now() - started}ms`
+    );
+    return signed;
+  };
+  return { ...base, signAllTransactions };
+}
+
 function formatBytes(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`;
   return `${(bytes / 1024).toFixed(1)} KB`;
@@ -134,7 +165,16 @@ export function DeployPanel({
   onBuildExpired,
 }: DeployPanelProps) {
   const t = useTranslations("deploy.deployment");
-  const { publicKey, signTransaction, signAllTransactions } = useWallet();
+  // Extension wallet or Dynamic embedded wallet — the deploy is signed and paid
+  // by whichever one this learner actually has.
+  const {
+    status: signerStatus,
+    signer,
+    kind: signerKind,
+    batchSize,
+    startReauth,
+  } = useDeploySigner();
+  const publicKey = signer?.publicKey ?? null;
   const { connection } = useConnection();
   const { profile, isLoading: authLoading } = useAuth();
 
@@ -156,6 +196,14 @@ export function DeployPanel({
     batchNumber: number;
     totalBatches: number;
   } | null>(null);
+  // The Dynamic session died mid-deploy. Distinct from the hook's `expired`,
+  // which describes the session BEFORE a deploy starts.
+  const [sessionExpired, setSessionExpired] = useState(false);
+  const [reauthDismissed, setReauthDismissed] = useState(false);
+  // Funding gate: what this deploy costs, and what the signer holds.
+  const [costLamports, setCostLamports] = useState<number | null>(null);
+  const [balanceLamports, setBalanceLamports] = useState<number | null>(null);
+  const fundingTrackedRef = useRef(false);
 
   // Timing
   const startTimeRef = useRef<number>(0);
@@ -221,6 +269,56 @@ export function DeployPanel({
         : linkedWallet !== connectedWallet
           ? "mismatch"
           : null;
+
+  const needsReauth =
+    (signerStatus === "expired" || sessionExpired) && !reauthDismissed;
+
+  // An embedded wallet starts at zero SOL, so "can this learner afford the
+  // deploy?" has to be answered before the button is enabled — otherwise the
+  // first thing they meet is a failed buffer-create transaction. The estimate
+  // covers buffer + program + programdata rent and every fee (packages/deploy).
+  const gateActive = panelState === "ready" || panelState === "paused";
+  useEffect(() => {
+    if (!gateActive || !signer?.publicKey) return;
+    const programLen = getCachedBinaryLength(buildUuid);
+    if (programLen === null) return;
+
+    const payer = signer.publicKey;
+    let cancelled = false;
+    (async () => {
+      try {
+        const [estimate, lamports] = await Promise.all([
+          estimateDeployCost(connection, programLen),
+          connection.getBalance(payer, "confirmed"),
+        ]);
+        if (cancelled) return;
+        setCostLamports(estimate.totalLamports);
+        setBalanceLamports(lamports);
+      } catch {
+        // A failed RPC read must not block a deploy the learner can afford:
+        // leaving both null keeps the gate open, as before this change.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [gateActive, signer, connection, buildUuid]);
+
+  const shortfallLamports =
+    costLamports !== null && balanceLamports !== null
+      ? Math.max(costLamports - balanceLamports, 0)
+      : 0;
+  const needsFunding = shortfallLamports > 0;
+
+  useEffect(() => {
+    if (!needsFunding || fundingTrackedRef.current) return;
+    fundingTrackedRef.current = true;
+    trackEvent("deploy_funding_required", {
+      signerKind,
+      shortfallLamports,
+      costLamports,
+    });
+  }, [needsFunding, shortfallLamports, costLamports, signerKind]);
 
   // Check for an existing deployment on mount. The SERVER record is the source
   // of truth for whether this deploy is recorded; localStorage is only an
@@ -413,6 +511,12 @@ export function DeployPanel({
         }
       }
 
+      trackEvent("deploy_completed", {
+        signerKind,
+        durationMs: deployResult.durationMs,
+        totalChunks: deployResult.totalChunks,
+      });
+
       // Medium celebration — a successful devnet deploy is one of the two
       // confetti-worthy milestones (LX-B11); respects prefers-reduced-motion.
       celebrate("deploy-success");
@@ -425,12 +529,12 @@ export function DeployPanel({
       // failed save is surfaced with a retry, never silently swallowed (#622).
       runSave(deployResult);
     },
-    [buildUuid, courseSlug, lessonId, walletPrefix, runSave]
+    [buildUuid, courseSlug, lessonId, walletPrefix, runSave, signerKind]
   );
 
   // Deploy handler
   const handleDeploy = useCallback(async () => {
-    if (!publicKey || !signTransaction || !signAllTransactions) return;
+    if (!signer || needsFunding) return;
 
     setPanelState("deploying");
     setTxLog([]);
@@ -440,22 +544,36 @@ export function DeployPanel({
     setResult(null);
     setBatchInfo(null);
     setSaveStatus("idle");
+    setSessionExpired(false);
     saveCancelledRef.current = true;
     startTimeRef.current = Date.now();
 
     const callbacks = buildCallbacks();
+    trackEvent("deploy_started", { signerKind, batchSize });
 
     try {
       const deployResult = await deployProgram({
         connection,
-        wallet: { publicKey, signTransaction, signAllTransactions },
+        wallet: instrumentSigner(signer),
         buildServerUrl: "/api",
         buildUuid,
         callbacks,
         programKeypairSecret,
+        batchSize,
       });
       handleSuccess(deployResult);
     } catch (err) {
+      // An expired embedded session is not a deploy failure: the uploaded
+      // chunks survive (the buffer authority is the payer, the same key after
+      // re-auth), so this pauses for re-auth rather than reporting an error.
+      if (isDynamicSessionExpiredError(err)) {
+        trackEvent("deploy_session_expired", { signerKind, phase: "deploy" });
+        setSessionExpired(true);
+        setReauthDismissed(false);
+        setPanelState("paused");
+        return;
+      }
+
       const message = err instanceof Error ? err.message : String(err);
       setErrorMessage(message);
 
@@ -470,9 +588,10 @@ export function DeployPanel({
       }
     }
   }, [
-    publicKey,
-    signTransaction,
-    signAllTransactions,
+    signer,
+    signerKind,
+    batchSize,
+    needsFunding,
     connection,
     buildUuid,
     programKeypairSecret,
@@ -482,12 +601,12 @@ export function DeployPanel({
 
   // Resume handler
   const handleResume = useCallback(async () => {
-    if (!publicKey || !signTransaction || !signAllTransactions || !savedState)
-      return;
+    if (!signer || !savedState) return;
 
     setPanelState("deploying");
     setErrorMessage(null);
     setBatchInfo(null);
+    setSessionExpired(false);
     startTimeRef.current = Date.now();
 
     // Restore chunk progress from saved state
@@ -495,25 +614,35 @@ export function DeployPanel({
     setChunkTotal(savedState.totalChunks);
 
     const callbacks = buildCallbacks();
+    trackEvent("deploy_started", { signerKind, batchSize, resumed: true });
 
     try {
       const deployResult = await resumeDeployment({
         connection,
-        wallet: { publicKey, signTransaction, signAllTransactions },
+        wallet: instrumentSigner(signer),
         buildServerUrl: "/api",
         state: savedState,
         callbacks,
+        batchSize,
       });
       handleSuccess(deployResult);
     } catch (err) {
+      if (isDynamicSessionExpiredError(err)) {
+        trackEvent("deploy_session_expired", { signerKind, phase: "resume" });
+        setSessionExpired(true);
+        setReauthDismissed(false);
+        setPanelState("paused");
+        return;
+      }
+
       const message = err instanceof Error ? err.message : String(err);
       setErrorMessage(message);
       setPanelState("paused");
     }
   }, [
-    publicKey,
-    signTransaction,
-    signAllTransactions,
+    signer,
+    signerKind,
+    batchSize,
     connection,
     savedState,
     buildCallbacks,
@@ -918,12 +1047,21 @@ export function DeployPanel({
             </div>
           )}
 
+          {needsReauth && (
+            <LinkedWalletPrompt
+              variant="reauth"
+              linkedWallet={linkedWallet}
+              onReauth={startReauth}
+              onDismiss={() => setReauthDismissed(true)}
+            />
+          )}
+
           <div className="flex gap-2">
             {!isExpired && savedState && (
               <Button
                 onClick={handleResume}
                 className="flex-1"
-                disabled={!publicKey}
+                disabled={!signer}
               >
                 {t("resume")}
               </Button>
@@ -1002,13 +1140,37 @@ export function DeployPanel({
           />
         )}
 
-        <Button
-          onClick={handleDeploy}
-          className="w-full bg-gradient-to-r from-solana-purple to-solana-green font-semibold text-white hover:opacity-90"
-          disabled={!publicKey}
-        >
-          {t("deployToDevnet")}
-        </Button>
+        {/* The deploy costs real rent and fees. An embedded wallet starts at
+            zero, so fund it here rather than failing on the first tx. */}
+        {needsFunding && (
+          <WalletFundingCard
+            requiredLamports={costLamports ?? undefined}
+            onBalance={setBalanceLamports}
+          />
+        )}
+
+        {needsReauth ? (
+          <LinkedWalletPrompt
+            variant="reauth"
+            linkedWallet={linkedWallet}
+            onReauth={startReauth}
+            onDismiss={() => setReauthDismissed(true)}
+          />
+        ) : (
+          <Button
+            onClick={handleDeploy}
+            className="w-full bg-gradient-to-r from-solana-purple to-solana-green font-semibold text-white hover:opacity-90"
+            disabled={!signer || needsFunding}
+          >
+            {signerStatus === "resolving"
+              ? t("resolvingWallet")
+              : needsFunding
+                ? t("insufficientSol", {
+                    amount: (shortfallLamports / LAMPORTS_PER_SOL).toFixed(2),
+                  })
+                : t("deployToDevnet")}
+          </Button>
+        )}
       </CardContent>
     </Card>
   );

--- a/apps/web/src/components/deploy/generic-program-explorer.tsx
+++ b/apps/web/src/components/deploy/generic-program-explorer.tsx
@@ -12,8 +12,10 @@ import { BorshInstructionCoder, BorshCoder, BN } from "@coral-xyz/anchor";
 import type { Idl } from "@coral-xyz/anchor";
 import { useTranslations } from "next-intl";
 import { useWalletModal } from "@solana/wallet-adapter-react-ui";
+import { useDeploySigner } from "@/hooks/use-deploy-signer";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
+import { LinkedWalletPrompt } from "@/components/wallet/linked-wallet-prompt";
 import { cn } from "@/lib/utils";
 import {
   isWalletKeyringError,
@@ -122,11 +124,17 @@ export function GenericProgramExplorer({
   courseId,
 }: GenericProgramExplorerProps) {
   const t = useTranslations("deploy.explorer");
-  const { publicKey, signTransaction, disconnect, wallet, select } =
-    useWallet();
+  // The wallet that signs — extension or embedded. `useWallet` is still read
+  // for the ADAPTER-only reconnect path below (an embedded wallet has no
+  // adapter to re-select; its recovery is Dynamic re-auth).
+  const { status: signerStatus, signer, startReauth } = useDeploySigner();
+  const publicKey = signer?.publicKey ?? null;
+  const signTransaction = signer?.signTransaction ?? null;
+  const { disconnect, wallet, select } = useWallet();
   const { connection } = useConnection();
   const { setVisible: openWalletModal } = useWalletModal();
   const [isReconnecting, setIsReconnecting] = useState(false);
+  const [reauthDismissed, setReauthDismissed] = useState(false);
   const [pendingReconnectWallet, setPendingReconnectWallet] =
     useState<WalletName | null>(null);
   const reconnectAttemptsRef = useRef(0);
@@ -671,19 +679,35 @@ export function GenericProgramExplorer({
   }
 
   if (!publicKey) {
+    // An embedded learner whose Dynamic session expired must never be shown the
+    // connect modal: they have no extension, and the modal has no route back to
+    // Dynamic short of a full sign-out.
+    if (signerStatus === "expired" && !reauthDismissed) {
+      return (
+        <LinkedWalletPrompt
+          variant="reauth"
+          linkedWallet={null}
+          onReauth={startReauth}
+          onDismiss={() => setReauthDismissed(true)}
+        />
+      );
+    }
+
     return (
       <Card className="border-yellow-500/30 bg-yellow-500/5">
         <CardContent className="space-y-4 py-8 text-center">
           <p className="text-sm text-muted-foreground">
             {t("walletDisconnected")}
           </p>
-          <Button
-            onClick={() => openWalletModal(true)}
-            variant="outline"
-            size="sm"
-          >
-            {t("connectWallet")}
-          </Button>
+          {signerStatus !== "resolving" && (
+            <Button
+              onClick={() => openWalletModal(true)}
+              variant="outline"
+              size="sm"
+            >
+              {t("connectWallet")}
+            </Button>
+          )}
         </CardContent>
       </Card>
     );

--- a/apps/web/src/components/deploy/generic-program-explorer.tsx
+++ b/apps/web/src/components/deploy/generic-program-explorer.tsx
@@ -13,6 +13,7 @@ import type { Idl } from "@coral-xyz/anchor";
 import { useTranslations } from "next-intl";
 import { useWalletModal } from "@solana/wallet-adapter-react-ui";
 import { useDeploySigner } from "@/hooks/use-deploy-signer";
+import { isDynamicSessionExpiredError } from "@/lib/dynamic/solana";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { LinkedWalletPrompt } from "@/components/wallet/linked-wallet-prompt";
@@ -135,6 +136,7 @@ export function GenericProgramExplorer({
   const { setVisible: openWalletModal } = useWalletModal();
   const [isReconnecting, setIsReconnecting] = useState(false);
   const [reauthDismissed, setReauthDismissed] = useState(false);
+  const [sessionExpired, setSessionExpired] = useState(false);
   const [pendingReconnectWallet, setPendingReconnectWallet] =
     useState<WalletName | null>(null);
   const reconnectAttemptsRef = useRef(0);
@@ -225,6 +227,12 @@ export function GenericProgramExplorer({
       reconnectAttemptsRef.current = 0;
     }
   }, [publicKey]);
+
+  // A session that came back is no longer expired. Keyed on the status rather
+  // than on `publicKey`, which is stable across a re-auth to the same address.
+  useEffect(() => {
+    if (signerStatus === "ready") setSessionExpired(false);
+  }, [signerStatus]);
 
   // State-driven reconnection: after select(null) deselects the adapter,
   // re-select the remembered wallet once the provider reflects the change.
@@ -579,6 +587,16 @@ export function GenericProgramExplorer({
           return;
         }
 
+        // An expired embedded session recovers through Dynamic re-auth, the
+        // same as in the deploy panel — `isWalletKeyringError` is
+        // extension-specific, so without this the learner gets a raw error and
+        // no way back.
+        if (isDynamicSessionExpiredError(err)) {
+          setSessionExpired(true);
+          setReauthDismissed(false);
+          return;
+        }
+
         if (isWalletKeyringError(msg)) {
           reconnectAttemptsRef.current += 1;
           setWalletError(true);
@@ -678,21 +696,22 @@ export function GenericProgramExplorer({
     );
   }
 
-  if (!publicKey) {
-    // An embedded learner whose Dynamic session expired must never be shown the
-    // connect modal: they have no extension, and the modal has no route back to
-    // Dynamic short of a full sign-out.
-    if (signerStatus === "expired" && !reauthDismissed) {
-      return (
-        <LinkedWalletPrompt
-          variant="reauth"
-          linkedWallet={null}
-          onReauth={startReauth}
-          onDismiss={() => setReauthDismissed(true)}
-        />
-      );
-    }
+  // An embedded learner whose Dynamic session expired must never be shown the
+  // connect modal: they have no extension, and the modal has no route back to
+  // Dynamic short of a full sign-out. `sessionExpired` covers the mid-execute
+  // case, where the signer can still look ready.
+  if ((signerStatus === "expired" || sessionExpired) && !reauthDismissed) {
+    return (
+      <LinkedWalletPrompt
+        variant="reauth"
+        linkedWallet={null}
+        onReauth={startReauth}
+        onDismiss={() => setReauthDismissed(true)}
+      />
+    );
+  }
 
+  if (!publicKey) {
     return (
       <Card className="border-yellow-500/30 bg-yellow-500/5">
         <CardContent className="space-y-4 py-8 text-center">

--- a/apps/web/src/components/deploy/wallet-funding-card.tsx
+++ b/apps/web/src/components/deploy/wallet-funding-card.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 import { useState, useEffect, useCallback, useRef } from "react";
-import { useWallet, useConnection } from "@solana/wallet-adapter-react";
+import { useConnection } from "@solana/wallet-adapter-react";
 import { LAMPORTS_PER_SOL } from "@solana/web3.js";
 import { createAirdropRequest } from "@superteam-lms/deploy";
 import { useTranslations } from "next-intl";
+import { useDeploySigner } from "@/hooks/use-deploy-signer";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Progress } from "@/components/ui/progress";
@@ -12,15 +13,33 @@ import { Progress } from "@/components/ui/progress";
 const TARGET_SOL = 5;
 const COOLDOWN_SECONDS = 15;
 
-export function WalletFundingCard() {
+interface WalletFundingCardProps {
+  /**
+   * What a pending deploy needs, in lamports. When set, the card measures
+   * progress against this figure instead of the standalone 5 SOL target — the
+   * deploy panel's inline funding gate passes the estimate it computed.
+   */
+  requiredLamports?: number;
+  /** Every balance read, so a parent gate can re-evaluate without polling. */
+  onBalance?: (lamports: number) => void;
+}
+
+export function WalletFundingCard({
+  requiredLamports,
+  onBalance,
+}: WalletFundingCardProps = {}) {
   const t = useTranslations("deploy.walletFunding");
-  const { publicKey } = useWallet();
+  // Extension or embedded — an embedded learner has no wallet-adapter key and
+  // is exactly who arrives here with zero SOL.
+  const { signer } = useDeploySigner();
+  const publicKey = signer?.publicKey ?? null;
   const { connection } = useConnection();
 
   const [balance, setBalance] = useState<number | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [isAirdropping, setIsAirdropping] = useState(false);
   const [cooldown, setCooldown] = useState(0);
+  const [addressCopied, setAddressCopied] = useState(false);
   const [message, setMessage] = useState<{
     text: string;
     type: "success" | "warning" | "error";
@@ -34,12 +53,13 @@ export function WalletFundingCard() {
     try {
       const lamports = await connection.getBalance(publicKey, "confirmed");
       setBalance(lamports / LAMPORTS_PER_SOL);
+      onBalance?.(lamports);
     } catch {
       setBalance(null);
     } finally {
       setIsLoading(false);
     }
-  }, [publicKey, connection]);
+  }, [publicKey, connection, onBalance]);
 
   useEffect(() => {
     refreshBalance();
@@ -65,6 +85,9 @@ export function WalletFundingCard() {
 
     if (result.success) {
       setBalance(result.newBalance ?? balance);
+      if (result.newBalance !== undefined) {
+        onBalance?.(Math.round(result.newBalance * LAMPORTS_PER_SOL));
+      }
       setMessage({
         text: t("airdropSuccess", { amount: "2" }),
         type: "success",
@@ -87,6 +110,17 @@ export function WalletFundingCard() {
     setIsAirdropping(false);
   };
 
+  const handleCopyAddress = async () => {
+    if (!publicKey) return;
+    try {
+      await navigator.clipboard.writeText(publicKey.toBase58());
+      setAddressCopied(true);
+      setTimeout(() => setAddressCopied(false), 2000);
+    } catch {
+      // clipboard API unavailable
+    }
+  };
+
   // Not connected state
   if (!publicKey) {
     return (
@@ -98,9 +132,20 @@ export function WalletFundingCard() {
     );
   }
 
+  // With a deploy estimate in hand, "enough" is that estimate — not a flat
+  // 5 SOL that is both too much for a small program and no guarantee for a
+  // large one.
+  const targetSol =
+    requiredLamports !== undefined
+      ? requiredLamports / LAMPORTS_PER_SOL
+      : TARGET_SOL;
   const progressPercent =
-    balance !== null ? Math.min((balance / TARGET_SOL) * 100, 100) : 0;
-  const isReady = balance !== null && balance >= TARGET_SOL - 0.5; // ~4.5 SOL is enough
+    balance !== null ? Math.min((balance / targetSol) * 100, 100) : 0;
+  const isReady =
+    balance !== null &&
+    (requiredLamports !== undefined
+      ? balance >= targetSol
+      : balance >= TARGET_SOL - 0.5); // ~4.5 SOL is enough
 
   return (
     <Card className="border-border/50">
@@ -144,7 +189,9 @@ export function WalletFundingCard() {
               ? t("readyForDeploy")
               : t("needMoreSol", {
                   amount:
-                    balance !== null ? (TARGET_SOL - balance).toFixed(1) : "5",
+                    balance !== null
+                      ? (targetSol - balance).toFixed(2)
+                      : targetSol.toFixed(2),
                 })}
           </p>
         </div>
@@ -162,17 +209,33 @@ export function WalletFundingCard() {
           >
             <p>{message.text}</p>
             {message.type === "warning" && (
-              <p className="mt-1">
-                {t("faucetHint")}{" "}
-                <a
-                  href="https://faucet.solana.com"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="underline hover:text-yellow-400"
+              <>
+                <p className="mt-1">
+                  {t("faucetHint")}{" "}
+                  <a
+                    href="https://faucet.solana.com"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="underline hover:text-yellow-400"
+                  >
+                    faucet.solana.com
+                  </a>
+                </p>
+                {/* The faucet asks for an address. An embedded wallet has no
+                    extension UI to read one out of, so hand it over here. */}
+                <button
+                  type="button"
+                  onClick={handleCopyAddress}
+                  className="bg-muted/50 mt-2 flex w-full items-center gap-2 rounded-md px-3 py-2 text-left font-mono text-xs text-foreground transition-colors hover:bg-muted"
                 >
-                  faucet.solana.com
-                </a>
-              </p>
+                  <span className="flex-1 truncate">
+                    {publicKey.toBase58()}
+                  </span>
+                  <span className="shrink-0 text-[10px] text-muted-foreground">
+                    {addressCopied ? t("addressCopied") : t("copyAddress")}
+                  </span>
+                </button>
+              </>
             )}
           </div>
         )}

--- a/apps/web/src/components/deploy/wallet-funding-card.tsx
+++ b/apps/web/src/components/deploy/wallet-funding-card.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useState, useEffect, useCallback, useRef } from "react";
+import { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import { useConnection } from "@solana/wallet-adapter-react";
-import { LAMPORTS_PER_SOL } from "@solana/web3.js";
+import { LAMPORTS_PER_SOL, PublicKey } from "@solana/web3.js";
 import { createAirdropRequest } from "@superteam-lms/deploy";
 import { useTranslations } from "next-intl";
 import { useDeploySigner } from "@/hooks/use-deploy-signer";
@@ -32,7 +32,15 @@ export function WalletFundingCard({
   // Extension or embedded — an embedded learner has no wallet-adapter key and
   // is exactly who arrives here with zero SOL.
   const { signer } = useDeploySigner();
-  const publicKey = signer?.publicKey ?? null;
+  // `refreshBalance` runs from an effect keyed on itself, so the key it closes
+  // over has to be referentially stable or the card polls `getBalance` forever.
+  // Re-deriving it from the address means a future caller cannot re-break this
+  // by handing the card a freshly-parsed `PublicKey` each render.
+  const address = signer?.publicKey?.toBase58() ?? null;
+  const publicKey = useMemo(
+    () => (address ? new PublicKey(address) : null),
+    [address]
+  );
   const { connection } = useConnection();
 
   const [balance, setBalance] = useState<number | null>(null);

--- a/apps/web/src/hooks/__tests__/use-deploy-signer.test.tsx
+++ b/apps/web/src/hooks/__tests__/use-deploy-signer.test.tsx
@@ -107,6 +107,21 @@ describe("useDeploySigner", () => {
     );
   });
 
+  it("hands back the SAME signer across re-renders while the session is unchanged", () => {
+    dynamic.account = { address: EMBEDDED_KEY.toBase58() };
+
+    const { result, rerender } = renderHook(() => useDeploySigner());
+    const first = result.current.signer;
+    rerender();
+    rerender();
+
+    // Referential stability is load-bearing: `WalletFundingCard` keys a
+    // `useCallback` on `signer.publicKey` and drives it from an effect, so a
+    // fresh object per render is an unbounded `getBalance` poll.
+    expect(result.current.signer).toBe(first);
+    expect(result.current.signer?.publicKey).toBe(first?.publicKey);
+  });
+
   it("reports `resolving` while the SDK is still initialising", () => {
     dynamic.status = "loading";
     const { result } = renderHook(() => useDeploySigner());

--- a/apps/web/src/hooks/__tests__/use-deploy-signer.test.tsx
+++ b/apps/web/src/hooks/__tests__/use-deploy-signer.test.tsx
@@ -1,0 +1,147 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { Keypair, Transaction } from "@solana/web3.js";
+import { useDeploySigner, EMBEDDED_BATCH_SIZE } from "../use-deploy-signer";
+
+const ADAPTER_KEY = Keypair.generate().publicKey;
+const EMBEDDED_KEY = Keypair.generate().publicKey;
+
+const wallet = vi.hoisted(() => ({
+  publicKey: null as unknown,
+  signTransaction: vi.fn(),
+  signAllTransactions: vi.fn(),
+}));
+
+const dynamic = vi.hoisted(() => ({
+  account: null as { address: string } | null,
+  status: "none" as "valid" | "expired" | "loading" | "none",
+  signWithDynamicWallet: vi.fn(),
+  signAllWithDynamicWallet: vi.fn(),
+  startDynamicSocialSignIn: vi.fn(),
+}));
+
+const dynamicEnabled = vi.hoisted(() => ({ value: true }));
+
+vi.mock("@solana/wallet-adapter-react", () => ({
+  useWallet: () => ({
+    publicKey: wallet.publicKey,
+    signTransaction: wallet.publicKey ? wallet.signTransaction : undefined,
+    signAllTransactions: wallet.publicKey
+      ? wallet.signAllTransactions
+      : undefined,
+  }),
+}));
+
+vi.mock("@/lib/dynamic/solana", () => ({
+  signWithDynamicWallet: dynamic.signWithDynamicWallet,
+  signAllWithDynamicWallet: dynamic.signAllWithDynamicWallet,
+}));
+
+vi.mock("@/lib/dynamic/social", () => ({
+  startDynamicSocialSignIn: dynamic.startDynamicSocialSignIn,
+}));
+
+vi.mock("@/lib/dynamic/config", () => ({
+  isDynamicEnabled: () => dynamicEnabled.value,
+}));
+
+vi.mock("@/hooks/use-dynamic-session-state", () => ({
+  useDynamicSessionState: () => ({
+    status: dynamic.account ? "valid" : dynamic.status,
+    account: dynamic.account,
+  }),
+}));
+
+beforeEach(() => {
+  wallet.publicKey = null;
+  wallet.signTransaction.mockReset();
+  wallet.signAllTransactions.mockReset();
+  dynamic.account = null;
+  dynamic.status = "none";
+  dynamic.signWithDynamicWallet.mockReset();
+  dynamic.signAllWithDynamicWallet.mockReset();
+  dynamicEnabled.value = true;
+});
+
+describe("useDeploySigner", () => {
+  it("prefers the wallet-adapter wallet and keeps the package's default batch size", () => {
+    wallet.publicKey = ADAPTER_KEY;
+    dynamic.account = { address: EMBEDDED_KEY.toBase58() };
+
+    const { result } = renderHook(() => useDeploySigner());
+
+    expect(result.current.status).toBe("ready");
+    expect(result.current.kind).toBe("adapter");
+    expect(result.current.signer?.publicKey).toBe(ADAPTER_KEY);
+    // undefined = deployProgram keeps BATCH_SIZE, i.e. today's behaviour.
+    expect(result.current.batchSize).toBeUndefined();
+  });
+
+  it("resolves the Dynamic embedded wallet when there is no adapter", async () => {
+    dynamic.account = { address: EMBEDDED_KEY.toBase58() };
+
+    const { result } = renderHook(() => useDeploySigner());
+
+    expect(result.current.status).toBe("ready");
+    expect(result.current.kind).toBe("embedded");
+    expect(result.current.signer?.publicKey?.toBase58()).toBe(
+      EMBEDDED_KEY.toBase58()
+    );
+    expect(result.current.batchSize).toBe(EMBEDDED_BATCH_SIZE);
+
+    // Both signing entry points route to the Dynamic helpers with the session's
+    // own account — never a caller-supplied one.
+    const tx = new Transaction();
+    dynamic.signWithDynamicWallet.mockResolvedValue(tx);
+    dynamic.signAllWithDynamicWallet.mockResolvedValue([tx]);
+    await result.current.signer!.signTransaction(tx);
+    await result.current.signer!.signAllTransactions([tx]);
+    expect(dynamic.signWithDynamicWallet).toHaveBeenCalledWith(
+      tx,
+      dynamic.account
+    );
+    expect(dynamic.signAllWithDynamicWallet).toHaveBeenCalledWith(
+      [tx],
+      dynamic.account
+    );
+  });
+
+  it("reports `resolving` while the SDK is still initialising", () => {
+    dynamic.status = "loading";
+    const { result } = renderHook(() => useDeploySigner());
+    expect(result.current.status).toBe("resolving");
+    expect(result.current.signer).toBeNull();
+  });
+
+  it("reports `expired` so callers offer re-auth, not the connect modal", () => {
+    dynamic.status = "expired";
+    const { result } = renderHook(() => useDeploySigner());
+    expect(result.current.status).toBe("expired");
+    expect(result.current.kind).toBeNull();
+  });
+
+  it("reports `none` when no wallet of either kind exists", () => {
+    const { result } = renderHook(() => useDeploySigner());
+    expect(result.current.status).toBe("none");
+    expect(result.current.signer).toBeNull();
+  });
+
+  it("kill switch off: a live Dynamic session is ignored entirely", () => {
+    dynamicEnabled.value = false;
+    dynamic.account = { address: EMBEDDED_KEY.toBase58() };
+
+    const { result } = renderHook(() => useDeploySigner());
+
+    expect(result.current.status).toBe("none");
+    expect(result.current.kind).toBeNull();
+    expect(result.current.signer).toBeNull();
+  });
+
+  it("an unparseable embedded address is no wallet, not a crash", () => {
+    dynamic.account = { address: "not-a-public-key" };
+    const { result } = renderHook(() => useDeploySigner());
+    expect(result.current.status).toBe("none");
+    expect(result.current.signer).toBeNull();
+  });
+});

--- a/apps/web/src/hooks/use-deploy-signer.ts
+++ b/apps/web/src/hooks/use-deploy-signer.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo } from "react";
+import { useMemo, useRef } from "react";
 import { useWallet } from "@solana/wallet-adapter-react";
 import type { WalletAdapter } from "@superteam-lms/deploy";
 import { parseWalletAddress } from "@/lib/solana/linked-wallet";
@@ -67,8 +67,17 @@ export function useDeploySigner(): DeploySignerState {
   const dynamicSession = useDynamicSessionState();
   const dynamicEnabled = isDynamicEnabled();
   const account = dynamicEnabled ? dynamicSession.account : null;
-  // Read before the memo so the adapter branch does not depend on it.
-  const embeddedKey = parseWalletAddress(account?.address ?? null);
+  // The session is identified by its ADDRESS, never by object identity:
+  // `parseWalletAddress` mints a new `PublicKey` per call and
+  // `getDynamicSolanaAccount` rebuilds its result per call, so keying the memo
+  // on either handed every caller a new `signer` — and a new
+  // `signer.publicKey` — on every render. `WalletFundingCard` turned that into
+  // an unbounded `getBalance` poll. The account stays live through a ref, so
+  // the sign closures always reach the current session object without
+  // destabilising the signer.
+  const embeddedAddress = account?.address ?? null;
+  const accountRef = useRef(account);
+  accountRef.current = account;
 
   return useMemo<DeploySignerState>(() => {
     const startReauth = (provider: DynamicSocialProvider) =>
@@ -93,7 +102,22 @@ export function useDeploySigner(): DeploySignerState {
 
     if (!dynamicEnabled) return { status: "none", ...idle };
 
-    if (account && embeddedKey) {
+    const embeddedKey = parseWalletAddress(embeddedAddress);
+    if (embeddedKey) {
+      // Reading the ref at call time, not at memo time, is what keeps the
+      // signer stable. It can only have gone null because the session died
+      // between this render and the signature, which is an expiry — raise it
+      // as one so callers offer re-auth instead of a raw failure.
+      const activeAccount = () => {
+        const current = accountRef.current;
+        if (!current) {
+          const expired = new Error("Dynamic session ended before signing");
+          expired.name = "UnauthorizedError";
+          throw expired;
+        }
+        return current;
+      };
+
       return {
         status: "ready",
         signer: {
@@ -102,9 +126,12 @@ export function useDeploySigner(): DeploySignerState {
           // given rather than rebuilding it, so these are safe to hand a
           // partially-signed tx (the buffer/program keypair's signature).
           signTransaction: async (tx) =>
-            (await signWithDynamicWallet(tx, account)) as typeof tx,
+            (await signWithDynamicWallet(tx, activeAccount())) as typeof tx,
           signAllTransactions: async (txs) =>
-            (await signAllWithDynamicWallet(txs, account)) as typeof txs,
+            (await signAllWithDynamicWallet(
+              txs,
+              activeAccount()
+            )) as typeof txs,
         },
         kind: "embedded",
         batchSize: EMBEDDED_BATCH_SIZE,
@@ -126,7 +153,6 @@ export function useDeploySigner(): DeploySignerState {
     signAllTransactions,
     dynamicEnabled,
     dynamicSession.status,
-    account,
-    embeddedKey,
+    embeddedAddress,
   ]);
 }

--- a/apps/web/src/hooks/use-deploy-signer.ts
+++ b/apps/web/src/hooks/use-deploy-signer.ts
@@ -1,0 +1,132 @@
+"use client";
+
+import { useMemo } from "react";
+import { useWallet } from "@solana/wallet-adapter-react";
+import type { WalletAdapter } from "@superteam-lms/deploy";
+import { parseWalletAddress } from "@/lib/solana/linked-wallet";
+import {
+  signAllWithDynamicWallet,
+  signWithDynamicWallet,
+} from "@/lib/dynamic/solana";
+import {
+  startDynamicSocialSignIn,
+  type DynamicSocialProvider,
+} from "@/lib/dynamic/social";
+import { isDynamicEnabled } from "@/lib/dynamic/config";
+import { useDynamicSessionState } from "@/hooks/use-dynamic-session-state";
+
+/**
+ * Write transactions signed per `signAllTransactions` call on the embedded
+ * wallet.
+ *
+ * PROVISIONAL — pending the owner's measurement against a real Dynamic session
+ * (spec C3). Every batch shares one blockhash fetched just before signing, and
+ * that blockhash lives ~60-90s on devnet, so the batch size is bounded by how
+ * long an MPC `signAllTransactions` call takes for N transactions. The
+ * wallet-adapter default is 50, where the cost is one popup and the learner's
+ * click; MPC signing instead scales with N over the network, and that latency
+ * is unmeasured. 15 is the conservative starting point: three times fewer
+ * signatures per call than the adapter path, still only ~8 batches for a
+ * 100 KB program. The deploy panel logs per-batch signing time in development
+ * so the number can be replaced with a measured one.
+ */
+export const EMBEDDED_BATCH_SIZE = 15;
+
+export type DeploySignerStatus = "resolving" | "none" | "expired" | "ready";
+
+export interface DeploySignerState {
+  status: DeploySignerStatus;
+  /** Non-null exactly when `status === "ready"`. */
+  signer: WalletAdapter | null;
+  kind: "adapter" | "embedded" | null;
+  /**
+   * Batch size to pass to `deployProgram` / `resumeDeployment`, or undefined to
+   * keep the package default (the adapter path, unchanged).
+   */
+  batchSize: number | undefined;
+  /** Starts the Dynamic social redirect — for the `expired` reauth card. */
+  startReauth: (provider: DynamicSocialProvider) => Promise<void>;
+}
+
+/**
+ * The wallet that will sign and pay for a program deploy — extension or
+ * embedded.
+ *
+ * `DeployPanel` and `WalletFundingCard` used to read `useWallet()` alone, so a
+ * learner who signed in with Google had no `publicKey` and Deploy stayed
+ * disabled forever — the same dead end enrol had before #1004, with the extra
+ * problem that an embedded wallet also starts at zero SOL. The resolution order
+ * mirrors `use-on-chain-enroll`: adapter first, then the Dynamic session, and
+ * the four states are the session's own so callers branch on one vocabulary.
+ *
+ * With `isDynamicEnabled()` false this degrades to exactly the adapter-only
+ * behaviour that shipped before — no Dynamic read, no reauth card.
+ */
+export function useDeploySigner(): DeploySignerState {
+  const { publicKey, signTransaction, signAllTransactions } = useWallet();
+  const dynamicSession = useDynamicSessionState();
+  const dynamicEnabled = isDynamicEnabled();
+  const account = dynamicEnabled ? dynamicSession.account : null;
+  // Read before the memo so the adapter branch does not depend on it.
+  const embeddedKey = parseWalletAddress(account?.address ?? null);
+
+  return useMemo<DeploySignerState>(() => {
+    const startReauth = (provider: DynamicSocialProvider) =>
+      startDynamicSocialSignIn(provider);
+
+    if (publicKey && signTransaction && signAllTransactions) {
+      return {
+        status: "ready",
+        signer: { publicKey, signTransaction, signAllTransactions },
+        kind: "adapter",
+        batchSize: undefined,
+        startReauth,
+      };
+    }
+
+    const idle = {
+      signer: null,
+      kind: null,
+      batchSize: undefined,
+      startReauth,
+    } as const;
+
+    if (!dynamicEnabled) return { status: "none", ...idle };
+
+    if (account && embeddedKey) {
+      return {
+        status: "ready",
+        signer: {
+          publicKey: embeddedKey,
+          // The MPC signer attaches its signature to the transaction it is
+          // given rather than rebuilding it, so these are safe to hand a
+          // partially-signed tx (the buffer/program keypair's signature).
+          signTransaction: async (tx) =>
+            (await signWithDynamicWallet(tx, account)) as typeof tx,
+          signAllTransactions: async (txs) =>
+            (await signAllWithDynamicWallet(txs, account)) as typeof txs,
+        },
+        kind: "embedded",
+        batchSize: EMBEDDED_BATCH_SIZE,
+        startReauth,
+      };
+    }
+
+    switch (dynamicSession.status) {
+      case "loading":
+        return { status: "resolving", ...idle };
+      case "expired":
+        return { status: "expired", ...idle };
+      default:
+        return { status: "none", ...idle };
+    }
+  }, [
+    publicKey,
+    signTransaction,
+    signAllTransactions,
+    dynamicEnabled,
+    dynamicSession.status,
+    account,
+    embeddedKey,
+  ]);
+}

--- a/apps/web/src/lib/dynamic/__tests__/sign-all.test.ts
+++ b/apps/web/src/lib/dynamic/__tests__/sign-all.test.ts
@@ -1,0 +1,81 @@
+/* eslint-disable import/order -- vi.mock calls must precede importing the module under test. */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Transaction } from "@solana/web3.js";
+
+/**
+ * The batch signing entry point, tested against the SDK boundary rather than a
+ * stub of this module — a deploy maps signature i back to chunk i, so order is
+ * load-bearing, and an expired session mid-batch must read as re-auth rather
+ * than as a failed deploy.
+ */
+const sdk = vi.hoisted(() => ({
+  signAllTransactions: vi.fn(),
+}));
+
+vi.mock("@/lib/dynamic/config", () => ({
+  isDynamicEnabled: () => true,
+  getDynamicEnvironmentId: () => "env-id",
+}));
+
+vi.mock("@/lib/dynamic/client", () => ({ getDynamicClient: () => null }));
+
+vi.mock("@dynamic-labs-sdk/client", () => ({
+  getWalletAccounts: () => [],
+}));
+
+vi.mock("@dynamic-labs-sdk/solana", () => ({
+  isSolanaWalletAccount: () => true,
+  signTransaction: vi.fn(),
+  signAllTransactions: sdk.signAllTransactions,
+}));
+
+import {
+  isDynamicSessionExpiredError,
+  signAllWithDynamicWallet,
+  type SolanaWalletAccount,
+} from "../solana";
+
+const ACCOUNT = { address: "acct" } as unknown as SolanaWalletAccount;
+
+beforeEach(() => {
+  sdk.signAllTransactions.mockReset();
+});
+
+describe("signAllWithDynamicWallet", () => {
+  it("passes the transactions through to the SDK with the session's account", async () => {
+    const txs = [new Transaction(), new Transaction()];
+    sdk.signAllTransactions.mockResolvedValue({ signedTransactions: txs });
+
+    await signAllWithDynamicWallet(txs, ACCOUNT);
+
+    expect(sdk.signAllTransactions).toHaveBeenCalledWith({
+      transactions: txs,
+      walletAccount: ACCOUNT,
+    });
+  });
+
+  it("returns the signed transactions in the order the SDK gave them", async () => {
+    const a = new Transaction();
+    const b = new Transaction();
+    const c = new Transaction();
+    sdk.signAllTransactions.mockResolvedValue({
+      signedTransactions: [a, b, c],
+    });
+
+    const signed = await signAllWithDynamicWallet([a, b, c], ACCOUNT);
+
+    expect(signed).toEqual([a, b, c]);
+  });
+
+  it("an expired session mid-batch reads as expiry, not as a program error", async () => {
+    const unauthorized = new Error("session gone");
+    unauthorized.name = "UnauthorizedError";
+    sdk.signAllTransactions.mockRejectedValue(unauthorized);
+
+    const err = await signAllWithDynamicWallet([new Transaction()], ACCOUNT)
+      .then(() => null)
+      .catch((e: unknown) => e);
+
+    expect(isDynamicSessionExpiredError(err)).toBe(true);
+  });
+});

--- a/apps/web/src/lib/dynamic/solana.ts
+++ b/apps/web/src/lib/dynamic/solana.ts
@@ -2,6 +2,7 @@ import { Transaction } from "@solana/web3.js";
 import { getWalletAccounts } from "@dynamic-labs-sdk/client";
 import {
   isSolanaWalletAccount,
+  signAllTransactions,
   signTransaction,
 } from "@dynamic-labs-sdk/solana";
 import type { SolanaWalletAccount } from "@dynamic-labs-sdk/solana";
@@ -149,6 +150,35 @@ export async function signWithDynamicWallet(
     walletAccount,
   });
   return signedTransaction as unknown as Transaction;
+}
+
+/**
+ * Sign every transaction in `transactions` with the embedded wallet, in order.
+ *
+ * A program deploy signs one transaction per ~900-byte chunk, batched so the
+ * whole batch shares a single blockhash. Signing them one MPC round trip at a
+ * time would spend that window on latency alone, which is why the batch entry
+ * point exists.
+ *
+ * The SDK returns the signed transactions positionally, and the caller relies on
+ * that: `packages/deploy` maps signature i back to chunk i. The array is
+ * returned as-is, never re-ordered.
+ */
+export async function signAllWithDynamicWallet(
+  transactions: Transaction[],
+  walletAccount: SolanaWalletAccount
+): Promise<Transaction[]> {
+  // Same version-boundary cast as signWithDynamicWallet: the SDK pins
+  // @solana/web3.js 1.98.1 while the app tracks ^1.98.4, so `Transaction` is
+  // nominally two types with identical shapes.
+  type SdkTransactions = Parameters<
+    typeof signAllTransactions
+  >[0]["transactions"];
+  const { signedTransactions } = await signAllTransactions({
+    transactions: transactions as unknown as SdkTransactions,
+    walletAccount,
+  });
+  return signedTransactions as unknown as Transaction[];
 }
 
 /**

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -824,7 +824,9 @@
       "readyForDeploy": "Ready for deployment!",
       "needMoreSol": "Need ~{amount} more SOL",
       "refreshBalance": "Refresh",
-      "connectWallet": "Connect your wallet to continue"
+      "connectWallet": "Connect your wallet to continue",
+      "copyAddress": "Copy address",
+      "addressCopied": "Copied!"
     },
     "deployment": {
       "deployToDevnet": "Deploy to Devnet",
@@ -849,7 +851,8 @@
       "startOver": "Start Over",
       "insufficientSol": "Not enough SOL. Need ~{amount} more.",
       "buildExpired": "Build expired",
-      "rebuildHint": "Click \"Run\" in the editor to rebuild, then deploy again."
+      "rebuildHint": "Click \"Run\" in the editor to rebuild, then deploy again.",
+      "resolvingWallet": "Checking your wallet…"
     },
     "save": {
       "recording": "Recording your deployment…",

--- a/apps/web/src/messages/es.json
+++ b/apps/web/src/messages/es.json
@@ -824,7 +824,9 @@
       "readyForDeploy": "Listo para el despliegue!",
       "needMoreSol": "Necesita ~{amount} SOL más",
       "refreshBalance": "Actualizar",
-      "connectWallet": "Conecta tu billetera para continuar"
+      "connectWallet": "Conecta tu billetera para continuar",
+      "copyAddress": "Copiar dirección",
+      "addressCopied": "¡Copiado!"
     },
     "deployment": {
       "deployToDevnet": "Desplegar en Devnet",
@@ -849,7 +851,8 @@
       "startOver": "Empezar de Nuevo",
       "insufficientSol": "SOL insuficiente. Necesita ~{amount} más.",
       "buildExpired": "Build expirado",
-      "rebuildHint": "Haz clic en \"Run\" en el editor para recompilar y despliega de nuevo."
+      "rebuildHint": "Haz clic en \"Run\" en el editor para recompilar y despliega de nuevo.",
+      "resolvingWallet": "Comprobando tu billetera…"
     },
     "save": {
       "recording": "Registrando tu despliegue…",

--- a/apps/web/src/messages/pt-BR.json
+++ b/apps/web/src/messages/pt-BR.json
@@ -824,7 +824,9 @@
       "readyForDeploy": "Pronto para o deploy!",
       "needMoreSol": "Precisa de ~{amount} SOL a mais",
       "refreshBalance": "Atualizar",
-      "connectWallet": "Conecte sua carteira para continuar"
+      "connectWallet": "Conecte sua carteira para continuar",
+      "copyAddress": "Copiar endereço",
+      "addressCopied": "Copiado!"
     },
     "deployment": {
       "deployToDevnet": "Deploy na Devnet",
@@ -849,7 +851,8 @@
       "startOver": "Recomeçar",
       "insufficientSol": "SOL insuficiente. Precisa de ~{amount} a mais.",
       "buildExpired": "Build expirado",
-      "rebuildHint": "Clique em \"Run\" no editor para recompilar e faça o deploy novamente."
+      "rebuildHint": "Clique em \"Run\" no editor para recompilar e faça o deploy novamente.",
+      "resolvingWallet": "Verificando sua carteira…"
     },
     "save": {
       "recording": "Registrando seu deploy…",

--- a/packages/deploy/src/__tests__/cost.test.ts
+++ b/packages/deploy/src/__tests__/cost.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi } from "vitest";
+import type { Connection } from "@solana/web3.js";
+import { estimateDeployCost } from "../cost";
+import {
+  BUFFER_HEADER_SIZE,
+  CHUNK_SIZE,
+  PROGRAM_ACCOUNT_SIZE,
+  PROGRAM_DATA_HEADER_SIZE,
+} from "../constants";
+
+/** Rent priced like the real cluster: a per-byte rate over the account size. */
+const LAMPORTS_PER_BYTE = 7;
+
+function connectionWithRent() {
+  const getMinimumBalanceForRentExemption = vi.fn(
+    async (space: number) => space * LAMPORTS_PER_BYTE
+  );
+  return {
+    connection: {
+      getMinimumBalanceForRentExemption,
+    } as unknown as Connection,
+    getMinimumBalanceForRentExemption,
+  };
+}
+
+describe("estimateDeployCost", () => {
+  it("prices the three accounts the deploy creates plus every transaction fee", async () => {
+    const programLen = 4_500; // 5 chunks at CHUNK_SIZE=900
+    const { connection, getMinimumBalanceForRentExemption } =
+      connectionWithRent();
+
+    const estimate = await estimateDeployCost(connection, programLen);
+
+    const bufferRent = (BUFFER_HEADER_SIZE + programLen) * LAMPORTS_PER_BYTE;
+    const programRent = PROGRAM_ACCOUNT_SIZE * LAMPORTS_PER_BYTE;
+    const programDataRent =
+      (PROGRAM_DATA_HEADER_SIZE + programLen * 2) * LAMPORTS_PER_BYTE;
+    // 5 write txs + buffer create + deploy, at 5_000 base + 1_000 priority.
+    const feeLamports = (programLen / CHUNK_SIZE + 2) * 6_000;
+
+    expect(estimate.bufferRent).toBe(bufferRent);
+    expect(estimate.programRent).toBe(programRent);
+    expect(estimate.programDataRent).toBe(programDataRent);
+    expect(estimate.feeLamports).toBe(feeLamports);
+    expect(estimate.totalLamports).toBe(
+      Math.ceil(
+        (bufferRent + programRent + programDataRent + feeLamports) * 1.2
+      )
+    );
+
+    // The three account sizes are the ones deployProgram actually allocates.
+    expect(
+      getMinimumBalanceForRentExemption.mock.calls.map((c) => c[0])
+    ).toEqual([
+      BUFFER_HEADER_SIZE + programLen,
+      PROGRAM_ACCOUNT_SIZE,
+      PROGRAM_DATA_HEADER_SIZE + programLen * 2,
+    ]);
+  });
+
+  it("rounds a partial final chunk up when counting fees", async () => {
+    const { connection } = connectionWithRent();
+    // 901 bytes = 2 chunks, so 4 txs in total.
+    const estimate = await estimateDeployCost(connection, 901);
+    expect(estimate.feeLamports).toBe(4 * 6_000);
+  });
+});

--- a/packages/deploy/src/__tests__/deploy.test.ts
+++ b/packages/deploy/src/__tests__/deploy.test.ts
@@ -378,3 +378,128 @@ describe("deployProgram + resumeDeployment both use the pool + CU limit (#776)",
     expect(h.writeTxs.every(hasCuLimit)).toBe(true);
   });
 });
+
+// ---------------------------------------------------------------------------
+// batchSize — an embedded (MPC) signer signs fewer txs per call than a wallet
+// popup can, and both entry points have to honour the same number.
+// ---------------------------------------------------------------------------
+describe("batchSize honoured by both entry points, default unchanged", () => {
+  const ZERO_HASH = "11111111111111111111111111111111";
+
+  function harness(bufferKp: Keypair) {
+    const batchSizes: number[] = [];
+    let sigN = 0;
+
+    const connection = {
+      getLatestBlockhash: vi.fn(async () => ({
+        blockhash: ZERO_HASH,
+        lastValidBlockHeight: 1000,
+      })),
+      getMinimumBalanceForRentExemption: vi.fn(async () => 1_000_000),
+      sendRawTransaction: vi.fn(async () => `sig-${sigN++}`),
+      confirmTransaction: vi.fn(async () => ({ value: { err: null } })),
+      getSignatureStatuses: vi.fn(async (pending: string[]) => ({
+        value: pending.map(() => ({
+          err: null,
+          confirmationStatus: "confirmed" as const,
+        })),
+      })),
+      getAccountInfo: vi.fn(async (pk: PublicKey) =>
+        pk.equals(bufferKp.publicKey) ? { data: Buffer.alloc(0) } : null
+      ),
+    } as unknown as Connection;
+
+    const kp = Keypair.generate();
+    const wallet: WalletAdapter = {
+      publicKey: kp.publicKey,
+      signTransaction: async (tx) => {
+        tx.partialSign(kp);
+        return tx;
+      },
+      signAllTransactions: async (txs) => {
+        batchSizes.push(txs.length);
+        for (const tx of txs) tx.partialSign(kp);
+        return txs;
+      },
+    };
+
+    const callbacks: DeploymentCallbacks = {
+      onStepChange: vi.fn(),
+      onChunkProgress: vi.fn(),
+      onTransactionConfirmed: vi.fn(),
+      onError: vi.fn(),
+      onStateUpdate: vi.fn(),
+      onBatchStart: vi.fn(),
+    };
+
+    return { connection, wallet, callbacks, batchSizes };
+  }
+
+  // 12 chunks at CHUNK_SIZE=900.
+  const BINARY = new Uint8Array(900 * 12).fill(7);
+
+  function resumeState(bufferKp: Keypair, uuid: string): DeploymentState {
+    return {
+      buildUuid: uuid,
+      bufferKeypairSecret: Array.from(bufferKp.secretKey),
+      programKeypairSecret: Array.from(Keypair.generate().secretKey),
+      lastUploadedChunk: -1,
+      totalChunks: 12,
+      phase: "uploading",
+    };
+  }
+
+  it("deployProgram splits the upload into batches of the requested size", async () => {
+    const bufferKp = Keypair.generate();
+    const h = harness(bufferKp);
+    setCachedBinary("uuid-batch-5", BINARY);
+
+    await deployProgram({
+      connection: h.connection,
+      wallet: h.wallet,
+      buildServerUrl: "unused",
+      buildUuid: "uuid-batch-5",
+      callbacks: h.callbacks,
+      batchSize: 5,
+    });
+
+    expect(h.batchSizes).toEqual([5, 5, 2]);
+    expect(h.callbacks.onBatchStart).toHaveBeenCalledWith({
+      batchNumber: 3,
+      totalBatches: 3,
+    });
+  });
+
+  it("resumeDeployment uses the same size", async () => {
+    const bufferKp = Keypair.generate();
+    const h = harness(bufferKp);
+    setCachedBinary("uuid-batch-resume", BINARY);
+
+    await resumeDeployment({
+      connection: h.connection,
+      wallet: h.wallet,
+      buildServerUrl: "unused",
+      state: resumeState(bufferKp, "uuid-batch-resume"),
+      callbacks: h.callbacks,
+      batchSize: 5,
+    });
+
+    expect(h.batchSizes).toEqual([5, 5, 2]);
+  });
+
+  it("omitting it keeps the 50-tx default — one batch for this binary", async () => {
+    const bufferKp = Keypair.generate();
+    const h = harness(bufferKp);
+    setCachedBinary("uuid-batch-default", BINARY);
+
+    await deployProgram({
+      connection: h.connection,
+      wallet: h.wallet,
+      buildServerUrl: "unused",
+      buildUuid: "uuid-batch-default",
+      callbacks: h.callbacks,
+    });
+
+    expect(h.batchSizes).toEqual([12]);
+  });
+});

--- a/packages/deploy/src/cost.ts
+++ b/packages/deploy/src/cost.ts
@@ -1,0 +1,76 @@
+import type { Connection } from "@solana/web3.js";
+import {
+  BUFFER_HEADER_SIZE,
+  CHUNK_SIZE,
+  PROGRAM_ACCOUNT_SIZE,
+  PROGRAM_DATA_HEADER_SIZE,
+} from "./constants";
+
+/** Lamports per signature — the fixed Solana base fee. */
+const BASE_FEE_LAMPORTS = 5_000;
+
+/**
+ * Priority fee a single deploy tx pays, in lamports.
+ *
+ * `deploy.ts` prices compute units at 100_000 µlamports and caps a write tx at
+ * 10_000 CU, so a write costs 100_000 × 10_000 / 1e6 = 1_000 lamports. The two
+ * one-off txs (buffer create, deploy) request the default budget and cost more,
+ * which the 20% margin below absorbs.
+ */
+const PRIORITY_FEE_LAMPORTS = 1_000;
+
+/** Margin over the computed total, for blockhash retries and resends. */
+const SAFETY_MULTIPLIER = 1.2;
+
+export interface DeployCostEstimate {
+  /** Rent for the upload buffer, reclaimable only by closing it. */
+  bufferRent: number;
+  /** Rent for the 36-byte program account. */
+  programRent: number;
+  /** Rent for the ProgramData account the loader creates (2x the binary). */
+  programDataRent: number;
+  /** Base + priority fees across every transaction the deploy sends. */
+  feeLamports: number;
+  /** What the payer needs on hand, margin included. */
+  totalLamports: number;
+}
+
+/**
+ * What a Loader-v3 deploy of `programLen` bytes will cost the payer.
+ *
+ * A learner on an embedded wallet starts at zero SOL, so "Deploy" has to be
+ * gated on a number rather than on a hopeful 2 SOL airdrop. The sizes mirror
+ * exactly what `deployProgram` creates: a buffer of `header + len`, a 36-byte
+ * program account, and the ProgramData account the loader allocates at
+ * `len * 2` (the same doubling `createDeployInstruction` is handed) plus its
+ * header.
+ */
+export async function estimateDeployCost(
+  connection: Connection,
+  programLen: number
+): Promise<DeployCostEstimate> {
+  const [bufferRent, programRent, programDataRent] = await Promise.all([
+    connection.getMinimumBalanceForRentExemption(
+      BUFFER_HEADER_SIZE + programLen
+    ),
+    connection.getMinimumBalanceForRentExemption(PROGRAM_ACCOUNT_SIZE),
+    connection.getMinimumBalanceForRentExemption(
+      PROGRAM_DATA_HEADER_SIZE + programLen * 2
+    ),
+  ]);
+
+  const chunks = Math.ceil(programLen / CHUNK_SIZE);
+  const feeLamports =
+    (chunks + 2) * (BASE_FEE_LAMPORTS + PRIORITY_FEE_LAMPORTS);
+
+  return {
+    bufferRent,
+    programRent,
+    programDataRent,
+    feeLamports,
+    totalLamports: Math.ceil(
+      (bufferRent + programRent + programDataRent + feeLamports) *
+        SAFETY_MULTIPLIER
+    ),
+  };
+}

--- a/packages/deploy/src/deploy.ts
+++ b/packages/deploy/src/deploy.ts
@@ -45,6 +45,17 @@ export function setCachedBinary(uuid: string, data: Uint8Array): void {
 }
 
 /**
+ * Byte length of the cached binary, or null when nothing is cached for `uuid`.
+ *
+ * The funding gate has to know what a deploy will cost BEFORE starting one, and
+ * that cost is driven by the binary's length. A miss means the build is gone
+ * from this session, which callers already treat as "rebuild".
+ */
+export function getCachedBinaryLength(uuid: string): number | null {
+  return getGlobalCache().get(uuid)?.length ?? null;
+}
+
+/**
  * Retrieve the compiled .so binary cached client-side after build.
  *
  * The build server returns the binary INLINE (binaryB64), which is stored in the
@@ -416,10 +427,19 @@ export async function deployProgram(params: {
   callbacks: DeploymentCallbacks;
   /** Pre-generated program keypair (from build-time declare_id injection). */
   programKeypairSecret?: number[];
+  /**
+   * Write txs signed per `signAllTransactions` call. Defaults to BATCH_SIZE,
+   * which is tuned for a wallet-adapter popup — one prompt, then the learner's
+   * click. A signer whose per-call latency scales with the batch (Dynamic's MPC
+   * service) passes a smaller one so each batch still lands inside the single
+   * blockhash the batch shares.
+   */
+  batchSize?: number;
 }): Promise<DeployResult> {
   // `buildServerUrl` is accepted for API compatibility but no longer used: the
   // binary is read from the client-side cache, not fetched over HTTP.
   const { connection, wallet, buildUuid, callbacks } = params;
+  const batchSize = params.batchSize ?? BATCH_SIZE;
   const startTime = Date.now();
 
   if (!wallet.publicKey) throw new Error("Wallet not connected");
@@ -487,8 +507,8 @@ export async function deployProgram(params: {
   callbacks.onStepChange("upload");
   state.phase = "uploading";
 
-  for (let batchStart = 0; batchStart < totalChunks; batchStart += BATCH_SIZE) {
-    const batchEnd = Math.min(batchStart + BATCH_SIZE, totalChunks);
+  for (let batchStart = 0; batchStart < totalChunks; batchStart += batchSize) {
+    const batchEnd = Math.min(batchStart + batchSize, totalChunks);
     const batchTxs: Transaction[] = [];
 
     // Get fresh blockhash for each batch (prevents expiry)
@@ -510,8 +530,8 @@ export async function deployProgram(params: {
     // Let the UI know which batch (of how many) is about to prompt the
     // wallet, before the popup actually appears.
     callbacks.onBatchStart({
-      batchNumber: Math.floor(batchStart / BATCH_SIZE) + 1,
-      totalBatches: Math.ceil(totalChunks / BATCH_SIZE),
+      batchNumber: Math.floor(batchStart / batchSize) + 1,
+      totalBatches: Math.ceil(totalChunks / batchSize),
     });
 
     // Batch sign (1 wallet popup per batch)
@@ -615,9 +635,12 @@ export async function resumeDeployment(params: {
   buildServerUrl: string;
   state: DeploymentState;
   callbacks: DeploymentCallbacks;
+  /** See `deployProgram`. Resume signs with the same signer, so same size. */
+  batchSize?: number;
 }): Promise<DeployResult> {
   // `buildServerUrl` accepted for API compatibility but unused (see deployProgram).
   const { connection, wallet, state, callbacks } = params;
+  const batchSize = params.batchSize ?? BATCH_SIZE;
   const startTime = Date.now();
 
   if (!wallet.publicKey) throw new Error("Wallet not connected");
@@ -651,9 +674,9 @@ export async function resumeDeployment(params: {
     for (
       let batchStart = startChunk;
       batchStart < totalChunks;
-      batchStart += BATCH_SIZE
+      batchStart += batchSize
     ) {
-      const batchEnd = Math.min(batchStart + BATCH_SIZE, totalChunks);
+      const batchEnd = Math.min(batchStart + batchSize, totalChunks);
       const batchTxs: Transaction[] = [];
 
       const { blockhash } = await connection.getLatestBlockhash("confirmed");
@@ -674,8 +697,8 @@ export async function resumeDeployment(params: {
       // Let the UI know which batch (of how many) is about to prompt the
       // wallet, before the popup actually appears.
       callbacks.onBatchStart({
-        batchNumber: Math.floor(batchStart / BATCH_SIZE) + 1,
-        totalBatches: Math.ceil(totalChunks / BATCH_SIZE),
+        batchNumber: Math.floor(batchStart / batchSize) + 1,
+        totalBatches: Math.ceil(totalChunks / batchSize),
       });
 
       const signedBatch = await wallet.signAllTransactions(batchTxs);

--- a/packages/deploy/src/index.ts
+++ b/packages/deploy/src/index.ts
@@ -3,7 +3,9 @@ export {
   resumeDeployment,
   closeBuffer,
   setCachedBinary,
+  getCachedBinaryLength,
 } from "./deploy";
+export { estimateDeployCost, type DeployCostEstimate } from "./cost";
 export { createAirdropRequest, type AirdropResult } from "./airdrop";
 export { CHUNK_SIZE, BPF_LOADER_UPGRADEABLE_ID } from "./constants";
 export type {


### PR DESCRIPTION
`DeployPanel` and `WalletFundingCard` took their signer from `useWallet()` alone, so a learner who signed in with Google had no key, Deploy stayed disabled forever, and the funding card had no address to show — the same dead end enrol had before #1004, with the extra problem that an embedded wallet starts at zero SOL. A new `useDeploySigner()` resolves adapter-first then the Dynamic session (four states, `isDynamicEnabled()` kill switch), `signAllWithDynamicWallet` batches MPC signing, and the panel gates Deploy on a real cost estimate (`estimateDeployCost`) with the funding card inline when the balance is short. An expired session — before or mid-deploy — gets the reauth card, not a generic error; uploaded chunks survive via the existing resume path.

Measurement pending: the embedded batch size is `EMBEDDED_BATCH_SIZE = 15`, provisional. MPC `signAllTransactions` latency for N transactions cannot be measured without a real Dynamic session, so the panel logs per-batch signing time via `console.debug` outside production for the owner to measure and replace the number. The adapter path keeps `BATCH_SIZE = 50` unchanged.

Spec PR: #1213 (sections C1–C7). Content (PR A) and lint (PR B) are separate; do not merge this ahead of the lock bump order in the spec's rollout.

Verified: `packages/deploy` 23/23 green, `pnpm --filter web exec tsc --noEmit` clean, `pnpm --filter web lint` clean (warnings only, matching the existing files), and the new suites for the hook, `signAllWithDynamicWallet`, `estimateDeployCost`, `batchSize`, the panel's embedded/resolving/expired/funding paths and the funding card all pass. The existing `deploy-panel.test.tsx` still passes (its `@superteam-lms/deploy` mock gained the new exports). Two failures in the full web run — `reminder-consent-execution` and one `open-ended-block` timeout — reproduce on stock main and are unrelated.

Sensitive lane: wallet signing and on-chain spend, so this wants the independent adversarial gate plus the browser probe on a fresh embedded account before merge.