### PR TITLE
fix(deploy): back off on the embedded wallet's rate limit, airdrop via the public devnet RPC

### DIFF
--- a/apps/web/src/components/deploy/__tests__/wallet-funding-card.test.tsx
+++ b/apps/web/src/components/deploy/__tests__/wallet-funding-card.test.tsx
@@ -80,7 +80,9 @@ describe("WalletFundingCard", () => {
     );
     // By address, not by object identity: the card re-derives the key from the
     // signer's address so its `refreshBalance` effect cannot self-sustain.
-    expect(h.createAirdropRequest.mock.calls[0]![1].toBase58()).toBe(
+    // The app connection is NOT passed — the airdrop goes to the public devnet
+    // RPC, whose faucet limit is per address rather than per project.
+    expect(h.createAirdropRequest.mock.calls[0]![0].toBase58()).toBe(
       EMBEDDED.toBase58()
     );
   });

--- a/apps/web/src/components/deploy/deploy-panel.tsx
+++ b/apps/web/src/components/deploy/deploy-panel.tsx
@@ -19,6 +19,7 @@ import { celebrate } from "@/lib/gamification/celebration";
 import { useAuth } from "@/lib/auth/auth-provider";
 import { trackEvent } from "@/lib/analytics";
 import { isDynamicSessionExpiredError } from "@/lib/dynamic/solana";
