### PR TITLE
fix(i18n): externalize the challenge and deploy panel strings

### DIFF
--- a/apps/web/src/components/deploy/deploy-panel.tsx
+++ b/apps/web/src/components/deploy/deploy-panel.tsx
@@ -599,7 +599,7 @@ export function DeployPanel({
                 {result.programId}
               </span>
               <span className="shrink-0 text-xs text-muted-foreground group-hover:text-foreground">
-                {copied ? "Copied!" : ""}
+                {copied ? t("copied") : ""}
               </span>
               {/* Copy icon */}
               <svg

--- a/apps/web/src/components/deploy/generic-program-explorer.tsx
+++ b/apps/web/src/components/deploy/generic-program-explorer.tsx
@@ -417,7 +417,7 @@ export function GenericProgramExplorer({
             }[];
           }
         ).instructions.find((ix) => ix.name === ixName);
-        if (!ixDef) throw new Error(`Unknown instruction: ${ixName}`);
+        if (!ixDef) throw new Error(t("unknownInstruction", { name: ixName }));
 
         // Build args object
         const args: Record<string, unknown> = {};
@@ -485,9 +485,7 @@ export function GenericProgramExplorer({
             const unresolved = r.unresolved;
             // Must have manual entry
             if (!manual[accName]) {
-              throw new Error(
-                `Account "${accName}" is not resolved. Please provide a public key.`
-              );
+              throw new Error(t("accountNotResolved", { name: accName }));
             }
             keys.push({
               pubkey: new PublicKey(manual[accName]),
@@ -851,7 +849,7 @@ export function GenericProgramExplorer({
                                 }}
                                 placeholder={
                                   rawType === "publicKey"
-                                    ? "Base58 address..."
+                                    ? t("base58AddressPlaceholder")
                                     : isBigNumType(rawType)
                                       ? "0 (string-backed BN)"
                                       : rawType
@@ -880,7 +878,7 @@ export function GenericProgramExplorer({
                                   }));
                                 }}
                               >
-                                My wallet
+                                {t("myWallet")}
                               </Button>
                             )}
                           </div>
@@ -929,7 +927,7 @@ export function GenericProgramExplorer({
                                   },
                                 }));
                               }}
-                              placeholder="PublicKey..."
+                              placeholder={t("publicKeyPlaceholder")}
                               className="w-full rounded border border-orange-500/30 bg-background px-1 py-0.5 font-mono text-[10px] sm:w-32"
                             />
                           </div>
@@ -947,7 +945,9 @@ export function GenericProgramExplorer({
                   >
                     {isExecuting
                       ? t("executing") + "..."
-                      : `Execute ${formatInstructionName(ix.name)}`}
+                      : t("executeInstruction", {
+                          name: formatInstructionName(ix.name),
+                        })}
                   </Button>
                 </div>
               )}

--- a/apps/web/src/components/editor/challenge-runner.tsx
+++ b/apps/web/src/components/editor/challenge-runner.tsx
@@ -18,6 +18,10 @@ import type {
   TestResult,
 } from "./types";
 
+/** The `lesson`-namespace translator, threaded into module-level orchestrators
+ * that run outside the component (so they can't call `useTranslations` themselves). */
+type Translator = ReturnType<typeof useTranslations>;
+
 // ---------------------------------------------------------------------------
 // Web Worker sandbox — all user code executes in a separate thread with no
 // DOM access.  The worker can be terminated to kill infinite loops.
