### PR TITLE
fix(deploy): signer refuses a swapped account, explorer reauth only for embedded wallets, wallet-scoped saved state

### DIFF
--- a/apps/web/src/components/deploy/__tests__/deploy-panel.test.tsx
+++ b/apps/web/src/components/deploy/__tests__/deploy-panel.test.tsx
@@ -82,6 +82,7 @@ beforeEach(() => {
   h.celebrate.mockClear();
   postStatus = 200;
   localStorage.clear();
+  sessionStorage.clear();
   vi.stubGlobal(
     "fetch",
     vi.fn(async (_url: string, init?: RequestInit) => {
@@ -147,5 +148,43 @@ describe("DeployPanel — save outcome after a successful deploy", () => {
     );
     // The on-chain deploy still succeeded — the program id is shown.
     expect(screen.getByText(PROGRAM_ID)).toBeInTheDocument();
+  });
+});
+
+describe("DeployPanel — saved deploy state is wallet-scoped", () => {
+  const BUILD_UUID = "build-uuid-123";
+
+  function seedPausedState(wallet: string) {
+    sessionStorage.setItem(
+      `deploy-state-${wallet.slice(0, 8)}-${BUILD_UUID}`,
+      JSON.stringify({
+        buildUuid: BUILD_UUID,
+        bufferKeypairSecret: [],
+        programKeypairSecret: [],
+        lastUploadedChunk: 3,
+        totalChunks: 10,
+        phase: "uploading",
+      })
+    );
+  }
+
+  it("resumes the paused deploy for the wallet that saved it", async () => {
+    seedPausedState(CONNECTED);
+    renderPanel();
+
+    expect(await screen.findByText("Deployment paused")).toBeInTheDocument();
+  });
+
+  it("hides it from a different wallet on the same browser", async () => {
+    // The saved buffer is owned by CONNECTED's keypair, so resuming it as
+    // OTHER_WALLET would spend the wrong learner's SOL on a deploy that
+    // cannot finalize — and it leaks that a deploy is in flight at all.
+    seedPausedState(OTHER_WALLET);
+    renderPanel();
+
+    expect(
+      await screen.findByRole("button", { name: "Deploy to Devnet" })
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Deployment paused")).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/deploy/__tests__/generic-program-explorer.test.tsx
+++ b/apps/web/src/components/deploy/__tests__/generic-program-explorer.test.tsx
@@ -28,18 +28,19 @@ const IDL = JSON.stringify({
 const h = vi.hoisted(() => ({
   signTransaction: vi.fn(),
   startReauth: vi.fn(),
+  kind: "embedded" as "embedded" | "adapter",
 }));
 
 vi.mock("@/hooks/use-deploy-signer", () => ({
   useDeploySigner: () => ({
     status: "ready",
-    kind: "embedded",
+    kind: h.kind,
     signer: {
       publicKey: WALLET,
       signTransaction: h.signTransaction,
       signAllTransactions: vi.fn(),
     },
-    batchSize: 15,
+    batchSize: h.kind === "embedded" ? 15 : undefined,
     startReauth: h.startReauth,
   }),
 }));
@@ -89,6 +90,7 @@ beforeEach(() => {
   );
   h.signTransaction.mockReset();
   h.startReauth.mockReset();
+  h.kind = "embedded";
   vi.stubGlobal(
     "fetch",
     vi.fn(async () => ({ ok: true, json: async () => ({ deployed: false }) }))
@@ -116,5 +118,26 @@ describe("GenericProgramExplorer — expired Dynamic session", () => {
       await screen.findByRole("button", { name: /Google/i })
     ).toBeInTheDocument();
     expect(screen.queryByText("session expired")).not.toBeInTheDocument();
+  });
+
+  it("leaves an adapter's unauthorized_error to the adapter path", async () => {
+    // Nothing in the extension wallets throws this today, but the re-auth card
+    // is a social sign-in an extension user cannot complete, so the branch is
+    // gated on the signer kind rather than on the error alone.
+    h.kind = "adapter";
+    const unauthorized = Object.assign(new Error("wallet locked"), {
+      code: "unauthorized_error",
+    });
+    h.signTransaction.mockRejectedValue(unauthorized);
+
+    renderExplorer();
+
+    fireEvent.click(await screen.findByText("Ping"));
+    fireEvent.click(await screen.findByRole("button", { name: /Execute/ }));
+
+    expect(await screen.findByText("wallet locked")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /Google/i })
+    ).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/deploy/deploy-panel.tsx
+++ b/apps/web/src/components/deploy/deploy-panel.tsx
@@ -67,13 +67,26 @@ const STORAGE_PREFIX = "deploy-state-";
 // Helpers
 // ---------------------------------------------------------------------------
 
-function sessionKey(buildUuid: string): string {
-  return `${STORAGE_PREFIX}${buildUuid}`;
+/**
+ * Saved deploy state is scoped by wallet, like the localStorage keys below: a
+ * resume replays a buffer the PAYER owns, so offering one learner's paused
+ * deploy to the next wallet on the same browser is both a leak and a resume
+ * that cannot succeed. With no wallet resolved there is no key, so nothing is
+ * read or written — by the time a deploy runs there is always a signer.
+ */
+function sessionKey(buildUuid: string, walletPrefix: string): string | null {
+  if (!walletPrefix) return null;
+  return `${STORAGE_PREFIX}${walletPrefix}-${buildUuid}`;
 }
 
-function loadSavedState(buildUuid: string): DeploymentState | null {
+function loadSavedState(
+  buildUuid: string,
+  walletPrefix: string
+): DeploymentState | null {
+  const key = sessionKey(buildUuid, walletPrefix);
+  if (!key) return null;
   try {
-    const raw = sessionStorage.getItem(sessionKey(buildUuid));
+    const raw = sessionStorage.getItem(key);
     if (!raw) return null;
     return JSON.parse(raw) as DeploymentState;
   } catch {
@@ -81,17 +94,25 @@ function loadSavedState(buildUuid: string): DeploymentState | null {
   }
 }
 
-function savePersistentState(buildUuid: string, state: DeploymentState): void {
+function savePersistentState(
+  buildUuid: string,
+  walletPrefix: string,
+  state: DeploymentState
+): void {
+  const key = sessionKey(buildUuid, walletPrefix);
+  if (!key) return;
   try {
-    sessionStorage.setItem(sessionKey(buildUuid), JSON.stringify(state));
+    sessionStorage.setItem(key, JSON.stringify(state));
   } catch {
     // sessionStorage full or unavailable — non-critical
   }
 }
 
-function clearSavedState(buildUuid: string): void {
+function clearSavedState(buildUuid: string, walletPrefix: string): void {
+  const key = sessionKey(buildUuid, walletPrefix);
+  if (!key) return;
   try {
-    sessionStorage.removeItem(sessionKey(buildUuid));
+    sessionStorage.removeItem(key);
   } catch {
     // ignore
   }
@@ -410,12 +431,12 @@ export function DeployPanel({
 
   // Check for resumable state on mount
   useEffect(() => {
-    const existing = loadSavedState(buildUuid);
+    const existing = loadSavedState(buildUuid, walletPrefix);
     if (existing && existing.phase !== "complete") {
       setSavedState(existing);
       setPanelState("paused");
     }
-  }, [buildUuid]);
+  }, [buildUuid, walletPrefix]);
 
   // Build deployment callbacks
   const buildCallbacks = useCallback((): DeploymentCallbacks => {
@@ -450,14 +471,14 @@ export function DeployPanel({
         setPanelState(error.retryable ? "paused" : "error");
       },
       onStateUpdate: (state: DeploymentState) => {
-        savePersistentState(buildUuid, state);
+        savePersistentState(buildUuid, walletPrefix, state);
         setSavedState(state);
       },
       onBatchStart: (info) => {
         setBatchInfo(info);
       },
     };
-  }, [buildUuid]);
+  }, [buildUuid, walletPrefix]);
 
   // Persist the deploy to the server (source of truth for the credential
   // gate), retrying transient failures with backoff and surfacing the outcome
@@ -487,7 +508,7 @@ export function DeployPanel({
     (deployResult: DeployResult) => {
       setResult(deployResult);
       setPanelState("success");
-      clearSavedState(buildUuid);
+      clearSavedState(buildUuid, walletPrefix);
 
       // Save program ID + stats to localStorage for use in later lessons and refresh.
       // Keys are scoped by wallet to prevent cross-user cache leaks.
@@ -651,7 +672,7 @@ export function DeployPanel({
 
   // Start over handler
   const handleStartOver = useCallback(() => {
-    clearSavedState(buildUuid);
+    clearSavedState(buildUuid, walletPrefix);
     setSavedState(null);
     setPanelState("ready");
     setTxLog([]);
@@ -663,7 +684,7 @@ export function DeployPanel({
     setCurrentStep("buffer");
     setSaveStatus("idle");
     saveCancelledRef.current = true;
-  }, [buildUuid]);
+  }, [buildUuid, walletPrefix]);
 
   // Copy program ID
   const handleCopyProgramId = useCallback(async () => {

--- a/apps/web/src/components/deploy/generic-program-explorer.tsx
+++ b/apps/web/src/components/deploy/generic-program-explorer.tsx
@@ -128,7 +128,12 @@ export function GenericProgramExplorer({
   // The wallet that signs — extension or embedded. `useWallet` is still read
   // for the ADAPTER-only reconnect path below (an embedded wallet has no
   // adapter to re-select; its recovery is Dynamic re-auth).
-  const { status: signerStatus, signer, startReauth } = useDeploySigner();
+  const {
+    status: signerStatus,
+    signer,
+    kind: signerKind,
+    startReauth,
+  } = useDeploySigner();
   const publicKey = signer?.publicKey ?? null;
   const signTransaction = signer?.signTransaction ?? null;
   const { disconnect, wallet, select } = useWallet();
@@ -589,7 +594,10 @@ export function GenericProgramExplorer({
         // same as in the deploy panel — `isWalletKeyringError` is
         // extension-specific, so without this the learner gets a raw error and
         // no way back.
-        if (isDynamicSessionExpiredError(err)) {
+        // Embedded only: an extension adapter that happened to throw an
+        // `unauthorized_error` has no Dynamic session to re-auth, and its own
+        // handling (keyring reconnect) is below.
+        if (signerKind === "embedded" && isDynamicSessionExpiredError(err)) {
           setSessionExpired(true);
           setReauthDismissed(false);
           return;
@@ -635,6 +643,7 @@ export function GenericProgramExplorer({
     [
       publicKey,
       signTransaction,
+      signerKind,
       programId,
       idl,
       instructionCoder,
@@ -698,7 +707,11 @@ export function GenericProgramExplorer({
   // connect modal: they have no extension, and the modal has no route back to
   // Dynamic short of a full sign-out. `sessionExpired` covers the mid-execute
   // case, where the signer can still look ready.
-  if ((signerStatus === "expired" || sessionExpired) && !reauthDismissed) {
+  if (
+    (signerStatus === "expired" ||
+      (sessionExpired && signerKind === "embedded")) &&
+    !reauthDismissed
+  ) {
     return (
       <LinkedWalletPrompt
         variant="reauth"

--- a/apps/web/src/hooks/__tests__/use-deploy-signer.test.tsx
+++ b/apps/web/src/hooks/__tests__/use-deploy-signer.test.tsx
@@ -2,10 +2,12 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderHook } from "@testing-library/react";
 import { Keypair, Transaction } from "@solana/web3.js";
+import { isDynamicSessionExpiredError } from "@/lib/dynamic/solana";
 import { useDeploySigner, EMBEDDED_BATCH_SIZE } from "../use-deploy-signer";
 
 const ADAPTER_KEY = Keypair.generate().publicKey;
 const EMBEDDED_KEY = Keypair.generate().publicKey;
+const OTHER_KEY = Keypair.generate().publicKey;
 
 const wallet = vi.hoisted(() => ({
   publicKey: null as unknown,
@@ -33,7 +35,10 @@ vi.mock("@solana/wallet-adapter-react", () => ({
   }),
 }));
 
-vi.mock("@/lib/dynamic/solana", () => ({
+// Only the signing calls are stubbed — `isDynamicSessionExpiredError` is the
+// real predicate, so the tests below assert what the app actually matches on.
+vi.mock("@/lib/dynamic/solana", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/dynamic/solana")>()),
   signWithDynamicWallet: dynamic.signWithDynamicWallet,
   signAllWithDynamicWallet: dynamic.signAllWithDynamicWallet,
 }));
@@ -63,6 +68,16 @@ beforeEach(() => {
   dynamic.signAllWithDynamicWallet.mockReset();
   dynamicEnabled.value = true;
 });
+
+/** The thrown value, so a test can assert on it with the app's own predicate. */
+async function rejection(promise: Promise<unknown>): Promise<unknown> {
+  try {
+    await promise;
+  } catch (error) {
+    return error;
+  }
+  throw new Error("expected the call to reject");
+}
 
 describe("useDeploySigner", () => {
   it("prefers the wallet-adapter wallet and keeps the package's default batch size", () => {
@@ -151,6 +166,63 @@ describe("useDeploySigner", () => {
     expect(result.current.status).toBe("none");
     expect(result.current.kind).toBeNull();
     expect(result.current.signer).toBeNull();
+  });
+
+  it("refuses to sign once the session moves to a different account", async () => {
+    dynamic.account = { address: EMBEDDED_KEY.toBase58() };
+
+    const { result, rerender } = renderHook(() => useDeploySigner());
+    const captured = result.current.signer!;
+    const advertised = captured.publicKey!.toBase58();
+
+    // The session swaps under an in-flight signer. Without the address check
+    // the closure would happily hand the NEW account to the MPC signer while
+    // still advertising the old key — a transaction built for A, signed by B.
+    dynamic.account = { address: OTHER_KEY.toBase58() };
+    rerender();
+
+    const tx = new Transaction();
+    await expect(captured.signTransaction(tx)).rejects.toMatchObject({
+      name: "UnauthorizedError",
+    });
+    await expect(captured.signAllTransactions([tx])).rejects.toMatchObject({
+      name: "UnauthorizedError",
+    });
+    expect(dynamic.signWithDynamicWallet).not.toHaveBeenCalled();
+    expect(dynamic.signAllWithDynamicWallet).not.toHaveBeenCalled();
+    // The advertised identity never mutates either — the swap produces a new
+    // signer, it does not repoint the old one.
+    expect(captured.publicKey!.toBase58()).toBe(advertised);
+    expect(result.current.signer).not.toBe(captured);
+    expect(result.current.signer?.publicKey?.toBase58()).toBe(
+      OTHER_KEY.toBase58()
+    );
+  });
+
+  it("raises an expiry both entry points when the session dies mid-flight", async () => {
+    dynamic.account = { address: EMBEDDED_KEY.toBase58() };
+
+    const { result, rerender } = renderHook(() => useDeploySigner());
+    const captured = result.current.signer!;
+
+    // Session gone between render and signature. The error has to be one
+    // `isDynamicSessionExpiredError` recognises, or the caller shows a raw
+    // failure instead of the re-auth card.
+    dynamic.account = null;
+    dynamic.status = "expired";
+    rerender();
+
+    const tx = new Transaction();
+    expect(
+      isDynamicSessionExpiredError(
+        await rejection(captured.signTransaction(tx))
+      )
+    ).toBe(true);
+    expect(
+      isDynamicSessionExpiredError(
+        await rejection(captured.signAllTransactions([tx]))
+      )
+    ).toBe(true);
   });
 
   it("an unparseable embedded address is no wallet, not a crash", () => {

--- a/apps/web/src/hooks/use-deploy-signer.ts
+++ b/apps/web/src/hooks/use-deploy-signer.ts
@@ -105,13 +105,20 @@ export function useDeploySigner(): DeploySignerState {
     const embeddedKey = parseWalletAddress(embeddedAddress);
     if (embeddedKey) {
       // Reading the ref at call time, not at memo time, is what keeps the
-      // signer stable. It can only have gone null because the session died
-      // between this render and the signature, which is an expiry — raise it
-      // as one so callers offer re-auth instead of a raw failure.
+      // signer stable. But a ref can drift from the address this signer
+      // advertises, so both ways it can drift raise the SDK's own
+      // `UnauthorizedError`, which `isDynamicSessionExpiredError` matches:
+      // null means the session died between this render and the signature, and
+      // a different address means the signer would sign with an account other
+      // than its `publicKey` — a transaction built for A signed by B.
       const activeAccount = () => {
         const current = accountRef.current;
-        if (!current) {
-          const expired = new Error("Dynamic session ended before signing");
+        if (!current || current.address !== embeddedAddress) {
+          const expired = new Error(
+            current
+              ? "Dynamic account changed before signing"
+              : "Dynamic session ended before signing"
+          );
           expired.name = "UnauthorizedError";
           throw expired;
         }


### PR DESCRIPTION
Second-pass gate follow-ups on #1220.

The embedded signer reads the session through a ref at call time but advertises the address it was memoized on, so an account swap under an in-flight signer would hand the MPC signer account B for a transaction built for payer A. `activeAccount()` now raises the same SDK-shaped `UnauthorizedError` on an address mismatch as it does on a dead session, so a signer can never sign as anyone but the key it exposes. The explorer's mid-execute reauth card is gated on `kind === "embedded"` — an extension wallet that threw `unauthorized_error` would otherwise get a Google/GitHub card it cannot complete, instead of the keyring reconnect path. Finally `deploy-state-{buildUuid}` joins the other wallet-scoped browser keys: the saved buffer belongs to the payer, so resuming it as a different wallet on the same browser spends the wrong SOL on a deploy that cannot finalize.

Five new tests; three of them fail against the pre-fix source.