### PR TITLE
fix(deploy): session expiry beats rate-limit backoff, cap the faucet cooldown

### DIFF
--- a/apps/web/src/components/deploy/__tests__/wallet-funding-card-loop.test.tsx
+++ b/apps/web/src/components/deploy/__tests__/wallet-funding-card-loop.test.tsx
@@ -49,6 +49,7 @@ vi.mock("@/hooks/use-dynamic-session-state", () => ({
 
 vi.mock("@superteam-lms/deploy", () => ({
   createAirdropRequest: vi.fn(),
+  MAX_RETRY_AFTER_SECONDS: 600,
 }));
 
 function renderCard() {

--- a/apps/web/src/components/deploy/__tests__/wallet-funding-card.test.tsx
+++ b/apps/web/src/components/deploy/__tests__/wallet-funding-card.test.tsx
@@ -38,6 +38,7 @@ vi.mock("@solana/wallet-adapter-react", () => ({
 
 vi.mock("@superteam-lms/deploy", () => ({
   createAirdropRequest: h.createAirdropRequest,
+  MAX_RETRY_AFTER_SECONDS: 600,
 }));
 
 function renderCard(props?: {
@@ -120,5 +121,28 @@ describe("WalletFundingCard", () => {
       name: new RegExp(EMBEDDED.toBase58()),
     });
     expect(copyButton).toHaveTextContent("Copy address");
+  });
+
+  it("clamps a hostile retry-after instead of parking the button for a day", async () => {
+    h.createAirdropRequest.mockResolvedValue({
+      success: false,
+      rateLimited: true,
+      retryAfterSeconds: 86_400,
+    });
+    renderCard();
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Request Airdrop" })
+    );
+
+    // The countdown label shows the clamped value, not the raw day-long one.
+    expect(
+      await screen.findByRole("button", { name: "Request Airdrop (600s)" })
+    ).toBeInTheDocument();
+
+    // The faucet link stays usable regardless of the cooldown.
+    expect(
+      screen.getByRole("link", { name: "faucet.solana.com" })
+    ).toHaveAttribute("href", "https://faucet.solana.com");
   });
 });

--- a/apps/web/src/components/deploy/wallet-funding-card.tsx
+++ b/apps/web/src/components/deploy/wallet-funding-card.tsx
@@ -3,7 +3,10 @@
 import { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import { useConnection } from "@solana/wallet-adapter-react";
 import { LAMPORTS_PER_SOL, PublicKey } from "@solana/web3.js";
-import { createAirdropRequest } from "@superteam-lms/deploy";
+import {
+  createAirdropRequest,
+  MAX_RETRY_AFTER_SECONDS,
+} from "@superteam-lms/deploy";
 import { useTranslations } from "next-intl";
 import { useDeploySigner } from "@/hooks/use-deploy-signer";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -105,7 +108,12 @@ export function WalletFundingCard({
       });
       setCooldown(COOLDOWN_SECONDS);
     } else if (result.rateLimited) {
-      const retryAfter = result.retryAfterSeconds;
+      // Capped again here, defensively — `createAirdropRequest` already caps
+      // what it parses out of the faucet body, but the cooldown timer should
+      // never trust an unbounded number even if that changes upstream.
+      const retryAfter = result.retryAfterSeconds
+        ? Math.min(result.retryAfterSeconds, MAX_RETRY_AFTER_SECONDS)
+        : undefined;
       setMessage({
         text: retryAfter
           ? t("rateLimitedRetryAfter", { seconds: String(retryAfter) })

--- a/apps/web/src/lib/dynamic/__tests__/rate-limit.test.ts
+++ b/apps/web/src/lib/dynamic/__tests__/rate-limit.test.ts
@@ -71,6 +71,25 @@ describe("isDynamicRateLimitError", () => {
     );
     expect(isDynamicRateLimitError(null)).toBe(false);
   });
+
+  it("defers to session expiry when a 429 also carries UnauthorizedError", () => {
+    const ambiguous = Object.assign(new Error("Unauthorized"), {
+      name: "UnauthorizedError",
+      status: 429,
+    });
+    expect(isDynamicRateLimitError(ambiguous)).toBe(false);
+  });
+
+  it("defers to session expiry when it arrives wrapped in cause", () => {
+    const wrapped = Object.assign(new Error("Rate limited"), {
+      name: "WalletApiError",
+      status: 429,
+      cause: Object.assign(new Error("Session ended"), {
+        name: "UnauthorizedError",
+      }),
+    });
+    expect(isDynamicRateLimitError(wrapped)).toBe(false);
+  });
 });
 
 describe("rateLimitDelayMs", () => {

--- a/apps/web/src/lib/dynamic/rate-limit.ts
+++ b/apps/web/src/lib/dynamic/rate-limit.ts
@@ -1,4 +1,5 @@
 import type { Transaction } from "@solana/web3.js";
+import { isDynamicSessionExpiredError } from "./solana";
 
 /**
  * Surviving Dynamic's MPC signing throttle.
@@ -84,9 +85,17 @@ export interface SignAllWithBackoffOptions {
  * rate limit, or the message itself. `cause` is walked one level for the same
  * reason `isDynamicSessionExpiredError` does it: the WaaS signer wraps
  * failures once.
+ *
+ * Session expiry takes precedence. Dynamic can hand back a 429 whose `name`
+ * is `UnauthorizedError` (or wrap one in `cause`) — the session died and the
+ * WaaS layer's own throttling response happens to carry the same status. That
+ * shape matches both matchers; treating it as a rate limit would burn the
+ * full backoff budget before the caller ever reaches reauth. Checked first so
+ * the caller goes straight to reauth instead.
  */
 export function isDynamicRateLimitError(error: unknown): boolean {
   if (!error || typeof error !== "object") return false;
+  if (isDynamicSessionExpiredError(error)) return false;
   return (
     isRateLimited(error) || isRateLimited((error as { cause?: unknown }).cause)
   );

--- a/packages/deploy/src/__tests__/airdrop.test.ts
+++ b/packages/deploy/src/__tests__/airdrop.test.ts
@@ -31,8 +31,11 @@ vi.mock("@solana/web3.js", async (importOriginal) => {
   };
 });
 
-const { createAirdropRequest, DEVNET_FAUCET_ENDPOINT } =
-  await import("../airdrop");
+const {
+  createAirdropRequest,
+  DEVNET_FAUCET_ENDPOINT,
+  MAX_RETRY_AFTER_SECONDS,
+} = await import("../airdrop");
 
 const WALLET = Keypair.generate().publicKey;
 
@@ -99,6 +102,17 @@ describe("createAirdropRequest", () => {
 
     expect(result.rateLimited).toBe(true);
     expect(result.retryAfterSeconds).toBeUndefined();
+  });
+
+  it("caps a hostile retry-after instead of parking the button for a day", async () => {
+    rpc.requestAirdrop.mockRejectedValue(
+      new Error("429 Too Many Requests, retry-after: 86400")
+    );
+
+    const result = await createAirdropRequest(WALLET);
+
+    expect(result.rateLimited).toBe(true);
+    expect(result.retryAfterSeconds).toBe(MAX_RETRY_AFTER_SECONDS);
   });
 
   it("retries transient failures before giving up", async () => {

--- a/packages/deploy/src/airdrop.ts
+++ b/packages/deploy/src/airdrop.ts
@@ -15,6 +15,17 @@ import { Connection, LAMPORTS_PER_SOL, PublicKey } from "@solana/web3.js";
  */
 export const DEVNET_FAUCET_ENDPOINT = "https://api.devnet.solana.com";
 
+/**
+ * Ceiling for a faucet-reported `retryAfterSeconds`.
+ *
+ * The faucet's `Retry-After` is an untrusted body we regex out of a thrown
+ * message (see `parseRetryAfterSeconds`) — a body like `retry-after: 86400`
+ * would otherwise park the funding button for a full day. Capped so a
+ * misbehaving or hostile response degrades to "wait a while", not "dead
+ * button".
+ */
+export const MAX_RETRY_AFTER_SECONDS = 600;
+
 export interface AirdropResult {
   success: boolean;
   signature?: string;
@@ -128,5 +139,6 @@ function parseRetryAfterSeconds(message: string): number | undefined {
     );
   if (!match) return undefined;
   const seconds = Number(match[1]);
-  return Number.isFinite(seconds) && seconds > 0 ? seconds : undefined;
+  if (!Number.isFinite(seconds) || seconds <= 0) return undefined;
+  return Math.min(seconds, MAX_RETRY_AFTER_SECONDS);
 }

--- a/packages/deploy/src/index.ts
+++ b/packages/deploy/src/index.ts
@@ -9,6 +9,7 @@ export { estimateDeployCost, type DeployCostEstimate } from "./cost";
 export {
   createAirdropRequest,
   DEVNET_FAUCET_ENDPOINT,
+  MAX_RETRY_AFTER_SECONDS,
   type AirdropResult,
 } from "./airdrop";
 export { CHUNK_SIZE, BPF_LOADER_UPGRADEABLE_ID } from "./constants";


### PR DESCRIPTION
Two follow-ups from #1228's gate review.

`isDynamicRateLimitError` matched an error shape that also satisfies `isDynamicSessionExpiredError` (429 status + `UnauthorizedError` name, bare or wrapped in `cause`), so the backoff burned its full budget before the panel could route to reauth. Session expiry now wins that check first.

An unbounded `retryAfterSeconds` parsed from the faucet's response body could park the funding button for as long as the body claimed (`retry-after: 86400` = a day). Capped at 10 minutes in `createAirdropRequest` and clamped again defensively in the funding card's cooldown timer; the faucet.solana.com link was already unconditional.

The other two follow-ups from the gate report (pre-existing blockhash-age gap, no cancel path while the signer sleeps) are out of scope here.