@@ -194,6 +198,7 @@ const EXEC_TIMEOUT_MS = 5_000;
  * The worker is terminated on timeout OR after the result arrives.
  */
 function runInWorker(
+  t: Translator,
   wrappedCode: string,
   timeoutMs: number = EXEC_TIMEOUT_MS
 ): Promise<{ result?: unknown; output: string; error?: string }> {
@@ -202,11 +207,7 @@ function runInWorker(
 
     const timer = setTimeout(() => {
       worker.terminate();
-      reject(
-        new Error(
-          `Execution timed out after ${timeoutMs / 1000}s — check for infinite loops`
-        )
-      );
+      reject(new Error(t("executionTimeout", { seconds: timeoutMs / 1000 })));
     }, timeoutMs);
 
     worker.onmessage = (e: MessageEvent) => {
@@ -230,10 +231,10 @@ function runInWorker(
 // The result is plain JS that gets sent to the worker.
 // ---------------------------------------------------------------------------
 
-function transformImports(code: string): string {
+function transformImports(t: Translator, code: string): string {
   // F-46: Block dynamic import() syntax to prevent module loading bypass
   if (/import\s*\(/.test(code)) {
-    throw new Error("Dynamic import() is not allowed in challenges");
+    throw new Error(t("dynamicImportBlocked"));
   }
 
   let transformed = code;
@@ -279,7 +280,7 @@ function transformImports(code: string): string {
     transformed = result.code;
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
-    throw new Error(`Syntax error: ${message}`);
+    throw new Error(t("syntaxError", { message }));
   }
 
   return transformed;
@@ -463,13 +464,14 @@ function isTypeShape(expected: string): Record<string, string> | null {
 // ---------------------------------------------------------------------------
 
 async function captureConsoleOutput(
+  t: Translator,
   code: string,
   firstTest?: TestCase
 ): Promise<{
   output: string;
   error?: string;
 }> {
-  const transformed = transformImports(code);
+  const transformed = transformImports(t, code);
   const fnName = detectFunctionName(transformed);
 
   try {
@@ -489,7 +491,7 @@ if (__res__ !== undefined) console.log(typeof __res__ === "object" ? JSON.string
 ${argSetup}
 const __res__ = await ${fnName}(${callArgs});
 if (__res__ !== undefined) {
-  console.log("Return value:");
+  console.log(${JSON.stringify(t("returnValueLabel"))});
   console.log(typeof __res__ === "object" ? JSON.stringify(__res__, null, 2) : __res__);
 }`;
     }
@@ -503,7 +505,7 @@ if (__res__ !== undefined) {
       })();
     `;
 
-    const { output, error } = await runInWorker(wrappedCode);
+    const { output, error } = await runInWorker(t, wrappedCode);
     return { output, error };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
@@ -512,10 +514,11 @@ if (__res__ !== undefined) {
 }
 
 async function runTestCase(
+  t: Translator,
   code: string,
   testCase: TestCase
 ): Promise<TestResult> {
-  const transformed = transformImports(code);
+  const transformed = transformImports(t, code);
   const fnName = detectFunctionName(transformed);
 
   if (!fnName) {
@@ -523,7 +526,7 @@ async function runTestCase(
       testCase,
       passed: false,
       actualOutput: "",
-      error: "No function found in your code",
+      error: t("noFunctionFound"),
     };
   }
 
@@ -579,7 +582,7 @@ async function runTestCase(
       })();
     `;
 
-    const { result, error } = await runInWorker(wrappedCode);
+    const { result, error } = await runInWorker(t, wrappedCode);
 
     if (error) {
       return { testCase, passed: false, actualOutput: "", error };
@@ -663,6 +666,7 @@ ${testCalls.join("\n")}
 }
 
 function parseRustTestResults(
+  t: Translator,
   stdout: string,
   stderr: string,
   tests: TestCase[],
@@ -684,7 +688,7 @@ function parseRustTestResults(
       return {
         testCase: tc,
         passed: false,
-        actualOutput: failMatch[1]?.trim() ?? "assertion failed",
+        actualOutput: failMatch[1]?.trim() ?? t("rustAssertionFailed"),
       };
     }
 
@@ -692,7 +696,7 @@ function parseRustTestResults(
       testCase: tc,
       passed: false,
       actualOutput: "",
-      error: success ? "Test did not produce output" : "Compilation failed",
+      error: success ? t("rustNoOutput") : t("rustCompilationFailed"),
     };
   });
 
@@ -705,11 +709,12 @@ function parseRustTestResults(
   return {
     testResults,
     output: cleanOutput,
-    error: !success ? cleanStderr || "Compilation failed" : undefined,
+    error: !success ? cleanStderr || t("rustCompilationFailed") : undefined,
   };
 }
 
 async function runRustChallenge(
+  t: Translator,
   code: string,
   tests: TestCase[]
 ): Promise<ExecutionResult> {
@@ -717,6 +722,7 @@ async function runRustChallenge(
   const result = await executeRustCode(harnessCode);
 
   const { testResults, output, error } = parseRustTestResults(
+    t,
     result.stdout,
     result.stderr,
     tests,
@@ -892,14 +898,18 @@ export function ChallengeRunner({
           }
         } else if (language === "rust") {
           // Rust path: remote execution via proxy API
-          const result = await runRustChallenge(code, tests);
+          const result = await runRustChallenge(t, code, tests);
           setAllPassed(result.success);
           onResult(result);
         } else {
           // JS/TS path: Web Worker sandbox (unchanged)
-          const { output, error } = await captureConsoleOutput(code, tests[0]);
+          const { output, error } = await captureConsoleOutput(
+            t,
+            code,
+            tests[0]
+          );
           const testResults: TestResult[] = await Promise.all(
-            tests.map((tc) => runTestCase(code, tc))
+            tests.map((tc) => runTestCase(t, code, tc))
           );
           const success = testResults.every((r) => r.passed);
 
@@ -923,7 +933,7 @@ export function ChallengeRunner({
         setIsRunning(false);
       }
     }, 50);
-  }, [code, tests, language, buildType, onResult]);
+  }, [code, tests, language, buildType, onResult, t]);
 
   const showSubmit =
     allPassed && !isComplete && !isJudging && (!isDeployable || deployComplete);

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -393,7 +393,15 @@
     "formatUnchanged": "Already formatted.",
     "formatUnsupported": "Formatting isn't available for this language.",
     "finishCourse": "Finish course",
-    "completeGateHint": "Finish the quiz and reflection above to enable"
+    "completeGateHint": "Finish the quiz and reflection above to enable",
+    "executionTimeout": "Execution timed out after {seconds}s — check for infinite loops",
+    "dynamicImportBlocked": "Dynamic import() is not allowed in challenges",
+    "syntaxError": "Syntax error: {message}",
+    "returnValueLabel": "Return value:",
+    "noFunctionFound": "No function found in your code",
+    "rustAssertionFailed": "assertion failed",
+    "rustNoOutput": "Test did not produce output",
+    "rustCompilationFailed": "Compilation failed"
   },
   "dashboard": {
     "allCaughtUp": "All caught up!",
@@ -849,7 +857,8 @@
       "startOver": "Start Over",
       "insufficientSol": "Not enough SOL. Need ~{amount} more.",
       "buildExpired": "Build expired",
-      "rebuildHint": "Click \"Run\" in the editor to rebuild, then deploy again."
+      "rebuildHint": "Click \"Run\" in the editor to rebuild, then deploy again.",
+      "copied": "Copied!"
     },
     "save": {
       "recording": "Recording your deployment…",
@@ -904,7 +913,12 @@
       "accounts": "Accounts",
       "accountData": "Account Data",
       "executeInstruction": "Execute {name}",
-      "accountNotFound": "Account not found. Run an instruction to create it."
+      "accountNotFound": "Account not found. Run an instruction to create it.",
+      "unknownInstruction": "Unknown instruction: {name}",
+      "accountNotResolved": "Account \"{name}\" is not resolved. Please provide a public key.",
+      "base58AddressPlaceholder": "Base58 address...",
+      "publicKeyPlaceholder": "PublicKey...",
+      "myWallet": "My wallet"
     },
     "capstone": {
       "journeyTitle": "Your Journey",

--- a/apps/web/src/messages/es.json
+++ b/apps/web/src/messages/es.json
@@ -393,7 +393,15 @@
     "formatUnchanged": "Ya está formateado.",
     "formatUnsupported": "El formateo no está disponible para este lenguaje.",
     "finishCourse": "Finalizar curso",
-    "completeGateHint": "Completa el quiz y la reflexión de arriba para habilitar"
+    "completeGateHint": "Completa el quiz y la reflexión de arriba para habilitar",
+    "executionTimeout": "La ejecución superó el tiempo tras {seconds}s — revisa si hay bucles infinitos",
+    "dynamicImportBlocked": "No se permite import() dinámico en los desafíos",
+    "syntaxError": "Error de sintaxis: {message}",
+    "returnValueLabel": "Valor de retorno:",
+    "noFunctionFound": "No se encontró ninguna función en tu código",
+    "rustAssertionFailed": "la aserción falló",
+    "rustNoOutput": "La prueba no produjo salida",
+    "rustCompilationFailed": "Falló la compilación"
   },
   "dashboard": {
     "allCaughtUp": "¡Todo al día!",
@@ -849,7 +857,8 @@
       "startOver": "Empezar de Nuevo",
       "insufficientSol": "SOL insuficiente. Necesita ~{amount} más.",
       "buildExpired": "Build expirado",
-      "rebuildHint": "Haz clic en \"Run\" en el editor para recompilar y despliega de nuevo."
+      "rebuildHint": "Haz clic en \"Run\" en el editor para recompilar y despliega de nuevo.",
+      "copied": "¡Copiado!"
     },
     "save": {
       "recording": "Registrando tu despliegue…",
@@ -904,7 +913,12 @@
       "accounts": "Cuentas",
       "accountData": "Datos de la Cuenta",
       "executeInstruction": "Ejecutar {name}",
-      "accountNotFound": "Cuenta no encontrada. Ejecuta una instrucción para crearla."
+      "accountNotFound": "Cuenta no encontrada. Ejecuta una instrucción para crearla.",
+      "unknownInstruction": "Instrucción desconocida: {name}",
+      "accountNotResolved": "La cuenta \"{name}\" no está resuelta. Proporciona una clave pública.",
+      "base58AddressPlaceholder": "Dirección Base58...",
+      "publicKeyPlaceholder": "Clave pública...",
+      "myWallet": "Mi billetera"
     },
     "capstone": {
       "journeyTitle": "Tu Camino",

--- a/apps/web/src/messages/pt-BR.json
+++ b/apps/web/src/messages/pt-BR.json
@@ -393,7 +393,15 @@
     "formatUnchanged": "Já está formatado.",
     "formatUnsupported": "A formatação não está disponível para esta linguagem.",
     "finishCourse": "Concluir curso",
-    "completeGateHint": "Conclua o quiz e a reflexão acima para habilitar"
+    "completeGateHint": "Conclua o quiz e a reflexão acima para habilitar",
+    "executionTimeout": "Execução expirou após {seconds}s — verifique se há loops infinitos",
+    "dynamicImportBlocked": "import() dinâmico não é permitido nos desafios",
+    "syntaxError": "Erro de sintaxe: {message}",
+    "returnValueLabel": "Valor de retorno:",
+    "noFunctionFound": "Nenhuma função encontrada no seu código",
+    "rustAssertionFailed": "asserção falhou",
+    "rustNoOutput": "O teste não produziu saída",
+    "rustCompilationFailed": "Falha na compilação"
   },
   "dashboard": {
     "allCaughtUp": "Tudo em dia!",
@@ -849,7 +857,8 @@
       "startOver": "Recomeçar",
       "insufficientSol": "SOL insuficiente. Precisa de ~{amount} a mais.",
       "buildExpired": "Build expirado",
-      "rebuildHint": "Clique em \"Run\" no editor para recompilar e faça o deploy novamente."
+      "rebuildHint": "Clique em \"Run\" no editor para recompilar e faça o deploy novamente.",
+      "copied": "Copiado!"
     },
     "save": {
       "recording": "Registrando seu deploy…",
@@ -904,7 +913,12 @@
       "accounts": "Contas",
       "accountData": "Dados da Conta",
       "executeInstruction": "Executar {name}",
-      "accountNotFound": "Conta não encontrada. Execute uma instrução para criá-la."
+      "accountNotFound": "Conta não encontrada. Execute uma instrução para criá-la.",
+      "unknownInstruction": "Instrução desconhecida: {name}",
+      "accountNotResolved": "A conta \"{name}\" não foi resolvida. Informe uma chave pública.",
+      "base58AddressPlaceholder": "Endereço Base58...",
+      "publicKeyPlaceholder": "Chave pública...",
+      "myWallet": "Minha carteira"
     },
     "capstone": {
       "journeyTitle": "Sua Jornada",


### PR DESCRIPTION
Externalizes hardcoded English from `challenge-runner.tsx`'s sandbox/Rust-playground error and label strings and `generic-program-explorer.tsx`'s throw messages, placeholders, and the "My wallet"/Execute button text, plus `deploy-panel.tsx`'s "Copied!" label. New keys go under the existing `lesson` and `deploy.explorer`/`deploy.deployment` namespaces, with pt-BR and es translations.

Deferred: the strings inside `challenge-runner.tsx`'s `runBuildChallenge` ("Compilation successful", "Compilation failed", "Program compiled successfully!", "pass") — that function is being actively rewritten on `fix/buildable-grader-harness-09-09-2026` (splices in `withCanonicalHarness`), so touching it here would conflict. `deploy-panel.tsx`'s six dead `t(...) || "English"` fallbacks (already localized, just redundant) were left alone as out of scope.

Verified: targeted vitest suite (146 tests incl. i18n parity), `tsc --noEmit`, `pnpm lint` — all clean on the touched files.