+import { isDynamicRateLimitError } from "@/lib/dynamic/rate-limit";
 import {
   saveDeploymentWithRetry,
   type SaveStatus,
@@ -48,7 +49,8 @@ interface DeployPanelProps {
 }
 
 interface TxLogEntry {
-  signature: string;
+  /** Absent for notices that aren't a transaction (e.g. a rate-limit wait). */
+  signature?: string;
   step: DeployStep;
   message: string;
   timestamp: number;
@@ -186,16 +188,6 @@ export function DeployPanel({
   onBuildExpired,
 }: DeployPanelProps) {
   const t = useTranslations("deploy.deployment");
-  // Extension wallet or Dynamic embedded wallet — the deploy is signed and paid
-  // by whichever one this learner actually has.
-  const {
-    status: signerStatus,
-    signer,
-    kind: signerKind,
-    batchSize,
-    startReauth,
-  } = useDeploySigner();
-  const publicKey = signer?.publicKey ?? null;
   const { connection } = useConnection();
   const { profile, isLoading: authLoading } = useAuth();
 
@@ -225,6 +217,32 @@ export function DeployPanel({
   const [costLamports, setCostLamports] = useState<number | null>(null);
   const [balanceLamports, setBalanceLamports] = useState<number | null>(null);
   const fundingTrackedRef = useRef(false);
+
+  // Extension wallet or Dynamic embedded wallet — the deploy is signed and paid
+  // by whichever one this learner actually has. A throttled embedded signing
+  // request is reported into the same log the learner is already watching:
+  // nothing has failed, the signer is waiting before it asks again.
+  const {
+    status: signerStatus,
+    signer,
+    kind: signerKind,
+    batchSize,
+    startReauth,
+  } = useDeploySigner({
+    onRateLimitWait: ({ waitMs }) => {
+      setTxLog((prev) => [
+        ...prev,
+        {
+          step: "upload",
+          message: t("rateLimitWaiting", {
+            seconds: String(Math.max(1, Math.round(waitMs / 1000))),
+          }),
+          timestamp: Date.now(),
+        },
+      ]);
+    },
+  });
+  const publicKey = signer?.publicKey ?? null;
 
   // Timing
   const startTimeRef = useRef<number>(0);
@@ -595,6 +613,16 @@ export function DeployPanel({
         return;
       }
 
+      // Throttled by Dynamic's wallet API after the signer had already spent
+      // its backoff. Nothing on chain failed and the buffer keeps every chunk
+      // that landed, so this is a wait, not a broken deploy.
+      if (isDynamicRateLimitError(err)) {
+        trackEvent("deploy_rate_limited", { signerKind, phase: "deploy" });
+        setErrorMessage(t("rateLimitPaused"));
+        setPanelState("paused");
+        return;
+      }
+
       const message = err instanceof Error ? err.message : String(err);
       setErrorMessage(message);
 
@@ -618,6 +646,7 @@ export function DeployPanel({
     programKeypairSecret,
     buildCallbacks,
     handleSuccess,
+    t,
   ]);
 
   // Resume handler
@@ -656,6 +685,13 @@ export function DeployPanel({
         return;
       }
 
+      if (isDynamicRateLimitError(err)) {
+        trackEvent("deploy_rate_limited", { signerKind, phase: "resume" });
+        setErrorMessage(t("rateLimitPaused"));
+        setPanelState("paused");
+        return;
+      }
+
       const message = err instanceof Error ? err.message : String(err);
       setErrorMessage(message);
       setPanelState("paused");
@@ -668,6 +704,7 @@ export function DeployPanel({
     savedState,
     buildCallbacks,
     handleSuccess,
+    t,
   ]);
 
   // Start over handler
@@ -979,17 +1016,19 @@ export function DeployPanel({
               <div className="space-y-1">
                 {txLog.map((entry, idx) => (
                   <div
-                    key={`${entry.signature}-${idx}`}
+                    key={`${entry.signature ?? "note"}-${idx}`}
                     className="flex items-center gap-2 text-[11px]"
                   >
-                    <a
-                      href={`${EXPLORER_BASE}/tx/${entry.signature}?cluster=devnet`}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="shrink-0 font-mono text-primary hover:underline"
-                    >
-                      {truncateSig(entry.signature)}
-                    </a>
+                    {entry.signature && (
+                      <a
+                        href={`${EXPLORER_BASE}/tx/${entry.signature}?cluster=devnet`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="shrink-0 font-mono text-primary hover:underline"
+                      >
+                        {truncateSig(entry.signature)}
+                      </a>
+                    )}
                     <span className="truncate text-muted-foreground">
                       {entry.message}
                     </span>
@@ -1048,17 +1087,19 @@ export function DeployPanel({
               <div className="space-y-1">
                 {txLog.map((entry, idx) => (
                   <div
-                    key={`${entry.signature}-${idx}`}
+                    key={`${entry.signature ?? "note"}-${idx}`}
                     className="flex items-center gap-2 text-[11px]"
                   >
-                    <a
-                      href={`${EXPLORER_BASE}/tx/${entry.signature}?cluster=devnet`}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="shrink-0 font-mono text-primary hover:underline"
-                    >
-                      {truncateSig(entry.signature)}
-                    </a>
+                    {entry.signature && (
+                      <a
+                        href={`${EXPLORER_BASE}/tx/${entry.signature}?cluster=devnet`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="shrink-0 font-mono text-primary hover:underline"
+                      >
+                        {truncateSig(entry.signature)}
+                      </a>
+                    )}
                     <span className="truncate text-muted-foreground">
                       {entry.message}
                     </span>

--- a/apps/web/src/components/deploy/wallet-funding-card.tsx
+++ b/apps/web/src/components/deploy/wallet-funding-card.tsx
@@ -89,7 +89,10 @@ export function WalletFundingCard({
     setIsAirdropping(true);
     setMessage(null);
 
-    const result = await createAirdropRequest(connection, publicKey, 2);
+    // No `connection` argument: the airdrop goes to the PUBLIC devnet RPC,
+    // whose limit is per address, while the app's keyed endpoint meters the
+    // faucet per project — one learner's 2 SOL used to exhaust everyone's day.
+    const result = await createAirdropRequest(publicKey, 2);
 
     if (result.success) {
       setBalance(result.newBalance ?? balance);
@@ -102,11 +105,14 @@ export function WalletFundingCard({
       });
       setCooldown(COOLDOWN_SECONDS);
     } else if (result.rateLimited) {
+      const retryAfter = result.retryAfterSeconds;
       setMessage({
-        text: t("rateLimitedWithFaucet"),
+        text: retryAfter
+          ? t("rateLimitedRetryAfter", { seconds: String(retryAfter) })
+          : t("rateLimitedWithFaucet"),
         type: "warning",
       });
-      setCooldown(60);
+      setCooldown(retryAfter ?? 60);
     } else {
       setMessage({
         text: result.error ?? t("networkError"),

--- a/apps/web/src/hooks/__tests__/use-deploy-signer.test.tsx
+++ b/apps/web/src/hooks/__tests__/use-deploy-signer.test.tsx
@@ -25,6 +25,13 @@ const dynamic = vi.hoisted(() => ({
 
 const dynamicEnabled = vi.hoisted(() => ({ value: true }));
 
+const connectionMock = vi.hoisted(() => ({
+  getLatestBlockhash: vi.fn(async () => ({
+    blockhash: "fresh",
+    lastValidBlockHeight: 1,
+  })),
+}));
+
 vi.mock("@solana/wallet-adapter-react", () => ({
   useWallet: () => ({
     publicKey: wallet.publicKey,
@@ -33,6 +40,9 @@ vi.mock("@solana/wallet-adapter-react", () => ({
       ? wallet.signAllTransactions
       : undefined,
   }),
+  // Only used by the embedded path, to re-stamp a batch whose blockhash the
+  // rate-limit backoff has outlived.
+  useConnection: () => ({ connection: connectionMock }),
 }));
 
 // Only the signing calls are stubbed — `isDynamicSessionExpiredError` is the
@@ -120,6 +130,59 @@ describe("useDeploySigner", () => {
       [tx],
       dynamic.account
     );
+  });
+
+  it("splits an embedded batch into sub-batches, in order", async () => {
+    dynamic.account = { address: EMBEDDED_KEY.toBase58() };
+    dynamic.signAllWithDynamicWallet.mockImplementation(
+      async (txs: Transaction[]) => txs
+    );
+
+    const { result } = renderHook(() => useDeploySigner());
+    const txs = Array.from({ length: 12 }, () => new Transaction());
+    const signed = await result.current.signer!.signAllTransactions(txs);
+
+    // Dynamic throttles the MPC API by signatures asked for at once, so a
+    // 15-tx batch goes out five at a time.
+    expect(
+      dynamic.signAllWithDynamicWallet.mock.calls.map((call) => call[0].length)
+    ).toEqual([5, 5, 2]);
+    // The deploy maps signature i back to chunk i.
+    expect(signed).toEqual(txs);
+  });
+
+  it("waits out a rate limit instead of failing the batch", async () => {
+    vi.useFakeTimers();
+    dynamic.account = { address: EMBEDDED_KEY.toBase58() };
+    const rateLimited = new Error("Rate limited");
+    rateLimited.name = "WalletApiError";
+    dynamic.signAllWithDynamicWallet
+      .mockRejectedValueOnce(rateLimited)
+      .mockImplementation(async (txs: Transaction[]) => txs);
+
+    const onRateLimitWait = vi.fn();
+    const { result } = renderHook(() => useDeploySigner({ onRateLimitWait }));
+    const txs = [new Transaction()];
+    const pending = result.current.signer!.signAllTransactions(txs);
+    await vi.runAllTimersAsync();
+
+    await expect(pending).resolves.toEqual(txs);
+    expect(dynamic.signAllWithDynamicWallet).toHaveBeenCalledTimes(2);
+    expect(onRateLimitWait).toHaveBeenCalledOnce();
+    vi.useRealTimers();
+  });
+
+  it("leaves the adapter path unwrapped", async () => {
+    wallet.publicKey = ADAPTER_KEY;
+    const txs = Array.from({ length: 12 }, () => new Transaction());
+    wallet.signAllTransactions.mockResolvedValue(txs);
+
+    const { result } = renderHook(() => useDeploySigner());
+    await result.current.signer!.signAllTransactions(txs);
+
+    // An extension wallet signs locally: one popup, no sub-batching, no
+    // backoff.
+    expect(wallet.signAllTransactions).toHaveBeenCalledWith(txs);
   });
 
   it("hands back the SAME signer across re-renders while the session is unchanged", () => {

--- a/apps/web/src/hooks/use-deploy-signer.ts
+++ b/apps/web/src/hooks/use-deploy-signer.ts
@@ -1,13 +1,17 @@
 "use client";
 
 import { useMemo, useRef } from "react";
-import { useWallet } from "@solana/wallet-adapter-react";
+import { useConnection, useWallet } from "@solana/wallet-adapter-react";
 import type { WalletAdapter } from "@superteam-lms/deploy";
 import { parseWalletAddress } from "@/lib/solana/linked-wallet";
 import {
   signAllWithDynamicWallet,
   signWithDynamicWallet,
 } from "@/lib/dynamic/solana";
+import {
+  signAllWithRateLimitBackoff,
+  type RateLimitWaitInfo,
+} from "@/lib/dynamic/rate-limit";
 import {
   startDynamicSocialSignIn,
   type DynamicSocialProvider,
@@ -29,6 +33,16 @@ import { useDynamicSessionState } from "@/hooks/use-dynamic-session-state";
  * signatures per call than the adapter path, still only ~8 batches for a
  * 100 KB program. The deploy panel logs per-batch signing time in development
  * so the number can be replaced with a measured one.
+ *
+ * MEASURED (owner, production, 09-09-2026, `your-first-solana-program`,
+ * 74 chunks): the first batch of 15 got three chunks in before Dynamic
+ * answered `WalletApiError: Rate limited`. So the binding constraint is not
+ * blockhash-window latency at all — it is how many signatures the MPC API
+ * accepts in quick succession. Lowering this number would not have helped: a
+ * batch of 3 would have been throttled on the next batch instead, and smaller
+ * batches mean more blockhash fetches for the same 74 chunks. The fix is
+ * `signAllWithRateLimitBackoff` below — sub-batches of
+ * `EMBEDDED_SUB_BATCH_SIZE` with backoff between them — so 15 stays.
  */
 export const EMBEDDED_BATCH_SIZE = 15;
 
@@ -48,6 +62,14 @@ export interface DeploySignerState {
   startReauth: (provider: DynamicSocialProvider) => Promise<void>;
 }
 
+export interface DeploySignerOptions {
+  /**
+   * Dynamic throttled the signing request and the signer is waiting before
+   * asking again. Embedded path only; the deploy has NOT failed.
+   */
+  onRateLimitWait?: (info: RateLimitWaitInfo) => void;
+}
+
 /**
  * The wallet that will sign and pay for a program deploy — extension or
  * embedded.
@@ -62,8 +84,11 @@ export interface DeploySignerState {
  * With `isDynamicEnabled()` false this degrades to exactly the adapter-only
  * behaviour that shipped before — no Dynamic read, no reauth card.
  */
-export function useDeploySigner(): DeploySignerState {
+export function useDeploySigner(
+  options: DeploySignerOptions = {}
+): DeploySignerState {
   const { publicKey, signTransaction, signAllTransactions } = useWallet();
+  const { connection } = useConnection();
   const dynamicSession = useDynamicSessionState();
   const dynamicEnabled = isDynamicEnabled();
   const account = dynamicEnabled ? dynamicSession.account : null;
@@ -78,6 +103,12 @@ export function useDeploySigner(): DeploySignerState {
   const embeddedAddress = account?.address ?? null;
   const accountRef = useRef(account);
   accountRef.current = account;
+  // Same reason as `accountRef`: callers pass a fresh closure per render, and
+  // keying the memo on it would hand every consumer a new signer each render.
+  const onRateLimitWaitRef = useRef(options.onRateLimitWait);
+  onRateLimitWaitRef.current = options.onRateLimitWait;
+  const connectionRef = useRef(connection);
+  connectionRef.current = connection;
 
   return useMemo<DeploySignerState>(() => {
     const startReauth = (provider: DynamicSocialProvider) =>
@@ -134,11 +165,18 @@ export function useDeploySigner(): DeploySignerState {
           // partially-signed tx (the buffer/program keypair's signature).
           signTransaction: async (tx) =>
             (await signWithDynamicWallet(tx, activeAccount())) as typeof tx,
+          // Dynamic throttles this call (see rate-limit.ts): sub-batched,
+          // retried with backoff, and re-stamped with a fresh blockhash when
+          // the waiting outlives the one the batch arrived with.
           signAllTransactions: async (txs) =>
-            (await signAllWithDynamicWallet(
-              txs,
-              activeAccount()
-            )) as typeof txs,
+            (await signAllWithRateLimitBackoff(txs, {
+              signAll: (batch) =>
+                signAllWithDynamicWallet(batch, activeAccount()),
+              onRateLimitWait: (info) => onRateLimitWaitRef.current?.(info),
+              refreshBlockhash: async () =>
+                (await connectionRef.current.getLatestBlockhash("confirmed"))
+                  .blockhash,
+            })) as typeof txs,
         },
         kind: "embedded",
         batchSize: EMBEDDED_BATCH_SIZE,

--- a/apps/web/src/lib/dynamic/__tests__/rate-limit.test.ts
+++ b/apps/web/src/lib/dynamic/__tests__/rate-limit.test.ts
@@ -1,0 +1,223 @@
+import { describe, it, expect, vi } from "vitest";
+import { Transaction } from "@solana/web3.js";
+import {
+  BLOCKHASH_MAX_AGE_MS,
+  RATE_LIMIT_MAX_DELAY_MS,
+  isDynamicRateLimitError,
+  rateLimitDelayMs,
+  signAllWithRateLimitBackoff,
+} from "../rate-limit";
+
+/**
+ * What Dynamic threw in the owner's production deploy: `WalletApiError: Rate
+ * limited`. The class is not in the installed SDK (it comes from the WaaS
+ * layer loaded at runtime), so the fixtures below mirror the SHAPES the error
+ * can arrive in rather than importing a type that does not exist here.
+ */
+function walletApiRateLimited(): Error {
+  const error = new Error("Rate limited");
+  error.name = "WalletApiError";
+  return error;
+}
+
+const txs = (count: number) =>
+  Array.from({ length: count }, () => new Transaction());
+
+const options = {
+  sleep: async () => {},
+  random: () => 0,
+};
+
+describe("isDynamicRateLimitError", () => {
+  it("matches the WalletApiError the owner's deploy hit", () => {
+    expect(isDynamicRateLimitError(walletApiRateLimited())).toBe(true);
+  });
+
+  it("matches an APIError carrying a 429", () => {
+    const error = Object.assign(new Error("Request failed"), {
+      name: "APIError",
+      code: "unknown_error",
+      status: 429,
+    });
+    expect(isDynamicRateLimitError(error)).toBe(true);
+  });
+
+  it("matches a rate_limit code and a rate-limit name", () => {
+    expect(
+      isDynamicRateLimitError(
+        Object.assign(new Error("nope"), { code: "rate_limit_exceeded" })
+      )
+    ).toBe(true);
+    expect(
+      isDynamicRateLimitError(
+        Object.assign(new Error("nope"), { name: "MfaRateLimitedError" })
+      )
+    ).toBe(true);
+  });
+
+  it("looks one level into cause, as the WaaS signer wraps failures", () => {
+    const wrapped = new Error("Failed to sign");
+    wrapped.name = "WaasLoadFailedError";
+    wrapped.cause = walletApiRateLimited();
+    expect(isDynamicRateLimitError(wrapped)).toBe(true);
+  });
+
+  it("does not match an ordinary signing failure", () => {
+    const expired = new Error("Session ended before signing");
+    expired.name = "UnauthorizedError";
+    expect(isDynamicRateLimitError(expired)).toBe(false);
+    expect(isDynamicRateLimitError(new Error("Transaction failed"))).toBe(
+      false
+    );
+    expect(isDynamicRateLimitError(null)).toBe(false);
+  });
+});
+
+describe("rateLimitDelayMs", () => {
+  it("grows exponentially from 2s and caps at 30s", () => {
+    expect(rateLimitDelayMs(0, () => 0)).toBe(1_000);
+    expect(rateLimitDelayMs(0, () => 1)).toBe(2_000);
+    expect(rateLimitDelayMs(3, () => 1)).toBe(16_000);
+    expect(rateLimitDelayMs(20, () => 1)).toBe(RATE_LIMIT_MAX_DELAY_MS);
+  });
+});
+
+describe("signAllWithRateLimitBackoff", () => {
+  it("retries the throttled sub-batch and keeps the already-signed work", async () => {
+    const signAll = vi
+      .fn()
+      .mockRejectedValueOnce(walletApiRateLimited())
+      .mockRejectedValueOnce(walletApiRateLimited())
+      .mockImplementation(async (batch: Transaction[]) => batch);
+    const waits: number[] = [];
+
+    const all = txs(3);
+    const signed = await signAllWithRateLimitBackoff(all, {
+      ...options,
+      signAll,
+      onRateLimitWait: ({ waitMs }) => waits.push(waitMs),
+    });
+
+    expect(signed).toEqual(all);
+    expect(signAll).toHaveBeenCalledTimes(3);
+    // Two waits, the second longer than the first.
+    expect(waits).toHaveLength(2);
+    expect(waits[1]).toBeGreaterThan(waits[0]!);
+  });
+
+  it("reports the attempt number and the wait it is about to take", async () => {
+    const signAll = vi
+      .fn()
+      .mockRejectedValueOnce(walletApiRateLimited())
+      .mockImplementation(async (batch: Transaction[]) => batch);
+    const onRateLimitWait = vi.fn();
+
+    await signAllWithRateLimitBackoff(txs(1), {
+      ...options,
+      signAll,
+      onRateLimitWait,
+    });
+
+    expect(onRateLimitWait).toHaveBeenCalledWith({ attempt: 1, waitMs: 1_000 });
+  });
+
+  it("signs in sub-batches and returns them in order", async () => {
+    const all = txs(12);
+    const seen: Transaction[][] = [];
+    const signAll = vi.fn(async (batch: Transaction[]) => {
+      seen.push(batch);
+      return batch;
+    });
+
+    const signed = await signAllWithRateLimitBackoff(all, {
+      ...options,
+      signAll,
+      subBatchSize: 5,
+    });
+
+    expect(seen.map((batch) => batch.length)).toEqual([5, 5, 2]);
+    // Order is load-bearing: the deploy maps signature i back to chunk i.
+    expect(signed).toEqual(all);
+  });
+
+  it("gives up on a non-rate-limit error without retrying", async () => {
+    const expired = new Error("Dynamic session ended before signing");
+    expired.name = "UnauthorizedError";
+    const signAll = vi.fn().mockRejectedValue(expired);
+
+    await expect(
+      signAllWithRateLimitBackoff(txs(2), { ...options, signAll })
+    ).rejects.toBe(expired);
+    expect(signAll).toHaveBeenCalledTimes(1);
+  });
+
+  it("rethrows once the attempts are spent", async () => {
+    const signAll = vi.fn().mockRejectedValue(walletApiRateLimited());
+
+    await expect(
+      signAllWithRateLimitBackoff(txs(1), {
+        ...options,
+        signAll,
+        maxAttempts: 3,
+      })
+    ).rejects.toThrow("Rate limited");
+    expect(signAll).toHaveBeenCalledTimes(3);
+  });
+
+  it("re-stamps the blockhash and re-signs the batch once waiting outlives it", async () => {
+    const all = txs(4);
+    for (const tx of all) tx.recentBlockhash = "stale";
+
+    let attempted = 0;
+    const signAll = vi.fn(async (batch: Transaction[]) => {
+      attempted++;
+      // Throttle only the very first sub-batch, so the retry is what crosses
+      // the blockhash age threshold.
+      if (attempted === 1) throw walletApiRateLimited();
+      return batch;
+    });
+
+    let clock = 0;
+    const signed = await signAllWithRateLimitBackoff(all, {
+      ...options,
+      signAll,
+      subBatchSize: 2,
+      // The wait pushes the batch past the window it was signed against.
+      sleep: async () => {
+        clock += BLOCKHASH_MAX_AGE_MS + 1_000;
+      },
+      now: () => clock,
+      refreshBlockhash: async () => "fresh",
+    });
+
+    expect(all.every((tx) => tx.recentBlockhash === "fresh")).toBe(true);
+    // Restarted from the first sub-batch, so every transaction carries the new
+    // blockhash — none is left signed against the stale one.
+    expect(signed).toHaveLength(4);
+    expect(signed).toEqual(all);
+  });
+
+  it("keeps the blockhash when the waiting stays inside the window", async () => {
+    const all = txs(2);
+    for (const tx of all) tx.recentBlockhash = "stale";
+    const refreshBlockhash = vi.fn(async () => "fresh");
+    const signAll = vi
+      .fn()
+      .mockRejectedValueOnce(walletApiRateLimited())
+      .mockImplementation(async (batch: Transaction[]) => batch);
+
+    let clock = 0;
+    await signAllWithRateLimitBackoff(all, {
+      ...options,
+      signAll,
+      sleep: async () => {
+        clock += 1_000;
+      },
+      now: () => clock,
+      refreshBlockhash,
+    });
+
+    expect(refreshBlockhash).not.toHaveBeenCalled();
+    expect(all.every((tx) => tx.recentBlockhash === "stale")).toBe(true);
+  });
+});

--- a/apps/web/src/lib/dynamic/rate-limit.ts
+++ b/apps/web/src/lib/dynamic/rate-limit.ts
@@ -1,0 +1,209 @@
+import type { Transaction } from "@solana/web3.js";
+
+/**
+ * Surviving Dynamic's MPC signing throttle.
+ *
+ * The owner's first production deploy of `your-first-solana-program` (74
+ * chunks) stopped at chunk 3 with `WalletApiError: Rate limited`: Dynamic
+ * throttles its wallet API, and one `signAllTransactions` call for a
+ * 15-transaction batch asks for 15 signatures at once. "Retomar Deploy" hit
+ * the same wall, because an immediate retry is the same request again.
+ *
+ * Two changes, both here: ask for fewer signatures per call
+ * (`EMBEDDED_SUB_BATCH_SIZE`), and when the throttle answers anyway, wait and
+ * ask again instead of discarding the batch.
+ *
+ * This is the EMBEDDED path only. An extension wallet signs locally and is
+ * never rate limited, so `use-deploy-signer` leaves the adapter path alone.
+ */
+
+/** First wait after a throttled call. */
+export const RATE_LIMIT_BASE_DELAY_MS = 2_000;
+
+/** Ceiling for one wait — beyond this the learner is just watching a spinner. */
+export const RATE_LIMIT_MAX_DELAY_MS = 30_000;
+
+/** Attempts per sub-batch, including the first. */
+export const RATE_LIMIT_MAX_ATTEMPTS = 8;
+
+/**
+ * How long a batch may spend signing before its shared blockhash is refetched.
+ *
+ * A recent blockhash is valid ~60-90s on devnet, and the deploy fetches ONE per
+ * batch just before signing. Backoff can spend that on waiting alone, so past
+ * this age the batch is re-stamped and re-signed rather than sent against a
+ * blockhash about to expire.
+ */
+export const BLOCKHASH_MAX_AGE_MS = 45_000;
+
+/**
+ * Transactions per MPC `signAllTransactions` call on the embedded path.
+ *
+ * The batch (`EMBEDDED_BATCH_SIZE`) still shares one blockhash; this only
+ * splits how many signatures are requested at a time. Five keeps a throttled
+ * call from discarding fourteen already-signed transactions, and gives the
+ * backoff something small to retry.
+ */
+export const EMBEDDED_SUB_BATCH_SIZE = 5;
+
+/** How many times one batch may re-stamp its blockhash before giving up. */
+const MAX_BLOCKHASH_REFRESHES = 2;
+
+export interface RateLimitWaitInfo {
+  /** 1 for the first wait. */
+  attempt: number;
+  waitMs: number;
+}
+
+export interface SignAllWithBackoffOptions {
+  /** The underlying MPC batch signer. */
+  signAll: (transactions: Transaction[]) => Promise<Transaction[]>;
+  subBatchSize?: number;
+  maxAttempts?: number;
+  /** Called before each wait, so the UI can say why nothing is happening. */
+  onRateLimitWait?: (info: RateLimitWaitInfo) => void;
+  /**
+   * Fetch a fresh blockhash. Without it (tests, callers holding no connection)
+   * the batch keeps the blockhash it arrived with.
+   */
+  refreshBlockhash?: () => Promise<string>;
+  /** Injected in tests. */
+  now?: () => number;
+  sleep?: (ms: number) => Promise<void>;
+  random?: () => number;
+}
+
+/**
+ * Did the wallet service throttle us, rather than reject the transaction?
+ *
+ * Matched structurally, not by class. The installed `@dynamic-labs-sdk/client`
+ * exports no `WalletApiError` — the name the owner saw in production comes
+ * from the WaaS layer the SDK loads at runtime — so an `instanceof` check
+ * would silently match nothing. What every shape of this failure does carry is
+ * at least one of: a 429 status, a `rate_limit`-ish code, a name that says
+ * rate limit, or the message itself. `cause` is walked one level for the same
+ * reason `isDynamicSessionExpiredError` does it: the WaaS signer wraps
+ * failures once.
+ */
+export function isDynamicRateLimitError(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  return (
+    isRateLimited(error) || isRateLimited((error as { cause?: unknown }).cause)
+  );
+}
+
+function isRateLimited(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  const candidate = error as {
+    name?: unknown;
+    code?: unknown;
+    status?: unknown;
+    message?: unknown;
+  };
+
+  if (candidate.status === 429) return true;
+  if (
+    typeof candidate.name === "string" &&
+    /rate.?limit/i.test(candidate.name)
+  ) {
+    return true;
+  }
+  if (
+    typeof candidate.code === "string" &&
+    /rate.?limit|too.?many.?requests/i.test(candidate.code)
+  ) {
+    return true;
+  }
+  return (
+    typeof candidate.message === "string" &&
+    /rate.?limit|too.?many.?requests|\b429\b/i.test(candidate.message)
+  );
+}
+
+/** Exponential backoff with jitter, capped. */
+export function rateLimitDelayMs(
+  attempt: number,
+  random: () => number = Math.random
+): number {
+  const base = Math.min(
+    RATE_LIMIT_BASE_DELAY_MS * 2 ** attempt,
+    RATE_LIMIT_MAX_DELAY_MS
+  );
+  // Half fixed, half jittered: two learners throttled at once don't retry in
+  // lockstep, and the wait never collapses to nothing either.
+  return Math.round(base / 2 + random() * (base / 2));
+}
+
+const defaultSleep = (ms: number) =>
+  new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Sign `transactions` in sub-batches, waiting out Dynamic's rate limit.
+ *
+ * Order is load-bearing — the deploy maps signature i back to chunk i — so
+ * sub-batches are signed in sequence and concatenated in order.
+ *
+ * On a blockhash refresh the WHOLE batch restarts. Refreshing only the
+ * remaining tail would leave the sub-batches signed a minute earlier holding
+ * the stale blockhash, and nothing in a batch is sent until all of it is
+ * signed — so those would be exactly the transactions that die on send.
+ */
+export async function signAllWithRateLimitBackoff(
+  transactions: Transaction[],
+  options: SignAllWithBackoffOptions
+): Promise<Transaction[]> {
+  const {
+    signAll,
+    subBatchSize = EMBEDDED_SUB_BATCH_SIZE,
+    maxAttempts = RATE_LIMIT_MAX_ATTEMPTS,
+    onRateLimitWait,
+    refreshBlockhash,
+    now = Date.now,
+    sleep = defaultSleep,
+    random = Math.random,
+  } = options;
+
+  if (transactions.length === 0) return [];
+
+  let refreshes = 0;
+  let batchStartedAt = now();
+
+  for (;;) {
+    const signed: Transaction[] = [];
+    let restart = false;
+
+    for (let i = 0; i < transactions.length && !restart; i += subBatchSize) {
+      const subBatch = transactions.slice(i, i + subBatchSize);
+
+      for (let attempt = 0; ; attempt++) {
+        try {
+          signed.push(...(await signAll(subBatch)));
+          break;
+        } catch (error) {
+          if (!isDynamicRateLimitError(error) || attempt >= maxAttempts - 1) {
+            throw error;
+          }
+
+          const waitMs = rateLimitDelayMs(attempt, random);
+          onRateLimitWait?.({ attempt: attempt + 1, waitMs });
+          await sleep(waitMs);
+
+          if (
+            refreshBlockhash &&
+            refreshes < MAX_BLOCKHASH_REFRESHES &&
+            now() - batchStartedAt > BLOCKHASH_MAX_AGE_MS
+          ) {
+            refreshes++;
+            const blockhash = await refreshBlockhash();
+            for (const tx of transactions) tx.recentBlockhash = blockhash;
+            batchStartedAt = now();
+            restart = true;
+            break;
+          }
+        }
+      }
+    }
+
+    if (!restart) return signed;
+  }
+}

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -834,7 +834,8 @@
       "refreshBalance": "Refresh",
       "connectWallet": "Connect your wallet to continue",
       "copyAddress": "Copy address",
-      "addressCopied": "Copied!"
+      "addressCopied": "Copied!",
+      "rateLimitedRetryAfter": "Devnet faucet is rate-limited. Try again in {seconds}s, or use the web faucet."
     },
     "deployment": {
       "deployToDevnet": "Deploy to Devnet",
@@ -861,7 +862,9 @@
       "buildExpired": "Build expired",
       "rebuildHint": "Click \"Run\" in the editor to rebuild, then deploy again.",
       "resolvingWallet": "Checking your wallet…",
-      "copied": "Copied!"
+      "copied": "Copied!",
+      "rateLimitWaiting": "Wallet service is busy (rate limited) — retrying in {seconds}s",
+      "rateLimitPaused": "The wallet service is still rate-limiting signatures. Nothing was lost — wait a minute and resume."
     },
     "save": {
       "recording": "Recording your deployment…",

--- a/apps/web/src/messages/es.json
+++ b/apps/web/src/messages/es.json
@@ -834,7 +834,8 @@
       "refreshBalance": "Actualizar",
       "connectWallet": "Conecta tu billetera para continuar",
       "copyAddress": "Copiar dirección",
-      "addressCopied": "¡Copiado!"
+      "addressCopied": "¡Copiado!",
+      "rateLimitedRetryAfter": "El faucet de devnet está limitado. Inténtalo en {seconds}s, o usa el faucet web."
     },
     "deployment": {
       "deployToDevnet": "Desplegar en Devnet",
@@ -861,7 +862,9 @@
       "buildExpired": "Build expirado",
       "rebuildHint": "Haz clic en \"Run\" en el editor para recompilar y despliega de nuevo.",
       "resolvingWallet": "Comprobando tu billetera…",
-      "copied": "¡Copiado!"
+      "copied": "¡Copiado!",
+      "rateLimitWaiting": "El servicio de la billetera está ocupado (límite de solicitudes) — reintentando en {seconds}s",
+      "rateLimitPaused": "El servicio de la billetera sigue limitando las firmas. No se perdió nada — espera un minuto y reanuda."
     },
     "save": {
       "recording": "Registrando tu despliegue…",

--- a/apps/web/src/messages/pt-BR.json
+++ b/apps/web/src/messages/pt-BR.json
@@ -834,7 +834,8 @@
       "refreshBalance": "Atualizar",
       "connectWallet": "Conecte sua carteira para continuar",
       "copyAddress": "Copiar endereço",
-      "addressCopied": "Copiado!"
+      "addressCopied": "Copiado!",
+      "rateLimitedRetryAfter": "O faucet da devnet está limitado. Tente de novo em {seconds}s, ou use o faucet web."
     },
     "deployment": {
       "deployToDevnet": "Deploy na Devnet",
@@ -861,7 +862,9 @@
       "buildExpired": "Build expirado",
       "rebuildHint": "Clique em \"Run\" no editor para recompilar e faça o deploy novamente.",
       "resolvingWallet": "Verificando sua carteira…",
-      "copied": "Copiado!"
+      "copied": "Copiado!",
+      "rateLimitWaiting": "O serviço da carteira está ocupado (limite de requisições) — tentando de novo em {seconds}s",
+      "rateLimitPaused": "O serviço da carteira ainda está limitando assinaturas. Nada foi perdido — espere um minuto e retome."
     },
     "save": {
       "recording": "Registrando seu deploy…",

--- a/packages/deploy/src/__tests__/airdrop.test.ts
+++ b/packages/deploy/src/__tests__/airdrop.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Keypair, LAMPORTS_PER_SOL } from "@solana/web3.js";
+
+/**
+ * The airdrop must not travel over the app's RPC connection: that endpoint is
+ * the platform's keyed Helius devnet key, and Helius meters the faucet per
+ * project (1 SOL/day for everyone put together). The public RPC meters per
+ * address instead.
+ */
+const rpc = vi.hoisted(() => ({
+  endpoints: [] as string[],
+  requestAirdrop: vi.fn(),
+  getLatestBlockhash: vi.fn(),
+  confirmTransaction: vi.fn(),
+  getBalance: vi.fn(),
+}));
+
+vi.mock("@solana/web3.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@solana/web3.js")>();
+  return {
+    ...actual,
+    Connection: class {
+      constructor(endpoint: string) {
+        rpc.endpoints.push(endpoint);
+      }
+      requestAirdrop = rpc.requestAirdrop;
+      getLatestBlockhash = rpc.getLatestBlockhash;
+      confirmTransaction = rpc.confirmTransaction;
+      getBalance = rpc.getBalance;
+    },
+  };
+});
+
+const { createAirdropRequest, DEVNET_FAUCET_ENDPOINT } =
+  await import("../airdrop");
+
+const WALLET = Keypair.generate().publicKey;
+
+beforeEach(() => {
+  rpc.endpoints.length = 0;
+  rpc.requestAirdrop.mockReset().mockResolvedValue("sig");
+  rpc.getLatestBlockhash
+    .mockReset()
+    .mockResolvedValue({ blockhash: "bh", lastValidBlockHeight: 1 });
+  rpc.confirmTransaction
+    .mockReset()
+    .mockResolvedValue({ value: { err: null } });
+  rpc.getBalance.mockReset().mockResolvedValue(2 * LAMPORTS_PER_SOL);
+});
+
+describe("createAirdropRequest", () => {
+  it("requests from the public devnet RPC, not the app's connection", async () => {
+    const result = await createAirdropRequest(WALLET);
+
+    expect(rpc.endpoints).toEqual([DEVNET_FAUCET_ENDPOINT]);
+    expect(DEVNET_FAUCET_ENDPOINT).toBe("https://api.devnet.solana.com");
+    expect(rpc.requestAirdrop).toHaveBeenCalledWith(
+      WALLET,
+      2 * LAMPORTS_PER_SOL
+    );
+    expect(result).toMatchObject({ success: true, newBalance: 2 });
+  });
+
+  it("honours an endpoint override", async () => {
+    await createAirdropRequest(WALLET, 1, {
+      endpoint: "http://localhost:8899",
+    });
+    expect(rpc.endpoints).toEqual(["http://localhost:8899"]);
+  });
+
+  it("reports the platform-wide 403 as rate limited rather than retrying it", async () => {
+    rpc.requestAirdrop.mockRejectedValue(
+      new Error(
+        "403 : {'error':'Rate limit exceeded. The devnet faucet has a limit of 1 SOL per project per day'}"
+      )
+    );
+
+    const result = await createAirdropRequest(WALLET);
+
+    expect(result).toMatchObject({ success: false, rateLimited: true });
+    expect(rpc.requestAirdrop).toHaveBeenCalledTimes(1);
+  });
+
+  it("surfaces the retry-after the faucet asked for", async () => {
+    rpc.requestAirdrop.mockRejectedValue(
+      new Error("429 Too Many Requests, retry-after: 45")
+    );
+
+    const result = await createAirdropRequest(WALLET);
+
+    expect(result.rateLimited).toBe(true);
+    expect(result.retryAfterSeconds).toBe(45);
+  });
+
+  it("leaves retryAfterSeconds unset when the faucet does not say", async () => {
+    rpc.requestAirdrop.mockRejectedValue(new Error("429 Too Many Requests"));
+
+    const result = await createAirdropRequest(WALLET);
+
+    expect(result.rateLimited).toBe(true);
+    expect(result.retryAfterSeconds).toBeUndefined();
+  });
+
+  it("retries transient failures before giving up", async () => {
+    rpc.requestAirdrop.mockRejectedValue(new Error("socket hang up"));
+
+    const result = await createAirdropRequest(WALLET);
+
+    expect(result.success).toBe(false);
+    expect(result.rateLimited).toBe(false);
+    expect(rpc.requestAirdrop).toHaveBeenCalledTimes(3);
+  });
+});

--- a/packages/deploy/src/airdrop.ts
+++ b/packages/deploy/src/airdrop.ts
@@ -1,24 +1,51 @@
 import { Connection, LAMPORTS_PER_SOL, PublicKey } from "@solana/web3.js";
 
+/**
+ * The faucet endpoint, deliberately NOT the app's RPC connection.
+ *
+ * The app talks to devnet through a keyed Helius endpoint, and Helius meters
+ * `requestAirdrop` per PROJECT: "The devnet faucet has a limit of 1 SOL per
+ * project per day". So the first learner to fund a wallet spent the whole
+ * platform's daily quota and everyone after them got a 403 — which is exactly
+ * what the owner hit on 09-09-2026 while testing the embedded-wallet deploy.
+ *
+ * The public devnet RPC meters per ADDRESS instead (2 SOL a request, with the
+ * occasional 429 when the faucet is busy), so each learner gets their own
+ * allowance. Balance reads stay on the app connection; only the airdrop moves.
+ */
+export const DEVNET_FAUCET_ENDPOINT = "https://api.devnet.solana.com";
+
 export interface AirdropResult {
   success: boolean;
   signature?: string;
   newBalance?: number;
   error?: string;
   rateLimited?: boolean;
+  /** Seconds the faucet asked us to wait, when it said. */
+  retryAfterSeconds?: number;
+}
+
+export interface AirdropOptions {
+  /** Override the faucet RPC. Tests and local validators only. */
+  endpoint?: string;
 }
 
 /**
  * Request an airdrop with exponential backoff retry.
  * Returns a structured result (never throws).
  *
- * @param amount - SOL to request (default: 2, max reliable on devnet)
+ * @param walletAddress - who to fund
+ * @param amount - SOL to request (default: 2, the public faucet's per-request cap)
  */
 export async function createAirdropRequest(
-  connection: Connection,
   walletAddress: PublicKey,
-  amount: number = 2
+  amount: number = 2,
+  options: AirdropOptions = {}
 ): Promise<AirdropResult> {
+  const connection = new Connection(
+    options.endpoint ?? DEVNET_FAUCET_ENDPOINT,
+    "confirmed"
+  );
   const lamports = amount * LAMPORTS_PER_SOL;
   const maxRetries = 3;
   let lastError = "";
@@ -52,10 +79,14 @@ export async function createAirdropRequest(
       const message = (err as Error).message ?? String(err);
       lastError = message;
 
-      // Detect rate limiting
+      // Detect rate limiting. The Helius 403 ("1 SOL per project per day") is
+      // matched by the `rate limit` test below, not by its status — a bare 403
+      // otherwise means "this endpoint won't serve you", which retrying and
+      // calling a cooldown would both misreport.
       if (
         message.includes("429") ||
         message.includes("Too Many Requests") ||
+        /rate limit/i.test(message) ||
         message.includes("airdrop request limit")
       ) {
         return {
@@ -63,6 +94,7 @@ export async function createAirdropRequest(
           error:
             "Devnet faucet is busy. Please wait 30-60 seconds and try again.",
           rateLimited: true,
+          retryAfterSeconds: parseRetryAfterSeconds(message),
         };
       }
 
@@ -78,4 +110,23 @@ export async function createAirdropRequest(
     error: `Airdrop failed after ${maxRetries} attempts: ${lastError}`,
     rateLimited: false,
   };
+}
+
+/**
+ * The wait the faucet asked for, when the error carries one.
+ *
+ * web3.js throws the response body as text, so a `Retry-After` header or a
+ * "try again in 30 seconds" body both arrive as part of the message — there is
+ * no structured field to read. Undefined when nothing plausible is there; the
+ * caller then falls back to its own cooldown.
+ */
+function parseRetryAfterSeconds(message: string): number | undefined {
+  const match =
+    /retry[- ]after[":\s]*(\d+)/i.exec(message) ??
+    /(?:try again|wait)(?: again)? in (\d+)\s*(?:second|sec|s)\b/i.exec(
+      message
+    );
+  if (!match) return undefined;
+  const seconds = Number(match[1]);
+  return Number.isFinite(seconds) && seconds > 0 ? seconds : undefined;
 }

--- a/packages/deploy/src/index.ts
+++ b/packages/deploy/src/index.ts
@@ -6,7 +6,11 @@ export {
   getCachedBinaryLength,
 } from "./deploy";
 export { estimateDeployCost, type DeployCostEstimate } from "./cost";
-export { createAirdropRequest, type AirdropResult } from "./airdrop";
+export {
+  createAirdropRequest,
+  DEVNET_FAUCET_ENDPOINT,
+  type AirdropResult,
+} from "./airdrop";
 export { CHUNK_SIZE, BPF_LOADER_UPGRADEABLE_ID } from "./constants";
 export type {
   DeployStep,


### PR DESCRIPTION
Deploying `your-first-solana-program` (74 chunks) from an embedded wallet in production stopped at chunk 3 with `WalletApiError: Rate limited`, and "Retomar Deploy" hit the same wall — Dynamic throttles its MPC wallet API and a 15-transaction `signAllTransactions` asks for 15 signatures at once. The embedded signer now signs five at a time with capped exponential backoff (2s → 30s, jittered, 8 attempts), reports each wait into the deploy log, and re-stamps the batch's shared blockhash when the waiting outlives it, since nothing in a batch is sent until all of it is signed. A deploy that runs out of attempts pauses with wording that says it's a wait, not a broken deploy. The extension-wallet path is untouched — it signs locally and is never throttled. `EMBEDDED_BATCH_SIZE` stays 15: throttling at chunk 3 means the constraint is signatures per unit time, not batch size.

The funding card's airdrop failed separately with `403 … The devnet faucet has a limit of 1 SOL per project per day`, because it went through the app's keyed Helius endpoint, where the daily cap is shared by every learner. Airdrops now go to `https://api.devnet.solana.com`, which meters per address; balance reads stay on the app connection, and a 429 surfaces the retry-after when the faucet gives one.