### PR TITLE
feat(deploy): session-key upload for embedded wallets

### DIFF
--- a/apps/web/src/components/deploy/__tests__/deploy-panel-signer.test.tsx
+++ b/apps/web/src/components/deploy/__tests__/deploy-panel-signer.test.tsx
@@ -1,6 +1,12 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import {
+  cleanup,
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+} from "@testing-library/react";
 import { NextIntlClientProvider } from "next-intl";
 import {
   Keypair,
@@ -32,6 +38,7 @@ const h = vi.hoisted(() => ({
   deployProgram: vi.fn(),
   runSessionKeyDeploy: vi.fn(),
   startOverSessionKey: vi.fn(),
+  sweepSessionKey: vi.fn(),
   binaryLength: null as number | null,
   estimateDeployCost: vi.fn(),
   balanceLamports: 0,
@@ -84,6 +91,7 @@ vi.mock("@superteam-lms/deploy", async (importOriginal) => ({
   resumeDeployment: vi.fn(),
   runSessionKeyDeploy: h.runSessionKeyDeploy,
   startOverSessionKey: h.startOverSessionKey,
+  sweepSessionKey: h.sweepSessionKey,
   getCachedBinaryLength: () => h.binaryLength,
   estimateDeployCost: h.estimateDeployCost,
   estimateSessionKeyDeployCost: h.estimateDeployCost,
@@ -126,6 +134,11 @@ beforeEach(() => {
     rentLamports: 0,
   });
   h.signTransaction.mockReset();
+  h.sweepSessionKey.mockReset();
+  h.sweepSessionKey.mockResolvedValue({
+    signature: "sweep-sig",
+    lamports: 500,
+  });
   h.startOverSessionKey.mockReset();
   h.startOverSessionKey.mockResolvedValue({
     closeSignature: "close-sig",
@@ -235,6 +248,95 @@ describe("DeployPanel — signer resolution", () => {
     expect(transfer.fromPubkey.toBase58()).toBe(EMBEDDED);
     expect(transfer.toPubkey.equals(destination)).toBe(true);
     expect(Number(transfer.lamports)).toBe(1_234_567);
+  });
+
+  const BUILD = "build-uuid-123";
+
+  it("persists the funding signature before the transfer is broadcast", async () => {
+    const sent: string[] = [];
+    h.signTransaction.mockImplementation(async () => ({
+      signature: Buffer.alloc(64, 7),
+      serialize: () => {
+        sent.push("broadcast");
+        return new Uint8Array([1, 2, 3]);
+      },
+    }));
+    renderPanel();
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Deploy to Devnet" })
+    );
+    await waitFor(() => expect(h.runSessionKeyDeploy).toHaveBeenCalledTimes(1));
+
+    const { fund } = h.runSessionKeyDeploy.mock.calls[0]![0];
+    const reported: string[] = [];
+    await fund(1_000, Keypair.generate().publicKey, (sig: string) =>
+      reported.push(sig)
+    );
+
+    expect(reported).toHaveLength(1);
+    expect(sent).toEqual(["broadcast"]);
+  });
+
+  it("a retry after a funded attempt reuses that key instead of funding a new one", async () => {
+    // The first attempt funds a key, then throws — a dropped confirmation.
+    const secret = Array.from(Keypair.generate().secretKey);
+    const sessionPubkey = Keypair.generate().publicKey;
+    h.runSessionKeyDeploy.mockImplementation(
+      async (params: {
+        events: {
+          onSessionKey: (s: number[], k: PublicKey) => Promise<void> | void;
+          onFundingBroadcast: (info: { signature: string }) => void;
+        };
+      }) => {
+        await params.events.onSessionKey(secret, sessionPubkey);
+        params.events.onFundingBroadcast({ signature: "first-fund-sig" });
+        throw new Error(
+          "Timed out waiting for the funding transfer to confirm."
+        );
+      }
+    );
+    renderPanel();
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Deploy to Devnet" })
+    );
+    await waitFor(() => expect(h.runSessionKeyDeploy).toHaveBeenCalledTimes(1));
+
+    // Nothing resumable was saved — the buffer never existed — so the learner
+    // comes back to a panel offering a plain Deploy. That must not walk away
+    // from the key their SOL is already sitting in.
+    await screen.findByRole("button", { name: "Start Over" });
+    cleanup();
+    h.runSessionKeyDeploy.mockReset();
+    h.runSessionKeyDeploy.mockResolvedValue({
+      programId: PROGRAM_ID,
+      programIdPubkey: new PublicKey(PROGRAM_ID),
+      totalChunks: 3,
+      durationMs: 1000,
+      rentLamports: 0,
+      sessionKeySecret: secret,
+      fundedLamports: 0,
+      authoritySignature: "authority-sig",
+      refundLamports: 0,
+      refundError: null,
+    });
+    renderPanel();
+    // The panel keeps the key and drops the (absent) offset — that rewrite is
+    // how we know the restore has run.
+    await waitFor(() =>
+      expect(
+        sessionStorage.getItem(`deploy-state-${EMBEDDED.slice(0, 8)}-${BUILD}`)
+      ).toContain('"deployment":null')
+    );
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Deploy to Devnet" })
+    );
+
+    await waitFor(() => expect(h.runSessionKeyDeploy).toHaveBeenCalledTimes(1));
+    const retry = h.runSessionKeyDeploy.mock.calls[0]![0];
+    expect(retry.persistedSessionKey).toEqual(secret);
+    expect(retry.pendingFundingSignature).toBe("first-fund-sig");
   });
 
   it("takes the mismatch check from the signer's key, not the adapter's", async () => {
@@ -356,6 +458,80 @@ describe("DeployPanel — session-key resume and start over", () => {
     expect(call.bufferKeypairSecret).toEqual(deployment.bufferKeypairSecret);
     expect(call.destination.toBase58()).toBe(EMBEDDED);
     expect(sessionStorage.length).toBe(0);
+  });
+
+  it("keeps the stranded key's address after a reload, and offers to copy it", async () => {
+    // A reload: the record survives in sessionStorage, but the wrapping nonce
+    // died with the page, so the ciphertext no longer decrypts.
+    sessionStorage.setItem(
+      `deploy-state-${EMBEDDED.slice(0, 8)}-${BUILD}`,
+      JSON.stringify({
+        deployment,
+        session: "dGhpcyBpcyBub3QgZGVjcnlwdGFibGUgYW55IG1vcmU=",
+        sessionAddress: "StrandedSessionKeyAddress",
+        fundingSignature: "fund-sig",
+      })
+    );
+    const writeText = vi.fn(async () => undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      configurable: true,
+    });
+
+    renderPanel();
+
+    // The address is shown, not forgotten — it is the only record of where the
+    // learner's SOL went.
+    const notice = await screen.findByRole("alert");
+    expect(notice).toHaveTextContent("StrandedSessionKeyAddress");
+    fireEvent.click(screen.getByRole("button", { name: "Copy address" }));
+    await waitFor(() =>
+      expect(writeText).toHaveBeenCalledWith("StrandedSessionKeyAddress")
+    );
+
+    // And it survives the next reload too.
+    const stored = JSON.parse(
+      sessionStorage.getItem(`deploy-state-${EMBEDDED.slice(0, 8)}-${BUILD}`)!
+    );
+    expect(stored).toMatchObject({
+      deployment: null,
+      session: null,
+      sessionAddress: "StrandedSessionKeyAddress",
+    });
+  });
+
+  it("warns before the transfer that a reload strands the funds", async () => {
+    renderPanel();
+    await screen.findByRole("button", { name: "Deploy to Devnet" });
+    expect(
+      screen.getByText(/reloading the page during the upload/i)
+    ).toBeInTheDocument();
+  });
+
+  it("retries the sweep when start over could not return the SOL", async () => {
+    await seedPausedSession();
+    h.startOverSessionKey.mockRejectedValueOnce(new Error("rpc down"));
+    renderPanel();
+
+    fireEvent.click(await screen.findByRole("button", { name: "Start Over" }));
+
+    const retry = await screen.findByRole("button", { name: "Retry refund" });
+    expect(screen.getByText(/SessionKeyAddress/)).toBeInTheDocument();
+
+    fireEvent.click(retry);
+
+    // The retry runs the same close-and-sweep, with the key start over was
+    // about to throw away — not a no-op on a cleared session.
+    await waitFor(() => expect(h.startOverSessionKey).toHaveBeenCalledTimes(2));
+    const call = h.startOverSessionKey.mock.calls[1]![0];
+    expect(call.sessionKeySecret).toEqual(SESSION_SECRET);
+    expect(call.bufferKeypairSecret).toEqual(deployment.bufferKeypairSecret);
+    expect(call.destination.toBase58()).toBe(EMBEDDED);
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("button", { name: "Retry refund" })
+      ).not.toBeInTheDocument()
+    );
   });
 
   it("drops a saved state whose program keypair is not this build's", async () => {

--- a/apps/web/src/components/deploy/__tests__/deploy-panel-signer.test.tsx
+++ b/apps/web/src/components/deploy/__tests__/deploy-panel-signer.test.tsx
@@ -2,9 +2,15 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { NextIntlClientProvider } from "next-intl";
-import { Keypair, LAMPORTS_PER_SOL, PublicKey } from "@solana/web3.js";
+import {
+  Keypair,
+  LAMPORTS_PER_SOL,
+  PublicKey,
+  SystemInstruction,
+} from "@solana/web3.js";
 import { EMBEDDED_BATCH_SIZE } from "@/hooks/use-deploy-signer";
 import messages from "@/messages/en.json";
+import { encryptSessionKey } from "@/lib/deploy/session-key-storage";
 import { DeployPanel } from "../deploy-panel";
 
 /**
@@ -24,6 +30,8 @@ const h = vi.hoisted(() => ({
   signTransaction: vi.fn(),
   signAllTransactions: vi.fn(),
   deployProgram: vi.fn(),
+  runSessionKeyDeploy: vi.fn(),
+  startOverSessionKey: vi.fn(),
   binaryLength: null as number | null,
   estimateDeployCost: vi.fn(),
   balanceLamports: 0,
@@ -52,7 +60,14 @@ vi.mock("@/hooks/use-deploy-signer", async (importOriginal) => ({
 vi.mock("@solana/wallet-adapter-react", () => ({
   useWallet: () => ({ publicKey: null }),
   useConnection: () => ({
-    connection: { getBalance: async () => h.balanceLamports },
+    connection: {
+      getBalance: async () => h.balanceLamports,
+      getLatestBlockhash: async () => ({
+        blockhash: "11111111111111111111111111111111",
+        lastValidBlockHeight: 1,
+      }),
+      sendRawTransaction: async () => "fund-sig",
+    },
   }),
 }));
 
@@ -63,11 +78,15 @@ vi.mock("@/lib/auth/auth-provider", () => ({
   }),
 }));
 
-vi.mock("@superteam-lms/deploy", () => ({
+vi.mock("@superteam-lms/deploy", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@superteam-lms/deploy")>()),
   deployProgram: h.deployProgram,
   resumeDeployment: vi.fn(),
+  runSessionKeyDeploy: h.runSessionKeyDeploy,
+  startOverSessionKey: h.startOverSessionKey,
   getCachedBinaryLength: () => h.binaryLength,
   estimateDeployCost: h.estimateDeployCost,
+  estimateSessionKeyDeployCost: h.estimateDeployCost,
   createAirdropRequest: vi.fn(async () => ({ success: false, error: "no" })),
 }));
 
@@ -106,11 +125,31 @@ beforeEach(() => {
     durationMs: 1000,
     rentLamports: 0,
   });
+  h.signTransaction.mockReset();
+  h.startOverSessionKey.mockReset();
+  h.startOverSessionKey.mockResolvedValue({
+    closeSignature: "close-sig",
+    refund: { signature: "refund-sig", lamports: 500 },
+  });
+  h.runSessionKeyDeploy.mockReset();
+  h.runSessionKeyDeploy.mockResolvedValue({
+    programId: PROGRAM_ID,
+    programIdPubkey: new PublicKey(PROGRAM_ID),
+    totalChunks: 3,
+    durationMs: 1000,
+    rentLamports: 0,
+    sessionKeySecret: Array.from(Keypair.generate().secretKey),
+    fundedLamports: 1_300_000_000,
+    authoritySignature: "authority-sig",
+    refundLamports: 1_000,
+    refundError: null,
+  });
   h.estimateDeployCost.mockReset();
   h.trackEvent.mockReset();
   h.isSessionExpired.mockReset();
   h.isSessionExpired.mockReturnValue(false);
   localStorage.clear();
+  sessionStorage.clear();
   vi.stubGlobal(
     "fetch",
     vi.fn(async (_url: string, init?: RequestInit) => {
@@ -149,21 +188,53 @@ describe("DeployPanel — signer resolution", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("deploys with the embedded signer and its batch size", async () => {
+  it("routes the embedded wallet through the session key, with one wallet signature", async () => {
     renderPanel();
 
     fireEvent.click(
       await screen.findByRole("button", { name: "Deploy to Devnet" })
     );
 
-    await waitFor(() => expect(h.deployProgram).toHaveBeenCalledTimes(1));
-    const call = h.deployProgram.mock.calls[0]![0];
-    expect(call.batchSize).toBe(EMBEDDED_BATCH_SIZE);
-    expect(call.wallet.publicKey.toBase58()).toBe(EMBEDDED);
+    await waitFor(() => expect(h.runSessionKeyDeploy).toHaveBeenCalledTimes(1));
+    // The MPC-signed upload batches are gone: nothing goes through
+    // deployProgram, and the wallet's only job is the funding transfer.
+    expect(h.deployProgram).not.toHaveBeenCalled();
+    const call = h.runSessionKeyDeploy.mock.calls[0]![0];
+    expect(call.learner.toBase58()).toBe(EMBEDDED);
+    expect(call.buildUuid).toBe("build-uuid-123");
+    expect(typeof call.fund).toBe("function");
     expect(h.trackEvent).toHaveBeenCalledWith("deploy_started", {
       signerKind: "embedded",
-      batchSize: EMBEDDED_BATCH_SIZE,
+      batchSize: null,
+      resumed: false,
     });
+  });
+
+  it("funds from the learner with exactly one wallet signature", async () => {
+    h.signTransaction.mockResolvedValue({
+      serialize: () => new Uint8Array([1, 2, 3]),
+    });
+    renderPanel();
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Deploy to Devnet" })
+    );
+    await waitFor(() => expect(h.runSessionKeyDeploy).toHaveBeenCalledTimes(1));
+
+    const { fund } = h.runSessionKeyDeploy.mock.calls[0]![0];
+    const destination = Keypair.generate().publicKey;
+    const signature = await fund(1_234_567, destination);
+
+    expect(signature).toBe("fund-sig");
+    // One MPC signature for the whole deploy — that is the entire point of the
+    // session key — and it pays from the learner into the session key.
+    expect(h.signTransaction).toHaveBeenCalledTimes(1);
+    const tx = h.signTransaction.mock.calls[0]![0];
+    expect(tx.feePayer.toBase58()).toBe(EMBEDDED);
+    const transfer = SystemInstruction.decodeTransfer(tx.instructions[0]);
+    expect(transfer.fromPubkey.toBase58()).toBe(EMBEDDED);
+    expect(transfer.toPubkey.equals(destination)).toBe(true);
+    expect(Number(transfer.lamports)).toBe(1_234_567);
   });
 
   it("takes the mismatch check from the signer's key, not the adapter's", async () => {
@@ -175,7 +246,7 @@ describe("DeployPanel — signer resolution", () => {
   });
 
   it("a session that expires mid-deploy pauses for re-auth instead of erroring", async () => {
-    h.deployProgram.mockRejectedValue(new Error("session gone"));
+    h.runSessionKeyDeploy.mockRejectedValue(new Error("session gone"));
     h.isSessionExpired.mockReturnValue(true);
     renderPanel();
 
@@ -229,5 +300,82 @@ describe("DeployPanel — funding gate", () => {
     });
     expect(button).toBeEnabled();
     expect(screen.queryByText("Fund Your Wallet")).not.toBeInTheDocument();
+  });
+});
+
+describe("DeployPanel — session-key resume and start over", () => {
+  const BUILD = "build-uuid-123";
+  const SESSION_SECRET = Array.from(Keypair.generate().secretKey);
+  const deployment = {
+    buildUuid: BUILD,
+    bufferKeypairSecret: Array.from(Keypair.generate().secretKey),
+    programKeypairSecret: Array.from(Keypair.generate().secretKey),
+    lastUploadedChunk: 12,
+    totalChunks: 74,
+    phase: "uploading" as const,
+  };
+
+  async function seedPausedSession() {
+    const session = await encryptSessionKey(SESSION_SECRET, BUILD);
+    sessionStorage.setItem(
+      `deploy-state-${EMBEDDED.slice(0, 8)}-${BUILD}`,
+      JSON.stringify({
+        deployment,
+        session,
+        sessionAddress: "SessionKeyAddress",
+      })
+    );
+  }
+
+  it("resumes from the saved offset with the same session key — no second transfer", async () => {
+    await seedPausedSession();
+    renderPanel();
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Resume Deployment" })
+    );
+
+    await waitFor(() => expect(h.runSessionKeyDeploy).toHaveBeenCalledTimes(1));
+    const call = h.runSessionKeyDeploy.mock.calls[0]![0];
+    expect(call.persistedSessionKey).toEqual(SESSION_SECRET);
+    expect(call.resumeState).toMatchObject({
+      lastUploadedChunk: 12,
+      totalChunks: 74,
+    });
+  });
+
+  it("start over closes the buffer and sweeps the session key back first", async () => {
+    await seedPausedSession();
+    renderPanel();
+
+    fireEvent.click(await screen.findByRole("button", { name: "Start Over" }));
+
+    await waitFor(() => expect(h.startOverSessionKey).toHaveBeenCalledTimes(1));
+    const call = h.startOverSessionKey.mock.calls[0]![0];
+    expect(call.sessionKeySecret).toEqual(SESSION_SECRET);
+    expect(call.bufferKeypairSecret).toEqual(deployment.bufferKeypairSecret);
+    expect(call.destination.toBase58()).toBe(EMBEDDED);
+    expect(sessionStorage.length).toBe(0);
+  });
+
+  it("drops a saved state whose program keypair is not this build's", async () => {
+    await seedPausedSession();
+    render(
+      <NextIntlClientProvider locale="en" messages={messages}>
+        <DeployPanel
+          buildUuid={BUILD}
+          lessonId="lesson-1"
+          courseSlug="btc-to-sol-evolution"
+          courseId="course-btc-to-sol"
+          programKeypairSecret={Array.from(Keypair.generate().secretKey)}
+        />
+      </NextIntlClientProvider>
+    );
+
+    // No resume is offered, and the crafted record is gone rather than reused.
+    expect(
+      await screen.findByRole("button", { name: "Deploy to Devnet" })
+    ).toBeInTheDocument();
+    expect(sessionStorage.length).toBe(0);
   });
 });

--- a/apps/web/src/components/deploy/__tests__/deploy-panel.test.tsx
+++ b/apps/web/src/components/deploy/__tests__/deploy-panel.test.tsx
@@ -2,7 +2,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { NextIntlClientProvider } from "next-intl";
-import { PublicKey } from "@solana/web3.js";
+import { Keypair, PublicKey } from "@solana/web3.js";
 import messages from "@/messages/en.json";
 import { DeployPanel } from "../deploy-panel";
 
@@ -38,7 +38,8 @@ vi.mock("@/lib/auth/auth-provider", () => ({
   }),
 }));
 
-vi.mock("@superteam-lms/deploy", () => ({
+vi.mock("@superteam-lms/deploy", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@superteam-lms/deploy")>()),
   deployProgram: h.deployProgram,
   resumeDeployment: vi.fn(),
   // No binary is cached in this suite, so the funding gate reads nothing and
@@ -159,8 +160,10 @@ describe("DeployPanel — saved deploy state is wallet-scoped", () => {
       `deploy-state-${wallet.slice(0, 8)}-${BUILD_UUID}`,
       JSON.stringify({
         buildUuid: BUILD_UUID,
-        bufferKeypairSecret: [],
-        programKeypairSecret: [],
+        // Real keypair secrets: the panel now validates saved state before
+        // offering a resume, and a malformed one is dropped.
+        bufferKeypairSecret: Array.from(Keypair.generate().secretKey),
+        programKeypairSecret: Array.from(Keypair.generate().secretKey),
         lastUploadedChunk: 3,
         totalChunks: 10,
         phase: "uploading",

--- a/apps/web/src/components/deploy/deploy-panel.tsx
+++ b/apps/web/src/components/deploy/deploy-panel.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import { useConnection } from "@solana/wallet-adapter-react";
 import { LAMPORTS_PER_SOL, PublicKey } from "@solana/web3.js";
+import bs58 from "bs58";
 import {
   createFundingTransfer,
   deployProgram,
@@ -189,6 +190,20 @@ export function DeployPanel({
   // the learner does not own it yet and the server record is refused.
   const [claim, setClaim] = useState<DeployResult | null>(null);
   const [refundFailed, setRefundFailed] = useState(false);
+  // A reload took the wrapping nonce with it, so the key that holds the
+  // learner's SOL can no longer be signed with. Its address is all that is
+  // left, and the panel keeps showing it until a new deploy replaces it.
+  const [lostSessionAddress, setLostSessionAddress] = useState<string | null>(
+    null
+  );
+  const lostSessionAddressRef = useRef<string | null>(null);
+  const [lostCopied, setLostCopied] = useState(false);
+  // A start-over sweep that rejected. Held so "retry refund" has a key to
+  // sweep WITH — `resetSession` runs before the sweep settles.
+  const strandedSweepRef = useRef<{
+    secret: number[];
+    bufferKeypairSecret: number[] | null;
+  } | null>(null);
 
   // Extension wallet or Dynamic embedded wallet — the deploy is signed and paid
   // by whichever one this learner actually has. A throttled embedded signing
@@ -275,14 +290,41 @@ export function DeployPanel({
     deployment: null,
     session: null,
     sessionAddress: null,
+    fundingSignature: null,
   });
 
   const persistStored = useCallback(() => {
     writeDeployState(buildUuid, walletPrefix, storedRef.current);
   }, [buildUuid, walletPrefix]);
 
+  const rememberLostAddress = useCallback((address: string | null) => {
+    lostSessionAddressRef.current = address;
+    setLostSessionAddress(address);
+  }, []);
+
+  /**
+   * Drop the saved deploy, keeping the stranded key's address if there is one.
+   * That address is not UI state — it is the only record of where a reload sent
+   * the learner's SOL, and it outlives the deploy that created it.
+   */
+  const clearStored = useCallback(() => {
+    const lost = lostSessionAddressRef.current;
+    if (!lost) {
+      clearDeployState(buildUuid, walletPrefix);
+      return;
+    }
+    storedRef.current = {
+      deployment: null,
+      session: null,
+      sessionAddress: lost,
+      fundingSignature: null,
+    };
+    writeDeployState(buildUuid, walletPrefix, storedRef.current);
+  }, [buildUuid, walletPrefix]);
+
   const resetSession = useCallback(() => {
     sessionSecretRef.current = null;
+    strandedSweepRef.current = null;
     setSessionAddress(null);
     setClaim(null);
     setRefundFailed(false);
@@ -290,6 +332,7 @@ export function DeployPanel({
       deployment: null,
       session: null,
       sessionAddress: null,
+      fundingSignature: null,
     };
   }, []);
 
@@ -464,14 +507,17 @@ export function DeployPanel({
     if (!stored) return;
 
     const deployment = stored.deployment;
-    if (
-      !deployment ||
-      deployment.phase === "complete" ||
-      !isResumableDeploymentState(deployment, {
+    const resumable =
+      deployment &&
+      deployment.phase !== "complete" &&
+      isResumableDeploymentState(deployment, {
         buildUuid,
         programKeypairSecret,
-      })
-    ) {
+      });
+
+    // Dropped without waiting on the decrypt: a state that is neither
+    // resumable nor attached to a funded key has nothing worth reading.
+    if (!resumable && !(stored.session && stored.fundingSignature)) {
       clearDeployState(buildUuid, walletPrefix);
       return;
     }
@@ -483,8 +529,39 @@ export function DeployPanel({
         ? await decryptSessionKey(stored.session, buildUuid)
         : null;
       if (cancelled) return;
+
+      // A reload. The key is unrecoverable, but it is where the learner's SOL
+      // went — so the record is kept down to its address, and shown, rather
+      // than deleted along with the only way to find the funds again.
       if (stored.session && !secret) {
-        clearDeployState(buildUuid, walletPrefix);
+        if (!stored.sessionAddress) {
+          clearDeployState(buildUuid, walletPrefix);
+          return;
+        }
+        storedRef.current = {
+          deployment: null,
+          session: null,
+          sessionAddress: stored.sessionAddress,
+          fundingSignature: stored.fundingSignature,
+        };
+        writeDeployState(buildUuid, walletPrefix, storedRef.current);
+        rememberLostAddress(stored.sessionAddress);
+        return;
+      }
+      // Nothing to resume from — but a key with a funding signature against it
+      // is a key an earlier attempt may have paid into, and the offset is not
+      // what makes it worth keeping. Keep it (and only it, never the state that
+      // failed validation) so the next Deploy carries it over instead of
+      // transferring a second time.
+      if (!resumable) {
+        if (!secret) {
+          clearDeployState(buildUuid, walletPrefix);
+          return;
+        }
+        sessionSecretRef.current = secret;
+        setSessionAddress(stored.sessionAddress);
+        storedRef.current = { ...stored, deployment: null };
+        writeDeployState(buildUuid, walletPrefix, storedRef.current);
         return;
       }
       sessionSecretRef.current = secret;
@@ -497,7 +574,7 @@ export function DeployPanel({
     return () => {
       cancelled = true;
     };
-  }, [buildUuid, walletPrefix, programKeypairSecret]);
+  }, [buildUuid, walletPrefix, programKeypairSecret, rememberLostAddress]);
 
   // Build deployment callbacks
   const buildCallbacks = useCallback((): DeploymentCallbacks => {
@@ -582,7 +659,7 @@ export function DeployPanel({
       setResult(deployResult);
       setPanelState("success");
       setClaim(null);
-      clearDeployState(buildUuid, walletPrefix);
+      clearStored();
 
       // Save program ID + stats to localStorage for use in later lessons and refresh.
       // Keys are scoped by wallet to prevent cross-user cache leaks.
@@ -624,7 +701,7 @@ export function DeployPanel({
       // failed save is surfaced with a retry, never silently swallowed (#622).
       runSave(deployResult);
     },
-    [buildUuid, courseSlug, lessonId, walletPrefix, runSave, signerKind]
+    [clearStored, courseSlug, lessonId, walletPrefix, runSave, signerKind]
   );
 
   /**
@@ -632,7 +709,11 @@ export function DeployPanel({
    * session key. Built with the learner as payer so the fee is theirs too.
    */
   const fundSessionKey = useCallback(
-    async (lamports: number, to: PublicKey): Promise<string> => {
+    async (
+      lamports: number,
+      to: PublicKey,
+      onSignature: (signature: string) => void
+    ): Promise<string> => {
       if (!signer?.publicKey) throw new Error("Wallet not connected");
       const { blockhash } = await connection.getLatestBlockhash("confirmed");
       const tx = createFundingTransfer({
@@ -642,6 +723,11 @@ export function DeployPanel({
         blockhash,
       });
       const signed = await signer.signTransaction(tx);
+      // The signature exists as soon as the wallet signs, and a send that
+      // throws can still have reached the cluster. Report it BEFORE
+      // broadcasting, so a retry can ask what happened instead of transferring
+      // a second time.
+      if (signed.signature) onSignature(bs58.encode(signed.signature));
       return connection.sendRawTransaction(signed.serialize());
     },
     [signer, connection]
@@ -652,6 +738,19 @@ export function DeployPanel({
     async (resume: { state: DeploymentState; secret: number[] } | null) => {
       if (!signer?.publicKey) return;
       const learner = signer.publicKey;
+
+      // A "fresh" deploy that follows an attempt which already funded a key is
+      // not fresh: that key holds the learner's SOL. Generating a new one over
+      // it would transfer a second time and orphan the first, so the key is
+      // carried over and `runSessionKeyDeploy` decides from the chain whether
+      // it still needs funding at all.
+      const carryOver =
+        !resume && sessionSecretRef.current
+          ? {
+              secret: sessionSecretRef.current,
+              fundingSignature: storedRef.current.fundingSignature,
+            }
+          : null;
 
       setPanelState("deploying");
       setErrorMessage(null);
@@ -672,11 +771,19 @@ export function DeployPanel({
         saveCancelledRef.current = true;
         // A fresh run gets a fresh key; leaving the previous run's buffer in
         // the record would offer a resume pairing a new key with an old buffer.
-        storedRef.current = {
-          deployment: null,
-          session: null,
-          sessionAddress: null,
-        };
+        storedRef.current = carryOver
+          ? {
+              deployment: null,
+              session: storedRef.current.session,
+              sessionAddress: storedRef.current.sessionAddress,
+              fundingSignature: storedRef.current.fundingSignature,
+            }
+          : {
+              deployment: null,
+              session: null,
+              sessionAddress: null,
+              fundingSignature: null,
+            };
       }
 
       trackEvent("deploy_started", {
@@ -693,19 +800,29 @@ export function DeployPanel({
           fund: fundSessionKey,
           callbacks: buildCallbacks(),
           programKeypairSecret,
-          persistedSessionKey: resume?.secret ?? null,
+          persistedSessionKey: resume?.secret ?? carryOver?.secret ?? null,
           resumeState: resume?.state ?? null,
+          pendingFundingSignature: carryOver?.fundingSignature ?? null,
           events: {
             onSessionKey: async (secret, sessionPubkey) => {
               // Persisted BEFORE the transfer: a crash right after it would
               // otherwise strand the funds with no key left to spend them.
               sessionSecretRef.current = secret;
               setSessionAddress(sessionPubkey.toBase58());
+              // This record now names a key that CAN be signed with.
+              rememberLostAddress(null);
               const ciphertext = await encryptSessionKey(secret, buildUuid);
               storedRef.current = {
                 ...storedRef.current,
                 session: ciphertext,
                 sessionAddress: sessionPubkey.toBase58(),
+              };
+              persistStored();
+            },
+            onFundingBroadcast: ({ signature }) => {
+              storedRef.current = {
+                ...storedRef.current,
+                fundingSignature: signature,
               };
               persistStored();
             },
@@ -736,7 +853,9 @@ export function DeployPanel({
         // The deploy landed but ownership did not move: the program is live and
         // paid for, so this is a claim-ownership retry, not a failed deploy.
         if (err instanceof OwnershipTransferError) {
-          sessionSecretRef.current = err.sessionKeySecret;
+          // The secret is already in `sessionSecretRef` (persisted from
+          // `onSessionKey`); the error carries only addresses.
+          setSessionAddress(err.sessionKeyAddress.toBase58());
           setClaim(err.deployResult);
           setErrorMessage(t("ownershipFailed"));
           setPanelState("paused");
@@ -785,6 +904,7 @@ export function DeployPanel({
       handleSuccess,
       logPhase,
       persistStored,
+      rememberLostAddress,
       costLamports,
       t,
     ]
@@ -841,23 +961,42 @@ export function DeployPanel({
     t,
   ]);
 
-  /** Retry a sweep that failed after an otherwise complete deploy. */
+  /**
+   * Retry a sweep that failed — after a complete deploy, or after a start over.
+   *
+   * Those need different transactions: a start over still has a buffer holding
+   * rent, so it retries the close-and-sweep, not the sweep alone. Which one is
+   * decided by whether `handleStartOver` left a stranded key behind.
+   */
   const handleRetryRefund = useCallback(async () => {
-    const secret = sessionSecretRef.current;
+    const stranded = strandedSweepRef.current;
+    const secret = stranded?.secret ?? sessionSecretRef.current;
     if (!secret || !signer?.publicKey) return;
+    const destination = signer.publicKey;
     try {
-      const refund = await sweepSessionKey({
-        connection,
-        sessionKeySecret: secret,
-        destination: signer.publicKey,
-      });
+      const refund = stranded
+        ? (
+            await startOverSessionKey({
+              connection,
+              sessionKeySecret: secret,
+              bufferKeypairSecret: stranded.bufferKeypairSecret,
+              destination,
+            })
+          ).refund
+        : await sweepSessionKey({
+            connection,
+            sessionKeySecret: secret,
+            destination,
+          });
       if (refund) {
         trackEvent("deploy_refunded", {
           signerKind,
           lamports: refund.lamports,
         });
       }
+      strandedSweepRef.current = null;
       setRefundFailed(false);
+      setSessionAddress(null);
     } catch {
       // Still failing — the warning stays, with its retry.
     }
@@ -956,7 +1095,7 @@ export function DeployPanel({
       // authority is that key, so a fresh deploy (and transfer) is the only way
       // forward.
       if (!secret) {
-        setErrorMessage(t("sessionKeyLost"));
+        setErrorMessage(t("sessionKeyLost", { address: sessionAddress ?? "" }));
         setPanelState("paused");
         return;
       }
@@ -1013,6 +1152,7 @@ export function DeployPanel({
     batchSize,
     connection,
     savedState,
+    sessionAddress,
     buildCallbacks,
     handleSuccess,
     isEmbedded,
@@ -1028,10 +1168,13 @@ export function DeployPanel({
     const secret = sessionSecretRef.current;
     if (secret && signer?.publicKey) {
       const destination = signer.publicKey;
+      const address = sessionAddress;
+      const bufferKeypairSecret =
+        storedRef.current.deployment?.bufferKeypairSecret ?? null;
       void startOverSessionKey({
         connection,
         sessionKeySecret: secret,
-        bufferKeypairSecret: storedRef.current.deployment?.bufferKeypairSecret,
+        bufferKeypairSecret,
         destination,
       })
         .then((outcome) => {
@@ -1042,10 +1185,17 @@ export function DeployPanel({
             });
           }
         })
-        .catch(() => setRefundFailed(true));
+        .catch(() => {
+          // The reset below has already run, so the retry would have no key to
+          // sweep with. Hand it this one back, along with the address the
+          // warning names.
+          strandedSweepRef.current = { secret, bufferKeypairSecret };
+          setSessionAddress(address);
+          setRefundFailed(true);
+        });
     }
 
-    clearDeployState(buildUuid, walletPrefix);
+    clearStored();
     resetSession();
     setSavedState(null);
     setPanelState("ready");
@@ -1058,7 +1208,14 @@ export function DeployPanel({
     setCurrentStep("buffer");
     setSaveStatus("idle");
     saveCancelledRef.current = true;
-  }, [buildUuid, walletPrefix, connection, signer, signerKind, resetSession]);
+  }, [
+    clearStored,
+    connection,
+    signer,
+    signerKind,
+    sessionAddress,
+    resetSession,
+  ]);
 
   // Copy program ID
   const handleCopyProgramId = useCallback(async () => {
@@ -1071,6 +1228,51 @@ export function DeployPanel({
       // clipboard API unavailable
     }
   }, [result]);
+
+  const handleCopyLostAddress = useCallback(async () => {
+    if (!lostSessionAddress) return;
+    try {
+      await navigator.clipboard.writeText(lostSessionAddress);
+      setLostCopied(true);
+      setTimeout(() => setLostCopied(false), 2000);
+    } catch {
+      // clipboard API unavailable
+    }
+  }, [lostSessionAddress]);
+
+  /**
+   * The sweep is the one step allowed to fail without failing the deploy: the
+   * program is live and owned by the learner either way. Rendered wherever the
+   * panel can land after a failed sweep — success AND, after a start over,
+   * ready — so the retry is never a button on a screen nobody reaches.
+   */
+  const refundWarning = refundFailed ? (
+    <div className="flex flex-wrap items-center gap-2 rounded-md bg-yellow-500/10 px-3 py-2 text-xs text-yellow-500">
+      <span className="flex-1">
+        {t("refundFailed", { address: sessionAddress ?? "" })}
+      </span>
+      <Button size="sm" variant="outline" onClick={handleRetryRefund}>
+        {t("retryRefund")}
+      </Button>
+    </div>
+  ) : null;
+
+  /**
+   * A reload took the key that holds the learner's SOL. Nothing here can spend
+   * it, so the panel does the one useful thing left: name the account, in a
+   * form they can copy into a wallet or the explorer.
+   */
+  const lostKeyNotice = lostSessionAddress ? (
+    <div
+      role="alert"
+      className="space-y-2 rounded-md bg-yellow-500/10 px-3 py-2 text-xs text-yellow-500"
+    >
+      <p>{t("sessionKeyLost", { address: lostSessionAddress })}</p>
+      <Button size="sm" variant="outline" onClick={handleCopyLostAddress}>
+        {lostCopied ? t("copied") : t("copyAddress")}
+      </Button>
+    </div>
+  ) : null;
 
   // Chunk progress percentage
   const chunkPercent =
@@ -1195,18 +1397,7 @@ export function DeployPanel({
             </div>
           )}
 
-          {/* The sweep is the one step allowed to fail without failing the
-              deploy: the program is live and owned by the learner either way. */}
-          {refundFailed && (
-            <div className="flex flex-wrap items-center gap-2 rounded-md bg-yellow-500/10 px-3 py-2 text-xs text-yellow-500">
-              <span className="flex-1">
-                {t("refundFailed", { address: sessionAddress ?? "" })}
-              </span>
-              <Button size="sm" variant="outline" onClick={handleRetryRefund}>
-                {t("retryRefund")}
-              </Button>
-            </div>
-          )}
+          {refundWarning}
 
           {/* Server-record status — the deploy only counts toward the capstone
               credential once it's recorded; un-recorded shows a retry. */}
@@ -1459,6 +1650,9 @@ export function DeployPanel({
             </div>
           )}
 
+          {lostKeyNotice}
+          {refundWarning}
+
           {needsReauth && (
             <LinkedWalletPrompt
               variant="reauth"
@@ -1555,6 +1749,9 @@ export function DeployPanel({
           <span className="text-xs text-muted-foreground">Build: </span>
           <span className="font-mono text-xs">{buildUuid.slice(0, 12)}...</span>
         </div>
+
+        {lostKeyNotice}
+        {refundWarning}
 
         {/* Pre-flight: warn (don't block) when this deploy won't be recorded
             against the wallet the learner is connected with. */}

--- a/apps/web/src/components/deploy/deploy-panel.tsx
+++ b/apps/web/src/components/deploy/deploy-panel.tsx
@@ -4,10 +4,18 @@ import { useState, useEffect, useCallback, useRef } from "react";
 import { useConnection } from "@solana/wallet-adapter-react";
 import { LAMPORTS_PER_SOL, PublicKey } from "@solana/web3.js";
 import {
+  createFundingTransfer,
   deployProgram,
   estimateDeployCost,
+  estimateSessionKeyDeployCost,
   getCachedBinaryLength,
+  isResumableDeploymentState,
+  OwnershipTransferError,
   resumeDeployment,
+  runSessionKeyDeploy,
+  startOverSessionKey,
+  sweepSessionKey,
+  transferProgramAuthority,
   type DeploymentCallbacks,
   type DeploymentState,
   type DeployResult,
@@ -23,6 +31,14 @@ import {
   saveDeploymentWithRetry,
   type SaveStatus,
 } from "@/lib/deploy/save-deployment";
+import {
+  clearDeployState,
+  decryptSessionKey,
+  encryptSessionKey,
+  readDeployState,
+  writeDeployState,
+  type StoredDeployState,
+} from "@/lib/deploy/session-key-storage";
 import { useDeploySigner } from "@/hooks/use-deploy-signer";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -61,62 +77,10 @@ type PanelState = "ready" | "deploying" | "success" | "paused" | "error";
 // ---------------------------------------------------------------------------
 
 const EXPLORER_BASE = "https://explorer.solana.com";
-const STORAGE_PREFIX = "deploy-state-";
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-/**
- * Saved deploy state is scoped by wallet, like the localStorage keys below: a
- * resume replays a buffer the PAYER owns, so offering one learner's paused
- * deploy to the next wallet on the same browser is both a leak and a resume
- * that cannot succeed. With no wallet resolved there is no key, so nothing is
- * read or written — by the time a deploy runs there is always a signer.
- */
-function sessionKey(buildUuid: string, walletPrefix: string): string | null {
-  if (!walletPrefix) return null;
-  return `${STORAGE_PREFIX}${walletPrefix}-${buildUuid}`;
-}
-
-function loadSavedState(
-  buildUuid: string,
-  walletPrefix: string
-): DeploymentState | null {
-  const key = sessionKey(buildUuid, walletPrefix);
-  if (!key) return null;
-  try {
-    const raw = sessionStorage.getItem(key);
-    if (!raw) return null;
-    return JSON.parse(raw) as DeploymentState;
-  } catch {
-    return null;
-  }
-}
-
-function savePersistentState(
-  buildUuid: string,
-  walletPrefix: string,
-  state: DeploymentState
-): void {
-  const key = sessionKey(buildUuid, walletPrefix);
-  if (!key) return;
-  try {
-    sessionStorage.setItem(key, JSON.stringify(state));
-  } catch {
-    // sessionStorage full or unavailable — non-critical
-  }
-}
-
-function clearSavedState(buildUuid: string, walletPrefix: string): void {
-  const key = sessionKey(buildUuid, walletPrefix);
-  if (!key) return;
-  try {
-    sessionStorage.removeItem(key);
-  } catch {
-    // ignore
-  }
-}
 
 function truncateSig(sig: string): string {
   return sig.slice(0, 8);
@@ -225,6 +189,14 @@ export function DeployPanel({
   const [costLamports, setCostLamports] = useState<number | null>(null);
   const [balanceLamports, setBalanceLamports] = useState<number | null>(null);
   const fundingTrackedRef = useRef(false);
+  // Session-key upload (embedded wallets): the local key that pays for and
+  // signs the whole upload after the wallet's single funding signature.
+  const sessionSecretRef = useRef<number[] | null>(null);
+  const [sessionAddress, setSessionAddress] = useState<string | null>(null);
+  // The deploy landed but the upgrade authority is still the session key —
+  // the learner does not own it yet and the server record is refused.
+  const [claim, setClaim] = useState<DeployResult | null>(null);
+  const [refundFailed, setRefundFailed] = useState(false);
 
   // Timing
   const startTimeRef = useRef<number>(0);
@@ -274,6 +246,35 @@ export function DeployPanel({
   // Wallet-scoped localStorage key prefix to prevent cross-user cache leaks
   const walletPrefix = publicKey ? publicKey.toBase58().slice(0, 8) : "";
 
+  // An embedded wallet signs through Dynamic's rate-limited MPC service, so it
+  // signs ONE transaction (the funding transfer) and a local session key signs
+  // the rest. Extension wallets are unchanged: they sign their own batches.
+  const isEmbedded = signerKind === "embedded";
+
+  // Everything worth resuming, in one record: the upload offset and the
+  // encrypted session key that owns the buffer that offset points into.
+  const storedRef = useRef<StoredDeployState>({
+    deployment: null,
+    session: null,
+    sessionAddress: null,
+  });
+
+  const persistStored = useCallback(() => {
+    writeDeployState(buildUuid, walletPrefix, storedRef.current);
+  }, [buildUuid, walletPrefix]);
+
+  const resetSession = useCallback(() => {
+    sessionSecretRef.current = null;
+    setSessionAddress(null);
+    setClaim(null);
+    setRefundFailed(false);
+    storedRef.current = {
+      deployment: null,
+      session: null,
+      sessionAddress: null,
+    };
+  }, []);
+
   // Pre-flight wallet check: the server records a deploy against the LINKED
   // wallet (profiles.wallet_address), while the deploy signs with the CONNECTED
   // wallet. When they differ, a successful deploy can't be recorded and the
@@ -309,7 +310,11 @@ export function DeployPanel({
     (async () => {
       try {
         const [estimate, lamports] = await Promise.all([
-          estimateDeployCost(connection, programLen),
+          // The embedded path funds a session key, which then pays for two more
+          // transactions of its own — gate on what will actually be transferred.
+          isEmbedded
+            ? estimateSessionKeyDeployCost(connection, programLen)
+            : estimateDeployCost(connection, programLen),
           connection.getBalance(payer, "confirmed"),
         ]);
         if (cancelled) return;
@@ -323,7 +328,7 @@ export function DeployPanel({
     return () => {
       cancelled = true;
     };
-  }, [gateActive, signer, connection, buildUuid]);
+  }, [gateActive, signer, connection, buildUuid, isEmbedded]);
 
   const shortfallLamports =
     costLamports !== null && balanceLamports !== null
@@ -429,14 +434,52 @@ export function DeployPanel({
     };
   }, [lessonId, courseId, courseSlug, walletPrefix]);
 
-  // Check for resumable state on mount
+  // Check for resumable state on mount.
+  //
+  // sessionStorage is writable by anything on this origin, and a resume replays
+  // rent-paying transactions against the accounts the state names, so the state
+  // is validated against this build and its injected program keypair before it
+  // is offered — and dropped, not repaired, when it fails.
   useEffect(() => {
-    const existing = loadSavedState(buildUuid, walletPrefix);
-    if (existing && existing.phase !== "complete") {
-      setSavedState(existing);
-      setPanelState("paused");
+    let cancelled = false;
+    const stored = readDeployState(buildUuid, walletPrefix);
+    if (!stored) return;
+
+    const deployment = stored.deployment;
+    if (
+      !deployment ||
+      deployment.phase === "complete" ||
+      !isResumableDeploymentState(deployment, {
+        buildUuid,
+        programKeypairSecret,
+      })
+    ) {
+      clearDeployState(buildUuid, walletPrefix);
+      return;
     }
-  }, [buildUuid, walletPrefix]);
+
+    (async () => {
+      // No session key means the adapter path (or a reload that took the
+      // wrapping nonce with it): a session-key deploy cannot resume without it.
+      const secret = stored.session
+        ? await decryptSessionKey(stored.session, buildUuid)
+        : null;
+      if (cancelled) return;
+      if (stored.session && !secret) {
+        clearDeployState(buildUuid, walletPrefix);
+        return;
+      }
+      sessionSecretRef.current = secret;
+      setSessionAddress(stored.sessionAddress);
+      storedRef.current = stored;
+      setSavedState(deployment);
+      setPanelState("paused");
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [buildUuid, walletPrefix, programKeypairSecret]);
 
   // Build deployment callbacks
   const buildCallbacks = useCallback((): DeploymentCallbacks => {
@@ -471,14 +514,26 @@ export function DeployPanel({
         setPanelState(error.retryable ? "paused" : "error");
       },
       onStateUpdate: (state: DeploymentState) => {
-        savePersistentState(buildUuid, walletPrefix, state);
+        storedRef.current = { ...storedRef.current, deployment: state };
+        persistStored();
         setSavedState(state);
       },
       onBatchStart: (info) => {
         setBatchInfo(info);
       },
     };
-  }, [buildUuid, walletPrefix]);
+  }, [persistStored]);
+
+  /** One log line per phase, alongside the per-chunk lines from the package. */
+  const logPhase = useCallback(
+    (signature: string, step: DeployStep, message: string) => {
+      setTxLog((prev) => [
+        ...prev,
+        { signature, step, message, timestamp: Date.now() },
+      ]);
+    },
+    []
+  );
 
   // Persist the deploy to the server (source of truth for the credential
   // gate), retrying transient failures with backoff and surfacing the outcome
@@ -508,7 +563,8 @@ export function DeployPanel({
     (deployResult: DeployResult) => {
       setResult(deployResult);
       setPanelState("success");
-      clearSavedState(buildUuid, walletPrefix);
+      setClaim(null);
+      clearDeployState(buildUuid, walletPrefix);
 
       // Save program ID + stats to localStorage for use in later lessons and refresh.
       // Keys are scoped by wallet to prevent cross-user cache leaks.
@@ -553,9 +609,236 @@ export function DeployPanel({
     [buildUuid, courseSlug, lessonId, walletPrefix, runSave, signerKind]
   );
 
+  /**
+   * The learner's single signature: a transfer of the estimated cost into the
+   * session key. Built with the learner as payer so the fee is theirs too.
+   */
+  const fundSessionKey = useCallback(
+    async (lamports: number, to: PublicKey): Promise<string> => {
+      if (!signer?.publicKey) throw new Error("Wallet not connected");
+      const { blockhash } = await connection.getLatestBlockhash("confirmed");
+      const tx = createFundingTransfer({
+        learner: signer.publicKey,
+        sessionKey: to,
+        lamports,
+        blockhash,
+      });
+      const signed = await signer.signTransaction(tx);
+      return connection.sendRawTransaction(signed.serialize());
+    },
+    [signer, connection]
+  );
+
+  /** Deploy (or resume) through a local session key — the embedded path. */
+  const runEmbedded = useCallback(
+    async (resume: { state: DeploymentState; secret: number[] } | null) => {
+      if (!signer?.publicKey) return;
+      const learner = signer.publicKey;
+
+      setPanelState("deploying");
+      setErrorMessage(null);
+      setBatchInfo(null);
+      setSessionExpired(false);
+      setRefundFailed(false);
+      setClaim(null);
+      startTimeRef.current = Date.now();
+      if (resume) {
+        setChunkCurrent(resume.state.lastUploadedChunk + 1);
+        setChunkTotal(resume.state.totalChunks);
+      } else {
+        setTxLog([]);
+        setChunkCurrent(0);
+        setChunkTotal(0);
+        setResult(null);
+        setSaveStatus("idle");
+        saveCancelledRef.current = true;
+        // A fresh run gets a fresh key; leaving the previous run's buffer in
+        // the record would offer a resume pairing a new key with an old buffer.
+        storedRef.current = {
+          deployment: null,
+          session: null,
+          sessionAddress: null,
+        };
+      }
+
+      trackEvent("deploy_started", {
+        signerKind,
+        batchSize: null,
+        resumed: Boolean(resume),
+      });
+
+      try {
+        const deployResult = await runSessionKeyDeploy({
+          connection,
+          learner,
+          buildUuid,
+          fund: fundSessionKey,
+          callbacks: buildCallbacks(),
+          programKeypairSecret,
+          persistedSessionKey: resume?.secret ?? null,
+          resumeState: resume?.state ?? null,
+          events: {
+            onSessionKey: async (secret, sessionPubkey) => {
+              // Persisted BEFORE the transfer: a crash right after it would
+              // otherwise strand the funds with no key left to spend them.
+              sessionSecretRef.current = secret;
+              setSessionAddress(sessionPubkey.toBase58());
+              const ciphertext = await encryptSessionKey(secret, buildUuid);
+              storedRef.current = {
+                ...storedRef.current,
+                session: ciphertext,
+                sessionAddress: sessionPubkey.toBase58(),
+              };
+              persistStored();
+            },
+            onFunded: ({ lamports, signature }) => {
+              trackEvent("deploy_session_key_funded", {
+                signerKind,
+                lamports,
+              });
+              logPhase(signature, "buffer", t("logFunded"));
+            },
+            onOwnershipTransferred: ({ signature }) => {
+              trackEvent("deploy_ownership_transferred", {
+                signerKind,
+                lamports: costLamports ?? 0,
+              });
+              logPhase(signature, "finalize", t("logOwnershipTransferred"));
+            },
+            onRefunded: ({ signature, lamports }) => {
+              trackEvent("deploy_refunded", { signerKind, lamports });
+              logPhase(signature, "complete", t("logRefunded"));
+            },
+            onRefundFailed: () => setRefundFailed(true),
+          },
+        });
+
+        handleSuccess(deployResult);
+      } catch (err) {
+        // The deploy landed but ownership did not move: the program is live and
+        // paid for, so this is a claim-ownership retry, not a failed deploy.
+        if (err instanceof OwnershipTransferError) {
+          sessionSecretRef.current = err.sessionKeySecret;
+          setClaim(err.deployResult);
+          setErrorMessage(t("ownershipFailed"));
+          setPanelState("paused");
+          return;
+        }
+        if (isDynamicSessionExpiredError(err)) {
+          trackEvent("deploy_session_expired", {
+            signerKind,
+            phase: resume ? "resume" : "deploy",
+          });
+          setSessionExpired(true);
+          setReauthDismissed(false);
+          setPanelState("paused");
+          return;
+        }
+        const message = err instanceof Error ? err.message : String(err);
+        setErrorMessage(message);
+        setPanelState(
+          message.toLowerCase().includes("expired") || message.includes("404")
+            ? "error"
+            : "paused"
+        );
+      }
+    },
+    [
+      signer,
+      signerKind,
+      connection,
+      buildUuid,
+      programKeypairSecret,
+      fundSessionKey,
+      buildCallbacks,
+      handleSuccess,
+      logPhase,
+      persistStored,
+      costLamports,
+      t,
+    ]
+  );
+
+  /** Re-run only the SetAuthority step after it failed post-deploy. */
+  const handleClaimOwnership = useCallback(async () => {
+    const secret = sessionSecretRef.current;
+    if (!claim || !secret || !signer?.publicKey) return;
+    const learner = signer.publicKey;
+    setErrorMessage(null);
+    try {
+      const signature = await transferProgramAuthority({
+        connection,
+        sessionKeySecret: secret,
+        programId: claim.programIdPubkey,
+        newAuthority: learner,
+      });
+      trackEvent("deploy_ownership_transferred", {
+        signerKind,
+        lamports: costLamports ?? 0,
+      });
+      logPhase(signature, "finalize", t("logOwnershipTransferred"));
+
+      try {
+        const refund = await sweepSessionKey({
+          connection,
+          sessionKeySecret: secret,
+          destination: learner,
+        });
+        if (refund) {
+          trackEvent("deploy_refunded", {
+            signerKind,
+            lamports: refund.lamports,
+          });
+          logPhase(refund.signature, "complete", t("logRefunded"));
+        }
+      } catch {
+        setRefundFailed(true);
+      }
+
+      handleSuccess(claim);
+    } catch (err) {
+      setErrorMessage(err instanceof Error ? err.message : String(err));
+    }
+  }, [
+    claim,
+    signer,
+    signerKind,
+    connection,
+    costLamports,
+    handleSuccess,
+    logPhase,
+    t,
+  ]);
+
+  /** Retry a sweep that failed after an otherwise complete deploy. */
+  const handleRetryRefund = useCallback(async () => {
+    const secret = sessionSecretRef.current;
+    if (!secret || !signer?.publicKey) return;
+    try {
+      const refund = await sweepSessionKey({
+        connection,
+        sessionKeySecret: secret,
+        destination: signer.publicKey,
+      });
+      if (refund) {
+        trackEvent("deploy_refunded", {
+          signerKind,
+          lamports: refund.lamports,
+        });
+      }
+      setRefundFailed(false);
+    } catch {
+      // Still failing — the warning stays, with its retry.
+    }
+  }, [signer, signerKind, connection]);
+
   // Deploy handler
   const handleDeploy = useCallback(async () => {
     if (!signer || needsFunding) return;
+    if (isEmbedded) {
+      await runEmbedded(null);
+      return;
+    }
 
     setPanelState("deploying");
     setTxLog([]);
@@ -618,11 +901,26 @@ export function DeployPanel({
     programKeypairSecret,
     buildCallbacks,
     handleSuccess,
+    isEmbedded,
+    runEmbedded,
   ]);
 
   // Resume handler
   const handleResume = useCallback(async () => {
     if (!signer || !savedState) return;
+    if (isEmbedded) {
+      const secret = sessionSecretRef.current;
+      // Without the session key there is nothing to resume WITH: the buffer's
+      // authority is that key, so a fresh deploy (and transfer) is the only way
+      // forward.
+      if (!secret) {
+        setErrorMessage(t("sessionKeyLost"));
+        setPanelState("paused");
+        return;
+      }
+      await runEmbedded({ state: savedState, secret });
+      return;
+    }
 
     setPanelState("deploying");
     setErrorMessage(null);
@@ -668,11 +966,38 @@ export function DeployPanel({
     savedState,
     buildCallbacks,
     handleSuccess,
+    isEmbedded,
+    runEmbedded,
+    t,
   ]);
 
   // Start over handler
   const handleStartOver = useCallback(() => {
-    clearSavedState(buildUuid, walletPrefix);
+    // A session key that is about to be discarded still holds the learner's
+    // SOL, and its buffer still holds rent. Close and sweep before the key is
+    // gone; both are best effort — a devnet balance must not block a retry.
+    const secret = sessionSecretRef.current;
+    if (secret && signer?.publicKey) {
+      const destination = signer.publicKey;
+      void startOverSessionKey({
+        connection,
+        sessionKeySecret: secret,
+        bufferKeypairSecret: storedRef.current.deployment?.bufferKeypairSecret,
+        destination,
+      })
+        .then((outcome) => {
+          if (outcome.refund) {
+            trackEvent("deploy_refunded", {
+              signerKind,
+              lamports: outcome.refund.lamports,
+            });
+          }
+        })
+        .catch(() => setRefundFailed(true));
+    }
+
+    clearDeployState(buildUuid, walletPrefix);
+    resetSession();
     setSavedState(null);
     setPanelState("ready");
     setTxLog([]);
@@ -684,7 +1009,7 @@ export function DeployPanel({
     setCurrentStep("buffer");
     setSaveStatus("idle");
     saveCancelledRef.current = true;
-  }, [buildUuid, walletPrefix]);
+  }, [buildUuid, walletPrefix, connection, signer, signerKind, resetSession]);
 
   // Copy program ID
   const handleCopyProgramId = useCallback(async () => {
@@ -818,6 +1143,19 @@ export function DeployPanel({
                   {(result.rentLamports / LAMPORTS_PER_SOL).toFixed(4)} SOL
                 </p>
               </div>
+            </div>
+          )}
+
+          {/* The sweep is the one step allowed to fail without failing the
+              deploy: the program is live and owned by the learner either way. */}
+          {refundFailed && (
+            <div className="flex flex-wrap items-center gap-2 rounded-md bg-yellow-500/10 px-3 py-2 text-xs text-yellow-500">
+              <span className="flex-1">
+                {t("refundFailed", { address: sessionAddress ?? "" })}
+              </span>
+              <Button size="sm" variant="outline" onClick={handleRetryRefund}>
+                {t("retryRefund")}
+              </Button>
             </div>
           )}
 
@@ -1077,8 +1415,19 @@ export function DeployPanel({
             />
           )}
 
+          {/* The program is deployed and paid for; only the authority handover
+              is missing, and it is the one step this button re-runs. */}
+          {claim && (
+            <div className="bg-muted/30 space-y-2 rounded-md p-3">
+              <p className="break-all font-mono text-xs">{claim.programId}</p>
+              <Button onClick={handleClaimOwnership} className="w-full">
+                {t("claimOwnership")}
+              </Button>
+            </div>
+          )}
+
           <div className="flex gap-2">
-            {!isExpired && savedState && (
+            {!isExpired && !claim && savedState && (
               <Button
                 onClick={handleResume}
                 className="flex-1"
@@ -1144,7 +1493,9 @@ export function DeployPanel({
       </CardHeader>
       <CardContent className="space-y-4">
         <p className="text-sm text-muted-foreground">{t("description")}</p>
-        <p className="text-xs text-muted-foreground">{t("batchExplainer")}</p>
+        <p className="text-xs text-muted-foreground">
+          {isEmbedded ? t("sessionKeyNotice") : t("batchExplainer")}
+        </p>
 
         {/* Build UUID */}
         <div className="bg-muted/30 rounded-md px-3 py-2">

--- a/apps/web/src/hooks/__tests__/use-deploy-signer.test.tsx
+++ b/apps/web/src/hooks/__tests__/use-deploy-signer.test.tsx
@@ -172,6 +172,29 @@ describe("useDeploySigner", () => {
     vi.useRealTimers();
   });
 
+  it("waits out a rate limit on the single funding signature too", async () => {
+    vi.useFakeTimers();
+    dynamic.account = { address: EMBEDDED_KEY.toBase58() };
+    const rateLimited = new Error("Rate limited");
+    rateLimited.name = "WalletApiError";
+    const tx = new Transaction();
+    dynamic.signWithDynamicWallet
+      .mockRejectedValueOnce(rateLimited)
+      .mockResolvedValue(tx);
+
+    const onRateLimitWait = vi.fn();
+    const { result } = renderHook(() => useDeploySigner({ onRateLimitWait }));
+    // On the session-key deploy this is the ONLY remote signature there is —
+    // the funding transfer. Failing it fails the deploy before a lamport moves.
+    const pending = result.current.signer!.signTransaction(tx);
+    await vi.runAllTimersAsync();
+
+    await expect(pending).resolves.toBe(tx);
+    expect(dynamic.signWithDynamicWallet).toHaveBeenCalledTimes(2);
+    expect(onRateLimitWait).toHaveBeenCalledOnce();
+    vi.useRealTimers();
+  });
+
   it("leaves the adapter path unwrapped", async () => {
     wallet.publicKey = ADAPTER_KEY;
     const txs = Array.from({ length: 12 }, () => new Transaction());

--- a/apps/web/src/hooks/use-deploy-signer.ts
+++ b/apps/web/src/hooks/use-deploy-signer.ts
@@ -163,8 +163,24 @@ export function useDeploySigner(
           // The MPC signer attaches its signature to the transaction it is
           // given rather than rebuilding it, so these are safe to hand a
           // partially-signed tx (the buffer/program keypair's signature).
-          signTransaction: async (tx) =>
-            (await signWithDynamicWallet(tx, activeAccount())) as typeof tx,
+          //
+          // Through the same backoff as the batch path. On the session-key
+          // deploy this is the ONLY remote signature there is — the funding
+          // transfer — so a throttled call here fails the whole deploy before
+          // a lamport moves, where a wait of a few seconds would have carried
+          // it. One transaction, one sub-batch.
+          signTransaction: async (tx) => {
+            const [signed] = await signAllWithRateLimitBackoff([tx], {
+              signAll: async (batch) => [
+                await signWithDynamicWallet(batch[0]!, activeAccount()),
+              ],
+              onRateLimitWait: (info) => onRateLimitWaitRef.current?.(info),
+              refreshBlockhash: async () =>
+                (await connectionRef.current.getLatestBlockhash("confirmed"))
+                  .blockhash,
+            });
+            return signed as typeof tx;
+          },
           // Dynamic throttles this call (see rate-limit.ts): sub-batched,
           // retried with backoff, and re-stamped with a fresh blockhash when
           // the waiting outlives the one the batch arrived with.

--- a/apps/web/src/lib/deploy/__tests__/session-key-storage.test.ts
+++ b/apps/web/src/lib/deploy/__tests__/session-key-storage.test.ts
@@ -56,17 +56,19 @@ describe("deploy state storage", () => {
     phase: "uploading" as const,
   };
 
-  it("round-trips the deployment, the wrapped key and its address", () => {
+  it("round-trips the deployment, the wrapped key, its address and funding", () => {
     writeDeployState(BUILD, WALLET, {
       deployment,
       session: "cipher",
       sessionAddress: "SessionAddr",
+      fundingSignature: "fund-sig",
     });
 
     expect(readDeployState(BUILD, WALLET)).toEqual({
       deployment,
       session: "cipher",
       sessionAddress: "SessionAddr",
+      fundingSignature: "fund-sig",
     });
     clearDeployState(BUILD, WALLET);
     expect(readDeployState(BUILD, WALLET)).toBeNull();
@@ -77,6 +79,7 @@ describe("deploy state storage", () => {
       deployment,
       session: null,
       sessionAddress: null,
+      fundingSignature: null,
     });
     expect(readDeployState(BUILD, "9WzDXwBb")).toBeNull();
 
@@ -89,6 +92,25 @@ describe("deploy state storage", () => {
       deployment,
       session: null,
       sessionAddress: null,
+      fundingSignature: null,
+    });
+  });
+
+  it("keeps a record that is nothing but the stranded key's address", () => {
+    // What a reload leaves behind: no deployment, no decryptable secret, and
+    // the one field that still means something.
+    writeDeployState(BUILD, WALLET, {
+      deployment: null,
+      session: null,
+      sessionAddress: "StrandedAddr",
+      fundingSignature: null,
+    });
+
+    expect(readDeployState(BUILD, WALLET)).toEqual({
+      deployment: null,
+      session: null,
+      sessionAddress: "StrandedAddr",
+      fundingSignature: null,
     });
   });
 });

--- a/apps/web/src/lib/deploy/__tests__/session-key-storage.test.ts
+++ b/apps/web/src/lib/deploy/__tests__/session-key-storage.test.ts
@@ -1,0 +1,94 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach } from "vitest";
+import { Keypair } from "@solana/web3.js";
+import {
+  clearDeployState,
+  decryptSessionKey,
+  encryptSessionKey,
+  readDeployState,
+  writeDeployState,
+} from "../session-key-storage";
+
+const BUILD = "build-uuid-123";
+const WALLET = "B7o8NfV8";
+
+beforeEach(() => {
+  sessionStorage.clear();
+});
+
+describe("session-key encryption", () => {
+  it("round-trips a session key secret", async () => {
+    const secret = Array.from(Keypair.generate().secretKey);
+    const ciphertext = await encryptSessionKey(secret, BUILD);
+
+    expect(ciphertext).not.toBeNull();
+    // Nothing recognisable from the secret survives into storage.
+    expect(ciphertext).not.toContain(secret.slice(0, 8).join(","));
+    expect(await decryptSessionKey(ciphertext!, BUILD)).toEqual(secret);
+  });
+
+  it("gives two encryptions of the same secret different ciphertexts", async () => {
+    const secret = Array.from(Keypair.generate().secretKey);
+    const a = await encryptSessionKey(secret, BUILD);
+    const b = await encryptSessionKey(secret, BUILD);
+    expect(a).not.toBe(b);
+  });
+
+  it("refuses a ciphertext bound to another build, or a tampered one", async () => {
+    const secret = Array.from(Keypair.generate().secretKey);
+    const ciphertext = (await encryptSessionKey(secret, BUILD))!;
+
+    expect(await decryptSessionKey(ciphertext, "other-build")).toBeNull();
+    expect(
+      await decryptSessionKey(`AAAA${ciphertext.slice(4)}`, BUILD)
+    ).toBeNull();
+    expect(await decryptSessionKey("not-base64-at-all!!", BUILD)).toBeNull();
+  });
+});
+
+describe("deploy state storage", () => {
+  const deployment = {
+    buildUuid: BUILD,
+    bufferKeypairSecret: Array.from(Keypair.generate().secretKey),
+    programKeypairSecret: Array.from(Keypair.generate().secretKey),
+    lastUploadedChunk: 3,
+    totalChunks: 10,
+    phase: "uploading" as const,
+  };
+
+  it("round-trips the deployment, the wrapped key and its address", () => {
+    writeDeployState(BUILD, WALLET, {
+      deployment,
+      session: "cipher",
+      sessionAddress: "SessionAddr",
+    });
+
+    expect(readDeployState(BUILD, WALLET)).toEqual({
+      deployment,
+      session: "cipher",
+      sessionAddress: "SessionAddr",
+    });
+    clearDeployState(BUILD, WALLET);
+    expect(readDeployState(BUILD, WALLET)).toBeNull();
+  });
+
+  it("stays wallet-scoped and reads back a pre-session-key record", () => {
+    writeDeployState(BUILD, WALLET, {
+      deployment,
+      session: null,
+      sessionAddress: null,
+    });
+    expect(readDeployState(BUILD, "9WzDXwBb")).toBeNull();
+
+    // The shape written before session keys existed: the DeploymentState alone.
+    sessionStorage.setItem(
+      `deploy-state-${WALLET}-legacy`,
+      JSON.stringify(deployment)
+    );
+    expect(readDeployState("legacy", WALLET)).toEqual({
+      deployment,
+      session: null,
+      sessionAddress: null,
+    });
+  });
+});

--- a/apps/web/src/lib/deploy/session-key-storage.ts
+++ b/apps/web/src/lib/deploy/session-key-storage.ts
@@ -23,9 +23,12 @@ import type { DeploymentState } from "@superteam-lms/deploy";
  * not change that, and no browser-side scheme would.
  *
  * The in-memory nonce also means a full page reload loses the ability to
- * decrypt. That costs nothing extra: the compiled binary lives in an in-memory
- * cache too, so a reload already forces a rebuild — and the panel warns before
- * the transfer that a lost page strands the (devnet, valueless) balance.
+ * decrypt. The compiled binary lives in an in-memory cache too, so a reload
+ * already forces a rebuild — and the panel warns before the transfer that it
+ * strands whatever the key holds. What survives a reload is the session key's
+ * ADDRESS: the record is kept, minus the parts that are now useless, so the
+ * panel can name the account the (devnet, valueless) balance is sitting in
+ * instead of forgetting it ever existed.
  */
 
 const STORAGE_PREFIX = "deploy-state-";
@@ -37,8 +40,17 @@ export interface StoredDeployState {
   deployment: DeploymentState | null;
   /** AES-GCM ciphertext of the session key's 64-byte secret, or null. */
   session: string | null;
-  /** The session key's address — shown when a refund needs a retry. */
+  /**
+   * The session key's address — shown when a refund needs a retry, and kept
+   * after a reload has taken the decryption nonce with it: it is then the only
+   * record of where the learner's SOL went.
+   */
   sessionAddress: string | null;
+  /**
+   * The funding transfer's signature, written before it was broadcast. A retry
+   * asks the cluster about it rather than transferring a second time.
+   */
+  fundingSignature: string | null;
 }
 
 /**
@@ -71,6 +83,10 @@ export function readDeployState(
           typeof stored.sessionAddress === "string"
             ? stored.sessionAddress
             : null,
+        fundingSignature:
+          typeof stored.fundingSignature === "string"
+            ? stored.fundingSignature
+            : null,
       };
     }
     // Pre-session-key shape: the DeploymentState written directly.
@@ -78,6 +94,7 @@ export function readDeployState(
       deployment: parsed as DeploymentState,
       session: null,
       sessionAddress: null,
+      fundingSignature: null,
     };
   } catch {
     return null;

--- a/apps/web/src/lib/deploy/session-key-storage.ts
+++ b/apps/web/src/lib/deploy/session-key-storage.ts
@@ -1,0 +1,206 @@
+import type { DeploymentState } from "@superteam-lms/deploy";
+
+/**
+ * Wallet-scoped `sessionStorage` for a deploy in progress — the resume offset,
+ * and on the embedded path the session key that paid for it.
+ *
+ * ## Threat model for the encryption
+ *
+ * The session key is a spendable Solana key holding roughly the cost of one
+ * devnet deploy. It has to survive a pause (that is the point: a resume must
+ * not need a second funding transfer), and the only place it can survive is
+ * this origin's `sessionStorage`.
+ *
+ * What the AES-GCM wrapper is for: a storage dump — a synced or backed-up
+ * profile directory, a devtools/extension read of stored values, a support
+ * screenshot — yields ciphertext, not a key. The wrapping key is derived by
+ * HKDF from a 32-byte nonce generated per page load and never persisted, so
+ * nothing on disk can decrypt it later.
+ *
+ * What it is NOT for, and cannot be: code already executing on this page. Such
+ * code can read the in-memory nonce, or simply ask this module to decrypt. An
+ * XSS on this origin owns the session key either way; encryption at rest does
+ * not change that, and no browser-side scheme would.
+ *
+ * The in-memory nonce also means a full page reload loses the ability to
+ * decrypt. That costs nothing extra: the compiled binary lives in an in-memory
+ * cache too, so a reload already forces a rebuild — and the panel warns before
+ * the transfer that a lost page strands the (devnet, valueless) balance.
+ */
+
+const STORAGE_PREFIX = "deploy-state-";
+const NONCE_BYTES = 32;
+const IV_BYTES = 12;
+const HKDF_INFO = "superteam-deploy-session-key";
+
+export interface StoredDeployState {
+  deployment: DeploymentState | null;
+  /** AES-GCM ciphertext of the session key's 64-byte secret, or null. */
+  session: string | null;
+  /** The session key's address — shown when a refund needs a retry. */
+  sessionAddress: string | null;
+}
+
+/**
+ * Saved deploy state is scoped by wallet: a resume replays a buffer the PAYER
+ * owns, so offering one learner's paused deploy to the next wallet on the same
+ * browser is both a leak and a resume that cannot succeed.
+ */
+function storageKey(buildUuid: string, walletPrefix: string): string | null {
+  if (!walletPrefix) return null;
+  return `${STORAGE_PREFIX}${walletPrefix}-${buildUuid}`;
+}
+
+export function readDeployState(
+  buildUuid: string,
+  walletPrefix: string
+): StoredDeployState | null {
+  const key = storageKey(buildUuid, walletPrefix);
+  if (!key) return null;
+  try {
+    const raw = sessionStorage.getItem(key);
+    if (!raw) return null;
+    const parsed: unknown = JSON.parse(raw);
+    if (typeof parsed !== "object" || parsed === null) return null;
+    if ("deployment" in parsed) {
+      const stored = parsed as Partial<StoredDeployState>;
+      return {
+        deployment: stored.deployment ?? null,
+        session: typeof stored.session === "string" ? stored.session : null,
+        sessionAddress:
+          typeof stored.sessionAddress === "string"
+            ? stored.sessionAddress
+            : null,
+      };
+    }
+    // Pre-session-key shape: the DeploymentState written directly.
+    return {
+      deployment: parsed as DeploymentState,
+      session: null,
+      sessionAddress: null,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function writeDeployState(
+  buildUuid: string,
+  walletPrefix: string,
+  state: StoredDeployState
+): void {
+  const key = storageKey(buildUuid, walletPrefix);
+  if (!key) return;
+  try {
+    sessionStorage.setItem(key, JSON.stringify(state));
+  } catch {
+    // sessionStorage full or unavailable — non-critical.
+  }
+}
+
+export function clearDeployState(
+  buildUuid: string,
+  walletPrefix: string
+): void {
+  const key = storageKey(buildUuid, walletPrefix);
+  if (!key) return;
+  try {
+    sessionStorage.removeItem(key);
+  } catch {
+    // ignore
+  }
+}
+
+let wrappingNonce: Uint8Array | null = null;
+
+function getNonce(): Uint8Array {
+  if (!wrappingNonce) {
+    wrappingNonce = crypto.getRandomValues(new Uint8Array(NONCE_BYTES));
+  }
+  return wrappingNonce;
+}
+
+async function deriveKey(buildUuid: string): Promise<CryptoKey> {
+  const encoder = new TextEncoder();
+  const base = await crypto.subtle.importKey(
+    "raw",
+    getNonce() as BufferSource,
+    "HKDF",
+    false,
+    ["deriveKey"]
+  );
+  return crypto.subtle.deriveKey(
+    {
+      name: "HKDF",
+      hash: "SHA-256",
+      // The build this key belongs to, so a secret saved for one build can
+      // never be decrypted into another build's deploy.
+      salt: encoder.encode(buildUuid),
+      info: encoder.encode(HKDF_INFO),
+    },
+    base,
+    { name: "AES-GCM", length: 256 },
+    false,
+    ["encrypt", "decrypt"]
+  );
+}
+
+function toBase64(bytes: Uint8Array): string {
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary);
+}
+
+function fromBase64(value: string): Uint8Array<ArrayBuffer> {
+  const binary = atob(value);
+  const bytes = new Uint8Array(new ArrayBuffer(binary.length));
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return bytes;
+}
+
+/** Wrap a session key's secret for `sessionStorage`. Null if WebCrypto refuses. */
+export async function encryptSessionKey(
+  secret: number[],
+  buildUuid: string
+): Promise<string | null> {
+  try {
+    const key = await deriveKey(buildUuid);
+    const iv = crypto.getRandomValues(new Uint8Array(IV_BYTES));
+    const ciphertext = await crypto.subtle.encrypt(
+      { name: "AES-GCM", iv },
+      key,
+      Uint8Array.from(secret) as BufferSource
+    );
+    const packed = new Uint8Array(iv.length + ciphertext.byteLength);
+    packed.set(iv, 0);
+    packed.set(new Uint8Array(ciphertext), iv.length);
+    return toBase64(packed);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Unwrap a stored session key. Null when the page has been reloaded (the nonce
+ * is gone), the ciphertext belongs to another build, or it was tampered with —
+ * all of which the caller treats the same way: no resumable session.
+ */
+export async function decryptSessionKey(
+  ciphertext: string,
+  buildUuid: string
+): Promise<number[] | null> {
+  try {
+    const packed = fromBase64(ciphertext);
+    if (packed.length <= IV_BYTES) return null;
+    const key = await deriveKey(buildUuid);
+    const plain = await crypto.subtle.decrypt(
+      { name: "AES-GCM", iv: packed.subarray(0, IV_BYTES) },
+      key,
+      packed.subarray(IV_BYTES) as BufferSource
+    );
+    const secret = Array.from(new Uint8Array(plain));
+    return secret.length === 64 ? secret : null;
+  } catch {
+    return null;
+  }
+}

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -861,7 +861,16 @@
       "buildExpired": "Build expired",
       "rebuildHint": "Click \"Run\" in the editor to rebuild, then deploy again.",
       "resolvingWallet": "Checking your wallet…",
-      "copied": "Copied!"
+      "copied": "Copied!",
+      "sessionKeyNotice": "Deploying moves the estimated cost from your wallet to a temporary key in this tab, which uploads the program for you; whatever is left comes back to your wallet at the end.",
+      "logFunded": "Temporary deploy key funded",
+      "logOwnershipTransferred": "Ownership transferred to your wallet",
+      "logRefunded": "Remaining SOL refunded to your wallet",
+      "ownershipFailed": "The program is deployed, but transferring ownership to your wallet failed. Claim it below — nothing else needs to be redone.",
+      "claimOwnership": "Claim ownership",
+      "refundFailed": "The leftover SOL is still in the temporary key ({address}). The deploy is complete; you can retry the refund.",
+      "retryRefund": "Retry refund",
+      "sessionKeyLost": "This page lost the temporary deploy key, so the upload cannot be resumed. Start over to deploy again."
     },
     "save": {
       "recording": "Recording your deployment…",

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -863,7 +863,7 @@
       "rebuildHint": "Click \"Run\" in the editor to rebuild, then deploy again.",
       "resolvingWallet": "Checking your wallet…",
       "copied": "Copied!",
-      "sessionKeyNotice": "Deploying moves the estimated cost from your wallet to a temporary key in this tab, which uploads the program for you; whatever is left comes back to your wallet at the end.",
+      "sessionKeyNotice": "Deploying moves the estimated cost from your wallet to a temporary key in this tab, which uploads the program for you; whatever is left comes back to your wallet at the end. Keep this tab open — reloading the page during the upload leaves that SOL in the temporary key until you recover it by hand.",
       "logFunded": "Temporary deploy key funded",
       "logOwnershipTransferred": "Ownership transferred to your wallet",
       "logRefunded": "Remaining SOL refunded to your wallet",
@@ -871,7 +871,8 @@
       "claimOwnership": "Claim ownership",
       "refundFailed": "The leftover SOL is still in the temporary key ({address}). The deploy is complete; you can retry the refund.",
       "retryRefund": "Retry refund",
-      "sessionKeyLost": "This page lost the temporary deploy key, so the upload cannot be resumed. Start over to deploy again.",
+      "sessionKeyLost": "This tab's temporary deploy key was lost when the page reloaded, so the upload can't be resumed and the SOL it still holds is stranded at {address}. Copy that address to recover the funds yourself; deploying again starts with a new key.",
+      "copyAddress": "Copy address",
       "rateLimitWaiting": "Wallet service is busy (rate limited) — retrying in {seconds}s",
       "rateLimitPaused": "The wallet service is still rate-limiting signatures. Nothing was lost — wait a minute and resume."
     },

--- a/apps/web/src/messages/es.json
+++ b/apps/web/src/messages/es.json
@@ -861,7 +861,16 @@
       "buildExpired": "Build expirado",
       "rebuildHint": "Haz clic en \"Run\" en el editor para recompilar y despliega de nuevo.",
       "resolvingWallet": "Comprobando tu billetera…",
-      "copied": "¡Copiado!"
+      "copied": "¡Copiado!",
+      "sessionKeyNotice": "Al desplegar, el costo estimado pasa de tu billetera a una clave temporal en esta pestaña, que sube el programa por ti; lo que sobre vuelve a tu billetera al final.",
+      "logFunded": "Clave temporal de despliegue financiada",
+      "logOwnershipTransferred": "Propiedad transferida a tu billetera",
+      "logRefunded": "SOL restante devuelto a tu billetera",
+      "ownershipFailed": "El programa está desplegado, pero la transferencia de propiedad a tu billetera falló. Reclámala abajo — no hay nada más que rehacer.",
+      "claimOwnership": "Reclamar propiedad",
+      "refundFailed": "El SOL restante sigue en la clave temporal ({address}). El despliegue está completo; puedes reintentar el reembolso.",
+      "retryRefund": "Reintentar reembolso",
+      "sessionKeyLost": "Esta página perdió la clave temporal de despliegue, así que la subida no puede reanudarse. Empieza de nuevo para desplegar."
     },
     "save": {
       "recording": "Registrando tu despliegue…",

--- a/apps/web/src/messages/es.json
+++ b/apps/web/src/messages/es.json
@@ -863,7 +863,7 @@
       "rebuildHint": "Haz clic en \"Run\" en el editor para recompilar y despliega de nuevo.",
       "resolvingWallet": "Comprobando tu billetera…",
       "copied": "¡Copiado!",
-      "sessionKeyNotice": "Al desplegar, el costo estimado pasa de tu billetera a una clave temporal en esta pestaña, que sube el programa por ti; lo que sobre vuelve a tu billetera al final.",
+      "sessionKeyNotice": "Al desplegar, el costo estimado pasa de tu billetera a una clave temporal de esta pestaña, que sube el programa por ti; lo que sobre vuelve a tu billetera al final. Mantén esta pestaña abierta: recargar la página durante la subida deja ese SOL en la clave temporal hasta que lo recuperes a mano.",
       "logFunded": "Clave temporal de despliegue financiada",
       "logOwnershipTransferred": "Propiedad transferida a tu billetera",
       "logRefunded": "SOL restante devuelto a tu billetera",
@@ -871,7 +871,8 @@
       "claimOwnership": "Reclamar propiedad",
       "refundFailed": "El SOL restante sigue en la clave temporal ({address}). El despliegue está completo; puedes reintentar el reembolso.",
       "retryRefund": "Reintentar reembolso",
-      "sessionKeyLost": "Esta página perdió la clave temporal de despliegue, así que la subida no puede reanudarse. Empieza de nuevo para desplegar.",
+      "sessionKeyLost": "La clave temporal de despliegue de esta pestaña se perdió al recargar la página, así que la subida no puede reanudarse y el SOL que aún tiene quedó atrapado en {address}. Copia esa dirección para recuperar los fondos por tu cuenta; un nuevo despliegue empieza con otra clave.",
+      "copyAddress": "Copiar dirección",
       "rateLimitWaiting": "El servicio de la billetera está ocupado (límite de solicitudes) — reintentando en {seconds}s",
       "rateLimitPaused": "El servicio de la billetera sigue limitando las firmas. No se perdió nada — espera un minuto y reanuda."
     },

--- a/apps/web/src/messages/pt-BR.json
+++ b/apps/web/src/messages/pt-BR.json
@@ -863,7 +863,7 @@
       "rebuildHint": "Clique em \"Run\" no editor para recompilar e faça o deploy novamente.",
       "resolvingWallet": "Verificando sua carteira…",
       "copied": "Copiado!",
-      "sessionKeyNotice": "Ao fazer o deploy, o custo estimado sai da sua carteira para uma chave temporária nesta aba, que envia o programa por você; o que sobrar volta para a sua carteira no final.",
+      "sessionKeyNotice": "Ao fazer o deploy, o custo estimado sai da sua carteira para uma chave temporária nesta aba, que envia o programa por você; o que sobrar volta para a sua carteira no final. Mantenha esta aba aberta — recarregar a página durante o envio deixa esse SOL preso na chave temporária até você recuperá-lo manualmente.",
       "logFunded": "Chave temporária de deploy financiada",
       "logOwnershipTransferred": "Propriedade transferida para a sua carteira",
       "logRefunded": "SOL restante devolvido para a sua carteira",
@@ -871,7 +871,8 @@
       "claimOwnership": "Reivindicar propriedade",
       "refundFailed": "O SOL restante ainda está na chave temporária ({address}). O deploy está completo; você pode tentar o reembolso de novo.",
       "retryRefund": "Tentar reembolso de novo",
-      "sessionKeyLost": "Esta página perdeu a chave temporária de deploy, então o envio não pode ser retomado. Recomece para fazer o deploy de novo.",
+      "sessionKeyLost": "A chave temporária de deploy desta aba se perdeu quando a página recarregou, então o envio não pode ser retomado e o SOL que ela ainda tem ficou preso em {address}. Copie esse endereço para recuperar os fundos por conta própria; um novo deploy começa com outra chave.",
+      "copyAddress": "Copiar endereço",
       "rateLimitWaiting": "O serviço da carteira está ocupado (limite de requisições) — tentando de novo em {seconds}s",
       "rateLimitPaused": "O serviço da carteira ainda está limitando assinaturas. Nada foi perdido — espere um minuto e retome."
     },

--- a/apps/web/src/messages/pt-BR.json
+++ b/apps/web/src/messages/pt-BR.json
@@ -861,7 +861,16 @@
       "buildExpired": "Build expirado",
       "rebuildHint": "Clique em \"Run\" no editor para recompilar e faça o deploy novamente.",
       "resolvingWallet": "Verificando sua carteira…",
-      "copied": "Copiado!"
+      "copied": "Copiado!",
+      "sessionKeyNotice": "Ao fazer o deploy, o custo estimado sai da sua carteira para uma chave temporária nesta aba, que envia o programa por você; o que sobrar volta para a sua carteira no final.",
+      "logFunded": "Chave temporária de deploy financiada",
+      "logOwnershipTransferred": "Propriedade transferida para a sua carteira",
+      "logRefunded": "SOL restante devolvido para a sua carteira",
+      "ownershipFailed": "O programa foi implantado, mas a transferência de propriedade para a sua carteira falhou. Reivindique abaixo — nada mais precisa ser refeito.",
+      "claimOwnership": "Reivindicar propriedade",
+      "refundFailed": "O SOL restante ainda está na chave temporária ({address}). O deploy está completo; você pode tentar o reembolso de novo.",
+      "retryRefund": "Tentar reembolso de novo",
+      "sessionKeyLost": "Esta página perdeu a chave temporária de deploy, então o envio não pode ser retomado. Recomece para fazer o deploy de novo."
     },
     "save": {
       "recording": "Registrando seu deploy…",

--- a/apps/web/vitest.setup.ts
+++ b/apps/web/vitest.setup.ts
@@ -15,6 +15,19 @@ process.env.NEXT_PUBLIC_APP_URL ??= "http://localhost:3000";
 process.env.SUPABASE_SERVICE_ROLE_KEY ??= "test-service-role-key";
 process.env.SOLANA_RPC_URL ??= "https://api.devnet.solana.com";
 
+// jsdom installs its OWN `Uint8Array` on the global, from a different realm
+// than Node's `Buffer`. `@solana/buffer-layout` type-checks with
+// `b instanceof Uint8Array` against whatever global was in scope when it
+// loaded, so under jsdom every web3.js instruction encode (e.g.
+// `SystemProgram.transfer`) fails with "b must be a Uint8Array" even though the
+// value IS one. Restoring Node's constructor before any test module imports
+// web3.js is what lets component tests exercise real transaction building.
+if (typeof window !== "undefined") {
+  const nodeUint8Array = Object.getPrototypeOf(Buffer.prototype).constructor;
+  globalThis.Uint8Array = nodeUint8Array;
+  window.Uint8Array = nodeUint8Array;
+}
+
 // Registers `toBeInTheDocument()`, `toBeDisabled()`, etc. globally for every
 // test file — required by component tests that render real DOM (jsdom) and
 // assert on it (e.g. diff-card.test.tsx).

--- a/packages/deploy/src/__tests__/session-key.test.ts
+++ b/packages/deploy/src/__tests__/session-key.test.ts
@@ -1,0 +1,427 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  Keypair,
+  PublicKey,
+  SystemInstruction,
+  Transaction,
+  type Connection,
+} from "@solana/web3.js";
+import { BPF_LOADER_UPGRADEABLE_ID, BUFFER_HEADER_SIZE } from "../constants";
+import { estimateSessionKeyDeployCost } from "../cost";
+import { setCachedBinary } from "../deploy";
+import {
+  createFundingTransfer,
+  isResumableDeploymentState,
+  runSessionKeyDeploy,
+  startOverSessionKey,
+  sweepSessionKey,
+  transferProgramAuthority,
+} from "../session-key";
+import type { DeploymentCallbacks, DeploymentState } from "../types";
+
+const BLOCKHASH = "11111111111111111111111111111111";
+const RENT = 1_000_000;
+/** 5 chunks at CHUNK_SIZE=900. */
+const BINARY = new Uint8Array(4500).fill(7);
+
+function callbacks(): DeploymentCallbacks {
+  return {
+    onStepChange: vi.fn(),
+    onChunkProgress: vi.fn(),
+    onTransactionConfirmed: vi.fn(),
+    onError: vi.fn(),
+    onStateUpdate: vi.fn(),
+    onBatchStart: vi.fn(),
+  };
+}
+
+function bufferAccount(authority: PublicKey) {
+  const data = Buffer.alloc(BUFFER_HEADER_SIZE);
+  data.writeUInt32LE(1, 0); // Buffer tag
+  data[4] = 1; // Some(authority)
+  authority.toBuffer().copy(data, 5);
+  return { owner: BPF_LOADER_UPGRADEABLE_ID, data, executable: false };
+}
+
+interface Harness {
+  connection: Connection;
+  sent: Transaction[];
+  setBalance: (lamports: number) => void;
+  balanceOf: (key: string) => number;
+}
+
+function harness(options: { buffer?: PublicKey } = {}): Harness {
+  const sent: Transaction[] = [];
+  const balances = new Map<string, number>();
+  let defaultBalance = 0;
+
+  const connection = {
+    getLatestBlockhash: vi.fn(async () => ({
+      blockhash: BLOCKHASH,
+      lastValidBlockHeight: 1000,
+    })),
+    getMinimumBalanceForRentExemption: vi.fn(async () => RENT),
+    getBalance: vi.fn(
+      async (key: PublicKey) => balances.get(key.toBase58()) ?? defaultBalance
+    ),
+    sendRawTransaction: vi.fn(async (raw: Uint8Array) => {
+      const tx = Transaction.from(Buffer.from(raw));
+      sent.push(tx);
+      return `sig-${sent.length}`;
+    }),
+    confirmTransaction: vi.fn(async () => ({ value: { err: null } })),
+    getSignatureStatuses: vi.fn(async (sigs: string[]) => ({
+      value: sigs.map(() => ({
+        err: null,
+        confirmationStatus: "confirmed" as const,
+      })),
+    })),
+    getAccountInfo: vi.fn(async (key: PublicKey) =>
+      options.buffer && key.equals(options.buffer)
+        ? bufferAccount(options.buffer)
+        : null
+    ),
+  } as unknown as Connection;
+
+  return {
+    connection,
+    sent,
+    setBalance: (lamports: number) => {
+      defaultBalance = lamports;
+    },
+    balanceOf: (key: string) => balances.get(key) ?? defaultBalance,
+  };
+}
+
+/** Instructions of a transaction that target the upgradeable loader. */
+function loaderIxs(tx: Transaction) {
+  return tx.instructions.filter((ix) =>
+    ix.programId.equals(BPF_LOADER_UPGRADEABLE_ID)
+  );
+}
+
+describe("runSessionKeyDeploy", () => {
+  it("funds the session key once, for exactly the estimate, and signs everything else locally", async () => {
+    setCachedBinary("uuid-fund", BINARY);
+    const h = harness();
+    h.setBalance(5_000_000);
+    const learner = Keypair.generate().publicKey;
+
+    const fund = vi.fn(async () => "fund-sig");
+    let sessionKey: PublicKey | null = null;
+
+    const result = await runSessionKeyDeploy({
+      connection: h.connection,
+      learner,
+      buildUuid: "uuid-fund",
+      fund,
+      callbacks: callbacks(),
+      events: {
+        onSessionKey: (_secret, publicKey) => {
+          sessionKey = publicKey;
+        },
+      },
+    });
+
+    const estimate = await estimateSessionKeyDeployCost(
+      h.connection,
+      BINARY.length
+    );
+
+    // The embedded wallet signs ONE transaction: the funding transfer.
+    expect(fund).toHaveBeenCalledTimes(1);
+    expect(fund).toHaveBeenCalledWith(estimate.totalLamports, sessionKey);
+    expect(result.fundedLamports).toBe(estimate.totalLamports);
+
+    // Everything actually sent — buffer create, 5 writes, deploy, SetAuthority,
+    // sweep — carries the session key's signature and no learner signature.
+    expect(h.sent.length).toBe(9);
+    for (const tx of h.sent) {
+      const signers = tx.signatures.map((s) => s.publicKey.toBase58());
+      expect(signers).toContain(sessionKey!.toBase58());
+      expect(signers).not.toContain(learner.toBase58());
+    }
+  });
+
+  it("hands the upgrade authority to the learner and sweeps the remainder back", async () => {
+    setCachedBinary("uuid-authority", BINARY);
+    const h = harness();
+    // Funded up front, drained by rent by the time the sweep reads it.
+    const remaining = 2_345_678;
+    h.setBalance(9_000_000);
+    let balanceReads = 0;
+    (h.connection.getBalance as ReturnType<typeof vi.fn>).mockImplementation(
+      async () => (balanceReads++ === 0 ? 9_000_000 : remaining)
+    );
+    const learner = Keypair.generate().publicKey;
+
+    const transferred: string[] = [];
+    const refunded: number[] = [];
+
+    const result = await runSessionKeyDeploy({
+      connection: h.connection,
+      learner,
+      buildUuid: "uuid-authority",
+      fund: async () => "fund-sig",
+      callbacks: callbacks(),
+      events: {
+        onOwnershipTransferred: (info) => transferred.push(info.signature),
+        onRefunded: (info) => refunded.push(info.lamports),
+      },
+    });
+
+    const [programData] = PublicKey.findProgramAddressSync(
+      [result.programIdPubkey.toBuffer()],
+      BPF_LOADER_UPGRADEABLE_ID
+    );
+
+    // SetAuthority: variant 4, programdata writable, session key signs, learner
+    // is the (non-signing) new authority.
+    const setAuthority = h.sent
+      .flatMap(loaderIxs)
+      .find((ix) => ix.data.length === 4 && ix.data.readUInt32LE(0) === 4);
+    expect(setAuthority).toBeDefined();
+    expect(setAuthority!.keys[0]!.pubkey.equals(programData)).toBe(true);
+    expect(setAuthority!.keys[0]!.isWritable).toBe(true);
+    expect(setAuthority!.keys[1]!.isSigner).toBe(true);
+    expect(setAuthority!.keys[2]!.pubkey.equals(learner)).toBe(true);
+    expect(setAuthority!.keys[2]!.isSigner).toBe(false);
+    expect(transferred).toHaveLength(1);
+    expect(result.authoritySignature).toBe(transferred[0]);
+
+    // Sweep: balance minus the sweep's own fee, to the learner.
+    const sweep = h.sent.at(-1)!;
+    const decoded = SystemInstruction.decodeTransfer(sweep.instructions[0]!);
+    expect(decoded.toPubkey.equals(learner)).toBe(true);
+    expect(Number(decoded.lamports)).toBe(remaining - 5_000);
+    expect(refunded).toEqual([remaining - 5_000]);
+    expect(result.refundError).toBeNull();
+  });
+
+  it("resume reuses the persisted key and starts at the saved offset without a second transfer", async () => {
+    setCachedBinary("uuid-resume", BINARY);
+    const session = Keypair.generate();
+    const bufferKp = Keypair.generate();
+    const programKp = Keypair.generate();
+    const h = harness({ buffer: bufferKp.publicKey });
+    h.setBalance(3_000_000);
+    // The persisted buffer's authority is the persisted session key.
+    (
+      h.connection.getAccountInfo as ReturnType<typeof vi.fn>
+    ).mockImplementation(async (key: PublicKey) =>
+      key.equals(bufferKp.publicKey) ? bufferAccount(session.publicKey) : null
+    );
+
+    const fund = vi.fn(async () => "fund-sig");
+    const state: DeploymentState = {
+      buildUuid: "uuid-resume",
+      bufferKeypairSecret: Array.from(bufferKp.secretKey),
+      programKeypairSecret: Array.from(programKp.secretKey),
+      lastUploadedChunk: 2,
+      totalChunks: 5,
+      phase: "uploading",
+    };
+
+    const result = await runSessionKeyDeploy({
+      connection: h.connection,
+      learner: Keypair.generate().publicKey,
+      buildUuid: "uuid-resume",
+      fund,
+      callbacks: callbacks(),
+      persistedSessionKey: Array.from(session.secretKey),
+      resumeState: state,
+    });
+
+    expect(fund).not.toHaveBeenCalled();
+    expect(result.fundedLamports).toBe(0);
+    expect(result.programId).toBe(programKp.publicKey.toBase58());
+    expect(result.sessionKeySecret).toEqual(Array.from(session.secretKey));
+
+    // Writes resume at chunk 3 (offset 2700), not at zero.
+    const writes = h.sent
+      .flatMap(loaderIxs)
+      .filter((ix) => ix.data.readUInt32LE(0) === 1);
+    expect(writes).toHaveLength(2);
+    expect(writes[0]!.data.readUInt32LE(4)).toBe(3 * 900);
+  });
+
+  it("refuses to resume into a buffer the session key does not control", async () => {
+    setCachedBinary("uuid-foreign", BINARY);
+    const session = Keypair.generate();
+    const bufferKp = Keypair.generate();
+    const h = harness();
+    (
+      h.connection.getAccountInfo as ReturnType<typeof vi.fn>
+    ).mockImplementation(async (key: PublicKey) =>
+      key.equals(bufferKp.publicKey)
+        ? bufferAccount(Keypair.generate().publicKey) // someone else's buffer
+        : null
+    );
+
+    const fund = vi.fn(async () => "fund-sig");
+    await expect(
+      runSessionKeyDeploy({
+        connection: h.connection,
+        learner: Keypair.generate().publicKey,
+        buildUuid: "uuid-foreign",
+        fund,
+        callbacks: callbacks(),
+        persistedSessionKey: Array.from(session.secretKey),
+        resumeState: {
+          buildUuid: "uuid-foreign",
+          bufferKeypairSecret: Array.from(bufferKp.secretKey),
+          programKeypairSecret: Array.from(Keypair.generate().secretKey),
+          lastUploadedChunk: 2,
+          totalChunks: 5,
+          phase: "uploading",
+        },
+      })
+    ).rejects.toThrow(/buffer this key cannot use/i);
+
+    expect(fund).not.toHaveBeenCalled();
+    expect(h.sent).toHaveLength(0);
+  });
+});
+
+describe("isResumableDeploymentState", () => {
+  setCachedBinary("uuid-check", BINARY);
+  const good: DeploymentState = {
+    buildUuid: "uuid-check",
+    bufferKeypairSecret: Array.from(Keypair.generate().secretKey),
+    programKeypairSecret: Array.from(Keypair.generate().secretKey),
+    lastUploadedChunk: 1,
+    totalChunks: 5,
+    phase: "uploading",
+  };
+
+  it("accepts the state this build actually produced", () => {
+    expect(
+      isResumableDeploymentState(good, {
+        buildUuid: "uuid-check",
+        programKeypairSecret: good.programKeypairSecret,
+      })
+    ).toBe(true);
+  });
+
+  it("rejects a state whose program keypair is not the build's", () => {
+    expect(
+      isResumableDeploymentState(good, {
+        buildUuid: "uuid-check",
+        programKeypairSecret: Array.from(Keypair.generate().secretKey),
+      })
+    ).toBe(false);
+  });
+
+  it("rejects a state from another build, a malformed key, or a bad offset", () => {
+    expect(isResumableDeploymentState(good, { buildUuid: "other-build" })).toBe(
+      false
+    );
+    expect(
+      isResumableDeploymentState(
+        { ...good, bufferKeypairSecret: [1, 2, 3] },
+        { buildUuid: "uuid-check" }
+      )
+    ).toBe(false);
+    expect(
+      isResumableDeploymentState(
+        { ...good, lastUploadedChunk: 5 },
+        { buildUuid: "uuid-check" }
+      )
+    ).toBe(false);
+    // totalChunks must match the cached binary, so a state claiming a bigger
+    // program cannot make the resume write past its end.
+    expect(
+      isResumableDeploymentState(
+        { ...good, totalChunks: 500 },
+        { buildUuid: "uuid-check" }
+      )
+    ).toBe(false);
+  });
+});
+
+describe("sweepSessionKey / startOverSessionKey", () => {
+  it("sends nothing when the balance cannot cover the fee", async () => {
+    const h = harness();
+    h.setBalance(4_000);
+    const result = await sweepSessionKey({
+      connection: h.connection,
+      sessionKeySecret: Array.from(Keypair.generate().secretKey),
+      destination: Keypair.generate().publicKey,
+    });
+    expect(result).toBeNull();
+    expect(h.sent).toHaveLength(0);
+  });
+
+  it("start over closes the buffer to the session key, then sweeps to the learner", async () => {
+    const session = Keypair.generate();
+    const bufferKp = Keypair.generate();
+    const learner = Keypair.generate().publicKey;
+    const h = harness({ buffer: bufferKp.publicKey });
+    h.setBalance(1_000_000);
+
+    const { closeSignature, refund } = await startOverSessionKey({
+      connection: h.connection,
+      sessionKeySecret: Array.from(session.secretKey),
+      bufferKeypairSecret: Array.from(bufferKp.secretKey),
+      destination: learner,
+    });
+
+    expect(closeSignature).not.toBeNull();
+    const close = loaderIxs(h.sent[0]!)[0]!;
+    expect(close.data.readUInt32LE(0)).toBe(5); // Close
+    expect(close.keys[0]!.pubkey.equals(bufferKp.publicKey)).toBe(true);
+    expect(close.keys[1]!.pubkey.equals(session.publicKey)).toBe(true); // refund
+
+    const decoded = SystemInstruction.decodeTransfer(
+      h.sent[1]!.instructions[0]!
+    );
+    expect(decoded.toPubkey.equals(learner)).toBe(true);
+    expect(refund!.lamports).toBe(1_000_000 - 5_000);
+  });
+});
+
+describe("transferProgramAuthority", () => {
+  it("retries a failing SetAuthority before giving up", async () => {
+    const h = harness();
+    let attempts = 0;
+    (
+      h.connection.sendRawTransaction as ReturnType<typeof vi.fn>
+    ).mockImplementation(async () => {
+      attempts++;
+      if (attempts < 4) throw new Error("blockhash not found");
+      return "authority-sig";
+    });
+
+    const signature = await transferProgramAuthority({
+      connection: h.connection,
+      sessionKeySecret: Array.from(Keypair.generate().secretKey),
+      programId: Keypair.generate().publicKey,
+      newAuthority: Keypair.generate().publicKey,
+      attempts: 4,
+    });
+
+    expect(signature).toBe("authority-sig");
+    expect(attempts).toBe(4);
+  });
+});
+
+describe("createFundingTransfer", () => {
+  it("pays from the learner into the session key, for the exact amount", () => {
+    const learner = Keypair.generate().publicKey;
+    const sessionKey = Keypair.generate().publicKey;
+
+    const tx = createFundingTransfer({
+      learner,
+      sessionKey,
+      lamports: 1_337_000,
+      blockhash: BLOCKHASH,
+    });
+
+    expect(tx.feePayer!.equals(learner)).toBe(true);
+    expect(tx.recentBlockhash).toBe(BLOCKHASH);
+    const transfer = SystemInstruction.decodeTransfer(tx.instructions[0]!);
+    expect(transfer.fromPubkey.equals(learner)).toBe(true);
+    expect(transfer.toPubkey.equals(sessionKey)).toBe(true);
+    expect(Number(transfer.lamports)).toBe(1_337_000);
+  });
+});

--- a/packages/deploy/src/__tests__/session-key.test.ts
+++ b/packages/deploy/src/__tests__/session-key.test.ts
@@ -12,6 +12,7 @@ import { setCachedBinary } from "../deploy";
 import {
   createFundingTransfer,
   isResumableDeploymentState,
+  OwnershipTransferError,
   runSessionKeyDeploy,
   startOverSessionKey,
   sweepSessionKey,
@@ -130,7 +131,11 @@ describe("runSessionKeyDeploy", () => {
 
     // The embedded wallet signs ONE transaction: the funding transfer.
     expect(fund).toHaveBeenCalledTimes(1);
-    expect(fund).toHaveBeenCalledWith(estimate.totalLamports, sessionKey);
+    expect(fund).toHaveBeenCalledWith(
+      estimate.totalLamports,
+      sessionKey,
+      expect.any(Function)
+    );
     expect(result.fundedLamports).toBe(estimate.totalLamports);
 
     // Everything actually sent — buffer create, 5 writes, deploy, SetAuthority,
@@ -244,6 +249,144 @@ describe("runSessionKeyDeploy", () => {
     expect(writes).toHaveLength(2);
     expect(writes[0]!.data.readUInt32LE(4)).toBe(3 * 900);
   });
+
+  it("reports the funding signature before the transfer is broadcast", async () => {
+    setCachedBinary("uuid-broadcast", BINARY);
+    const h = harness();
+    h.setBalance(9_000_000);
+
+    const order: string[] = [];
+    const result = await runSessionKeyDeploy({
+      connection: h.connection,
+      learner: Keypair.generate().publicKey,
+      buildUuid: "uuid-broadcast",
+      fund: async (_lamports, _to, onSignature) => {
+        onSignature("fund-sig");
+        order.push("broadcast");
+        return "fund-sig";
+      },
+      callbacks: callbacks(),
+      events: {
+        onFundingBroadcast: ({ signature }) => {
+          order.push(`persisted:${signature}`);
+        },
+      },
+    });
+
+    // The signature is persisted BEFORE the send: a `fund` that throws after
+    // broadcasting must still leave a record of the transfer behind.
+    expect(order[0]).toBe("persisted:fund-sig");
+    expect(order[1]).toBe("broadcast");
+    expect(result.fundedLamports).toBeGreaterThan(0);
+  });
+
+  it("does not fund a carried-over key the first attempt already paid for", async () => {
+    setCachedBinary("uuid-refund-twice", BINARY);
+    const session = Keypair.generate();
+    const h = harness();
+    const estimate = await estimateSessionKeyDeployCost(
+      h.connection,
+      BINARY.length
+    );
+    // The first attempt's transfer landed; only its confirmation was lost.
+    h.setBalance(estimate.totalLamports);
+
+    const fund = vi.fn(async () => "second-fund-sig");
+    const result = await runSessionKeyDeploy({
+      connection: h.connection,
+      learner: Keypair.generate().publicKey,
+      buildUuid: "uuid-refund-twice",
+      fund,
+      callbacks: callbacks(),
+      persistedSessionKey: Array.from(session.secretKey),
+      pendingFundingSignature: "first-fund-sig",
+    });
+
+    // Same key, no second transfer — the learner pays for this deploy once.
+    expect(fund).not.toHaveBeenCalled();
+    expect(result.fundedLamports).toBe(0);
+    expect(result.sessionKeySecret).toEqual(Array.from(session.secretKey));
+  });
+
+  it("funds a carried-over key whose transfer never landed", async () => {
+    setCachedBinary("uuid-refund-none", BINARY);
+    const session = Keypair.generate();
+    const h = harness();
+    let balanceReads = 0;
+    (h.connection.getBalance as ReturnType<typeof vi.fn>).mockImplementation(
+      async () => (balanceReads++ === 0 ? 0 : 9_000_000)
+    );
+    // The persisted transfer is on chain and failed; only the retry's own
+    // transfer confirms.
+    (
+      h.connection.getSignatureStatuses as ReturnType<typeof vi.fn>
+    ).mockImplementation(async (sigs: string[]) => ({
+      value: sigs.map((sig) =>
+        sig === "lost-sig"
+          ? { err: { InsufficientFundsForRent: {} }, confirmationStatus: null }
+          : { err: null, confirmationStatus: "confirmed" as const }
+      ),
+    }));
+
+    const fund = vi.fn(async () => "fund-sig");
+    const result = await runSessionKeyDeploy({
+      connection: h.connection,
+      learner: Keypair.generate().publicKey,
+      buildUuid: "uuid-refund-none",
+      fund,
+      callbacks: callbacks(),
+      persistedSessionKey: Array.from(session.secretKey),
+      pendingFundingSignature: "lost-sig",
+    });
+
+    expect(fund).toHaveBeenCalledTimes(1);
+    expect(result.fundedLamports).toBeGreaterThan(0);
+  });
+
+  it("reports a failed handover with the session ADDRESS, never its secret", async () => {
+    setCachedBinary("uuid-ownership", BINARY);
+    const h = harness();
+    h.setBalance(9_000_000);
+    let sessionKey: PublicKey | null = null;
+    // Everything sends until SetAuthority (variant 4), which never lands.
+    const send = h.connection.sendRawTransaction as ReturnType<typeof vi.fn>;
+    const realSend = send.getMockImplementation() as (
+      raw: Uint8Array
+    ) => Promise<string>;
+    send.mockImplementation(async (raw: Uint8Array) => {
+      const tx = Transaction.from(Buffer.from(raw));
+      const isSetAuthority = loaderIxs(tx).some(
+        (ix) => ix.data.length === 4 && ix.data.readUInt32LE(0) === 4
+      );
+      if (isSetAuthority) throw new Error("SetAuthority refused");
+      return realSend(raw);
+    });
+
+    const error = await runSessionKeyDeploy({
+      connection: h.connection,
+      learner: Keypair.generate().publicKey,
+      buildUuid: "uuid-ownership",
+      fund: async () => "fund-sig",
+      callbacks: callbacks(),
+      events: {
+        onSessionKey: (_secret, publicKey) => {
+          sessionKey = publicKey;
+        },
+      },
+    }).catch((err: unknown) => err);
+
+    expect(error).toBeInstanceOf(OwnershipTransferError);
+    const ownership = error as OwnershipTransferError;
+    expect(ownership.sessionKeyAddress.equals(sessionKey!)).toBe(true);
+    expect(
+      ownership.programId.equals(ownership.deployResult.programIdPubkey)
+    ).toBe(true);
+    // Nothing spendable rides on an error object: it gets rethrown, logged and
+    // captured by Sentry.
+    expect(Object.values(ownership)).not.toContainEqual(expect.any(Array));
+    expect(JSON.stringify(ownership)).not.toContain("sessionKeySecret");
+    // `transferProgramAuthority` spends its full backoff before giving up.
+  }, 20_000);
 
   it("refuses to resume into a buffer the session key does not control", async () => {
     setCachedBinary("uuid-foreign", BINARY);

--- a/packages/deploy/src/cost.ts
+++ b/packages/deploy/src/cost.ts
@@ -47,7 +47,13 @@ export interface DeployCostEstimate {
  */
 export async function estimateDeployCost(
   connection: Connection,
-  programLen: number
+  programLen: number,
+  /**
+   * Transactions the payer sends beyond the deploy itself. The session-key
+   * path adds two (SetAuthority, sweep) that the payer — the session key —
+   * must still be able to pay for after the deploy has drained it into rent.
+   */
+  extraTransactions = 0
 ): Promise<DeployCostEstimate> {
   const [bufferRent, programRent, programDataRent] = await Promise.all([
     connection.getMinimumBalanceForRentExemption(
@@ -61,7 +67,8 @@ export async function estimateDeployCost(
 
   const chunks = Math.ceil(programLen / CHUNK_SIZE);
   const feeLamports =
-    (chunks + 2) * (BASE_FEE_LAMPORTS + PRIORITY_FEE_LAMPORTS);
+    (chunks + 2 + extraTransactions) *
+    (BASE_FEE_LAMPORTS + PRIORITY_FEE_LAMPORTS);
 
   return {
     bufferRent,
@@ -73,4 +80,30 @@ export async function estimateDeployCost(
         SAFETY_MULTIPLIER
     ),
   };
+}
+
+/**
+ * Transactions the session key sends that a plain deploy does not: the
+ * `SetAuthority` that hands the program to the learner, and the sweep that
+ * returns the remainder.
+ */
+export const SESSION_KEY_EXTRA_TRANSACTIONS = 2;
+
+/**
+ * What the learner must transfer into a freshly generated session key.
+ *
+ * The session key pays for everything from the buffer onwards, so if the
+ * transfer is short by even one fee the deploy strands mid-upload with SOL the
+ * learner cannot easily get back. Same estimate as `estimateDeployCost`, plus
+ * the two transactions the session key sends on its own behalf.
+ */
+export function estimateSessionKeyDeployCost(
+  connection: Connection,
+  programLen: number
+): Promise<DeployCostEstimate> {
+  return estimateDeployCost(
+    connection,
+    programLen,
+    SESSION_KEY_EXTRA_TRANSACTIONS
+  );
 }

--- a/packages/deploy/src/deploy.ts
+++ b/packages/deploy/src/deploy.ts
@@ -79,7 +79,7 @@ function fetchBinary(uuid: string): Uint8Array {
 /**
  * Send a signed transaction with retry logic.
  */
-async function sendWithRetry(
+export async function sendWithRetry(
   connection: Connection,
   serializedTx: Uint8Array,
   maxRetries = 3
@@ -105,7 +105,7 @@ async function sendWithRetry(
 /**
  * Confirm a transaction with timeout.
  */
-async function confirmTx(
+export async function confirmTx(
   connection: Connection,
   signature: string,
   blockhash: string,

--- a/packages/deploy/src/index.ts
+++ b/packages/deploy/src/index.ts
@@ -5,7 +5,26 @@ export {
   setCachedBinary,
   getCachedBinaryLength,
 } from "./deploy";
-export { estimateDeployCost, type DeployCostEstimate } from "./cost";
+export {
+  estimateDeployCost,
+  estimateSessionKeyDeployCost,
+  SESSION_KEY_EXTRA_TRANSACTIONS,
+  type DeployCostEstimate,
+} from "./cost";
+export {
+  runSessionKeyDeploy,
+  createFundingTransfer,
+  transferProgramAuthority,
+  sweepSessionKey,
+  startOverSessionKey,
+  isResumableDeploymentState,
+  assertSessionOwnsBuffer,
+  keypairSigner,
+  OwnershipTransferError,
+  type SessionKeyDeployParams,
+  type SessionKeyDeployResult,
+  type SessionKeyEvents,
+} from "./session-key";
 export { createAirdropRequest, type AirdropResult } from "./airdrop";
 export { CHUNK_SIZE, BPF_LOADER_UPGRADEABLE_ID } from "./constants";
 export type {

--- a/packages/deploy/src/instructions.ts
+++ b/packages/deploy/src/instructions.ts
@@ -106,3 +106,35 @@ export function createCloseBufferInstruction(
     data,
   });
 }
+
+/**
+ * Move the upgrade authority of a ProgramData (or buffer) account.
+ *
+ * Loader v3 variant 4, `SetAuthority`, whose account list is
+ * `[buffer-or-programdata (writable), current authority (signer), new
+ * authority]` — the NEW authority does not sign, which is the whole reason a
+ * session-key upload can hand ownership to a learner whose wallet signs only
+ * once. The ProgramData layout this writes into is the one
+ * `apps/web/src/lib/solana/verify-program-deploy.ts` reads back:
+ * tag(u32) | slot(u64) | Option<Pubkey> authority — so a confirmed
+ * SetAuthority is exactly what makes `verifyProgramDeployment(programId,
+ * learner)` return ok.
+ */
+export function createSetAuthorityInstruction(
+  programDataAddress: PublicKey,
+  currentAuthorityAddress: PublicKey,
+  newAuthorityAddress: PublicKey
+): TransactionInstruction {
+  const data = Buffer.alloc(4);
+  data.writeUInt32LE(4, 0); // variant 4: SetAuthority
+
+  return new TransactionInstruction({
+    keys: [
+      { pubkey: programDataAddress, isSigner: false, isWritable: true },
+      { pubkey: currentAuthorityAddress, isSigner: true, isWritable: false },
+      { pubkey: newAuthorityAddress, isSigner: false, isWritable: false },
+    ],
+    programId: BPF_LOADER_UPGRADEABLE_ID,
+    data,
+  });
+}

--- a/packages/deploy/src/session-key.ts
+++ b/packages/deploy/src/session-key.ts
@@ -56,6 +56,13 @@ const SWEEP_FEE_LAMPORTS = 5_000;
 const FUNDING_TIMEOUT_MS = 90_000;
 const FUNDING_POLL_MS = 1_500;
 
+/**
+ * How long to wait on a funding signature left over from an attempt that threw.
+ * Shorter than a fresh transfer: the point is to find out whether it landed, and
+ * a signature the cluster has never heard of should not stall a retry.
+ */
+const PENDING_FUNDING_TIMEOUT_MS = 20_000;
+
 /** Attempts for `SetAuthority`, which must succeed or the deploy is unowned. */
 const AUTHORITY_ATTEMPTS = 4;
 const AUTHORITY_BACKOFF_MS = 1_000;
@@ -72,6 +79,12 @@ export interface SessionKeyEvents {
    * otherwise strand the funds with no key to spend them.
    */
   onSessionKey?: (secret: number[], publicKey: PublicKey) => void;
+  /**
+   * The funding transfer has a signature — it is on the wire, and may land even
+   * if the very next line throws. Callers persist it HERE, so a retry can ask
+   * the cluster what happened instead of transferring a second time.
+   */
+  onFundingBroadcast?: (info: { signature: string }) => void;
   onFunded?: (info: { lamports: number; signature: string }) => void;
   onOwnershipTransferred?: (info: {
     signature: string;
@@ -89,14 +102,28 @@ export interface SessionKeyDeployParams {
   /**
    * Sign and send the funding transfer from the learner's wallet, returning its
    * signature. This is the ONE transaction the embedded wallet signs.
+   *
+   * `onSignature` is called with the signature BEFORE the transaction is
+   * broadcast, because a `fund` that throws after broadcasting still moves the
+   * learner's SOL — and without the signature a retry has no way to find out.
    */
-  fund: (lamports: number, to: PublicKey) => Promise<string>;
+  fund: (
+    lamports: number,
+    to: PublicKey,
+    onSignature: (signature: string) => void
+  ) => Promise<string>;
   callbacks: DeploymentCallbacks;
   programKeypairSecret?: number[];
   /** Session-key secret from a paused deploy; a new key is generated without it. */
   persistedSessionKey?: number[] | null;
   /** Deployment state from a paused deploy — set together with the key. */
   resumeState?: DeploymentState | null;
+  /**
+   * A funding signature persisted by an attempt that threw before it could
+   * confirm. Passed with `persistedSessionKey` and no `resumeState`: the upload
+   * never started, but the transfer may well have landed.
+   */
+  pendingFundingSignature?: string | null;
   events?: SessionKeyEvents;
 }
 
@@ -158,17 +185,26 @@ export function createFundingTransfer(params: {
 /**
  * Raised when the deploy landed but the upgrade authority is still the session
  * key. The program is on-chain and paid for; the panel offers "claim
- * ownership", which re-runs only `transferProgramAuthority`, so the fields it
- * needs travel with the error.
+ * ownership", which re-runs only `transferProgramAuthority`.
+ *
+ * It carries the program it deployed and the session key's ADDRESS — never the
+ * secret. An error object gets rethrown, logged and captured by Sentry; a
+ * spendable key riding on one is a live key in an error report. The caller
+ * already holds the secret (it persisted it from `onSessionKey`), so putting it
+ * here bought nothing.
  */
 export class OwnershipTransferError extends Error {
   constructor(
     message: string,
     readonly deployResult: DeployResult,
-    readonly sessionKeySecret: number[]
+    readonly sessionKeyAddress: PublicKey
   ) {
     super(message);
     this.name = "OwnershipTransferError";
+  }
+
+  get programId(): PublicKey {
+    return this.deployResult.programIdPubkey;
   }
 }
 
@@ -328,6 +364,38 @@ async function waitForFunding(
       throw new Error("Timed out waiting for the funding transfer to confirm.");
     }
     await new Promise((r) => setTimeout(r, FUNDING_POLL_MS));
+  }
+}
+
+/**
+ * Does this session key already hold the deploy's cost?
+ *
+ * Two ways it can, both from an attempt that threw after the transfer was on
+ * the wire: the balance is simply there, or a signature was persisted before
+ * broadcast and the cluster confirms it landed. Either answer means the retry
+ * must NOT transfer again. Anything else — no balance, an unknown or failed
+ * signature — falls through to a fresh transfer.
+ */
+async function isAlreadyFunded(
+  connection: Connection,
+  sessionKey: PublicKey,
+  requiredLamports: number,
+  pendingSignature: string | null
+): Promise<boolean> {
+  const balance = await connection.getBalance(sessionKey, "confirmed");
+  if (balance >= requiredLamports) return true;
+  if (!pendingSignature) return false;
+  try {
+    await waitForFunding(
+      connection,
+      pendingSignature,
+      sessionKey,
+      requiredLamports,
+      PENDING_FUNDING_TIMEOUT_MS
+    );
+    return true;
+  } catch {
+    return false;
   }
 }
 
@@ -504,15 +572,37 @@ export async function runSessionKeyDeploy(
       );
     }
     const estimate = await estimateSessionKeyDeployCost(connection, programLen);
-    const signature = await fund(estimate.totalLamports, session.publicKey);
-    await waitForFunding(
-      connection,
-      signature,
-      session.publicKey,
-      estimate.totalLamports
-    );
-    fundedLamports = estimate.totalLamports;
-    events.onFunded?.({ lamports: fundedLamports, signature });
+
+    // A carried-over key may already be paid for: a `fund` that broadcast and
+    // then threw — a dropped response, a confirm timeout — leaves the learner's
+    // SOL on chain, and funding a second time would double the bill for a
+    // deploy they have already paid for. A key generated a line ago cannot be,
+    // so it is not asked.
+    const funded = params.persistedSessionKey
+      ? await isAlreadyFunded(
+          connection,
+          session.publicKey,
+          estimate.totalLamports,
+          params.pendingFundingSignature ?? null
+        )
+      : false;
+
+    if (!funded) {
+      const signature = await fund(
+        estimate.totalLamports,
+        session.publicKey,
+        (broadcast) => events.onFundingBroadcast?.({ signature: broadcast })
+      );
+      events.onFundingBroadcast?.({ signature });
+      await waitForFunding(
+        connection,
+        signature,
+        session.publicKey,
+        estimate.totalLamports
+      );
+      fundedLamports = estimate.totalLamports;
+      events.onFunded?.({ lamports: fundedLamports, signature });
+    }
   }
 
   const deployResult = resumeState
@@ -544,7 +634,7 @@ export async function runSessionKeyDeploy(
     throw new OwnershipTransferError(
       err instanceof Error ? err.message : String(err),
       deployResult,
-      sessionKeySecret
+      session.publicKey
     );
   }
   events.onOwnershipTransferred?.({

--- a/packages/deploy/src/session-key.ts
+++ b/packages/deploy/src/session-key.ts
@@ -1,0 +1,585 @@
+import {
+  Connection,
+  Keypair,
+  PublicKey,
+  SystemProgram,
+  Transaction,
+} from "@solana/web3.js";
+import {
+  BPF_LOADER_UPGRADEABLE_ID,
+  BUFFER_HEADER_SIZE,
+  CHUNK_SIZE,
+} from "./constants";
+import { estimateSessionKeyDeployCost } from "./cost";
+import {
+  confirmTx,
+  deployProgram,
+  getCachedBinaryLength,
+  priorityFeeIx,
+  resumeDeployment,
+  sendWithRetry,
+} from "./deploy";
+import {
+  createCloseBufferInstruction,
+  createSetAuthorityInstruction,
+} from "./instructions";
+import type {
+  DeploymentCallbacks,
+  DeploymentState,
+  DeployResult,
+  WalletAdapter,
+} from "./types";
+
+/**
+ * Deploying through a locally generated session key.
+ *
+ * An embedded (Dynamic) wallet signs through an MPC service, one network round
+ * trip per signature, rate-limited. A 74-chunk program is 76 signatures, which
+ * in production hit `WalletApiError: Rate limited` at chunk 3. So the embedded
+ * wallet signs exactly ONE transaction — a SystemProgram transfer of the
+ * estimated cost into a fresh keypair — and that keypair, held only in this
+ * browser tab, is payer and authority for the whole upload. When the deploy
+ * confirms, a Loader-v3 `SetAuthority` moves the upgrade authority to the
+ * learner (the new authority does not sign, so no second MPC signature), and
+ * the session key sweeps its remainder back.
+ *
+ * The learner still pays every lamport from their own wallet and still owns the
+ * program: `verifyProgramDeployment` on the server keeps requiring
+ * `upgrade_authority == profiles.wallet_address`, and only the SetAuthority
+ * makes that true.
+ */
+
+/** Base fee for the single-signature sweep transaction. */
+const SWEEP_FEE_LAMPORTS = 5_000;
+
+/** How long to wait for the learner's funding transfer to land. */
+const FUNDING_TIMEOUT_MS = 90_000;
+const FUNDING_POLL_MS = 1_500;
+
+/** Attempts for `SetAuthority`, which must succeed or the deploy is unowned. */
+const AUTHORITY_ATTEMPTS = 4;
+const AUTHORITY_BACKOFF_MS = 1_000;
+
+const BUFFER_STATE_TAG = 1;
+/** Buffer layout: tag(u32) | Option flag(u8) | authority(32). */
+const BUFFER_AUTHORITY_OPTION_OFFSET = 4;
+const BUFFER_AUTHORITY_OFFSET = 5;
+
+export interface SessionKeyEvents {
+  /**
+   * The session key exists, before a single lamport moves. Callers persist the
+   * secret HERE — a crash between the transfer and the first write would
+   * otherwise strand the funds with no key to spend them.
+   */
+  onSessionKey?: (secret: number[], publicKey: PublicKey) => void;
+  onFunded?: (info: { lamports: number; signature: string }) => void;
+  onOwnershipTransferred?: (info: {
+    signature: string;
+    newAuthority: PublicKey;
+  }) => void;
+  onRefunded?: (info: { signature: string; lamports: number }) => void;
+  onRefundFailed?: (info: { sessionKey: PublicKey; message: string }) => void;
+}
+
+export interface SessionKeyDeployParams {
+  connection: Connection;
+  /** The learner's wallet: funds the session key, ends up owning the program. */
+  learner: PublicKey;
+  buildUuid: string;
+  /**
+   * Sign and send the funding transfer from the learner's wallet, returning its
+   * signature. This is the ONE transaction the embedded wallet signs.
+   */
+  fund: (lamports: number, to: PublicKey) => Promise<string>;
+  callbacks: DeploymentCallbacks;
+  programKeypairSecret?: number[];
+  /** Session-key secret from a paused deploy; a new key is generated without it. */
+  persistedSessionKey?: number[] | null;
+  /** Deployment state from a paused deploy — set together with the key. */
+  resumeState?: DeploymentState | null;
+  events?: SessionKeyEvents;
+}
+
+export interface SessionKeyDeployResult extends DeployResult {
+  sessionKeySecret: number[];
+  /** 0 on a resume, which reuses the transfer the first attempt already made. */
+  fundedLamports: number;
+  authoritySignature: string;
+  refundLamports: number;
+  /** Set when the sweep failed; the deploy itself is complete regardless. */
+  refundError: string | null;
+}
+
+/**
+ * The session key as a `WalletAdapter`, signing locally.
+ *
+ * `signAllTransactions` has no batch ceiling here: the reason a batch is capped
+ * at all is remote-signer latency against the shared blockhash, and a
+ * `partialSign` costs microseconds.
+ */
+export function keypairSigner(keypair: Keypair): WalletAdapter {
+  return {
+    publicKey: keypair.publicKey,
+    signTransaction: async (tx) => {
+      tx.partialSign(keypair);
+      return tx;
+    },
+    signAllTransactions: async (txs) => {
+      for (const tx of txs) tx.partialSign(keypair);
+      return txs;
+    },
+  };
+}
+
+/**
+ * The learner's one transaction: move `lamports` into the session key.
+ *
+ * Built here rather than at the call site so the payer can never drift from
+ * the learner — the fee, like the funds, is theirs.
+ */
+export function createFundingTransfer(params: {
+  learner: PublicKey;
+  sessionKey: PublicKey;
+  lamports: number;
+  blockhash: string;
+}): Transaction {
+  const tx = new Transaction().add(
+    SystemProgram.transfer({
+      fromPubkey: params.learner,
+      toPubkey: params.sessionKey,
+      lamports: params.lamports,
+    })
+  );
+  tx.feePayer = params.learner;
+  tx.recentBlockhash = params.blockhash;
+  return tx;
+}
+
+/**
+ * Raised when the deploy landed but the upgrade authority is still the session
+ * key. The program is on-chain and paid for; the panel offers "claim
+ * ownership", which re-runs only `transferProgramAuthority`, so the fields it
+ * needs travel with the error.
+ */
+export class OwnershipTransferError extends Error {
+  constructor(
+    message: string,
+    readonly deployResult: DeployResult,
+    readonly sessionKeySecret: number[]
+  ) {
+    super(message);
+    this.name = "OwnershipTransferError";
+  }
+}
+
+function toKeypair(secret: number[]): Keypair {
+  return Keypair.fromSecretKey(Uint8Array.from(secret));
+}
+
+function sameBytes(a: number[], b: number[]): boolean {
+  return a.length === b.length && a.every((byte, i) => byte === b[i]);
+}
+
+/**
+ * Is this saved state safe to resume into?
+ *
+ * Saved state comes back from `sessionStorage`, which anything running in the
+ * origin can write. Resuming replays rent-paying transactions against whatever
+ * accounts the state names, so a crafted state is a way to make a learner fund
+ * an attacker's buffer or, worse, deploy the lesson's binary to an attacker's
+ * program id. Every field that names an account is therefore checked against
+ * something this session already knows: the build it belongs to, and the
+ * program keypair the build server injected via `declare_id!`.
+ */
+export function isResumableDeploymentState(
+  state: unknown,
+  expected: { buildUuid: string; programKeypairSecret?: number[] }
+): state is DeploymentState {
+  if (typeof state !== "object" || state === null) return false;
+  const candidate = state as Partial<DeploymentState>;
+
+  if (candidate.buildUuid !== expected.buildUuid) return false;
+  if (
+    typeof candidate.totalChunks !== "number" ||
+    candidate.totalChunks <= 0 ||
+    !Number.isInteger(candidate.totalChunks)
+  ) {
+    return false;
+  }
+  if (
+    typeof candidate.lastUploadedChunk !== "number" ||
+    !Number.isInteger(candidate.lastUploadedChunk) ||
+    candidate.lastUploadedChunk < -1 ||
+    candidate.lastUploadedChunk >= candidate.totalChunks
+  ) {
+    return false;
+  }
+
+  const cachedLen = getCachedBinaryLength(expected.buildUuid);
+  if (
+    cachedLen !== null &&
+    candidate.totalChunks !== Math.ceil(cachedLen / CHUNK_SIZE)
+  ) {
+    return false;
+  }
+
+  if (
+    !isKeypairSecret(candidate.bufferKeypairSecret) ||
+    !isKeypairSecret(candidate.programKeypairSecret)
+  ) {
+    return false;
+  }
+
+  // The deployed address must be the one `declare_id!()` was compiled with, so
+  // a swapped program keypair — the crafted state that would hand the deploy to
+  // someone else's program id — cannot be resumed into.
+  if (
+    expected.programKeypairSecret &&
+    !sameBytes(candidate.programKeypairSecret, expected.programKeypairSecret)
+  ) {
+    return false;
+  }
+
+  return (
+    candidate.phase === "buffer_created" ||
+    candidate.phase === "uploading" ||
+    candidate.phase === "finalizing" ||
+    candidate.phase === "complete"
+  );
+}
+
+function isKeypairSecret(value: unknown): value is number[] {
+  if (!Array.isArray(value) || value.length !== 64) return false;
+  if (!value.every((b) => Number.isInteger(b) && b >= 0 && b <= 255)) {
+    return false;
+  }
+  try {
+    Keypair.fromSecretKey(Uint8Array.from(value));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Refuse to resume into a buffer this session key cannot write to.
+ *
+ * The state check above proves the buffer secret is well-formed; this proves
+ * the on-chain account it names is a loader buffer whose authority is our
+ * session key. Without it a crafted state could point the resume at a foreign
+ * buffer and burn the learner's fees on writes that can only fail.
+ */
+export async function assertSessionOwnsBuffer(
+  connection: Connection,
+  buffer: PublicKey,
+  sessionKey: PublicKey
+): Promise<void> {
+  const info = await connection.getAccountInfo(buffer, {
+    dataSlice: { offset: 0, length: BUFFER_HEADER_SIZE },
+  });
+  if (!info) {
+    throw new Error(
+      "Buffer account no longer exists. Please start a new deployment."
+    );
+  }
+  const data = Buffer.from(info.data);
+  if (
+    !info.owner.equals(BPF_LOADER_UPGRADEABLE_ID) ||
+    data.length < BUFFER_HEADER_SIZE ||
+    data.readUInt32LE(0) !== BUFFER_STATE_TAG ||
+    data[BUFFER_AUTHORITY_OPTION_OFFSET] !== 1
+  ) {
+    throw new Error("Saved deployment does not point at a usable buffer.");
+  }
+  const authority = new PublicKey(
+    data.subarray(BUFFER_AUTHORITY_OFFSET, BUFFER_AUTHORITY_OFFSET + 32)
+  );
+  if (!authority.equals(sessionKey)) {
+    throw new Error("Saved deployment points at a buffer this key cannot use.");
+  }
+}
+
+/** Wait for the learner's transfer to leave the session key spendable. */
+async function waitForFunding(
+  connection: Connection,
+  signature: string,
+  sessionKey: PublicKey,
+  requiredLamports: number,
+  timeoutMs = FUNDING_TIMEOUT_MS
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const { value } = await connection.getSignatureStatuses([signature]);
+    const status = value[0];
+    if (status?.err) {
+      throw new Error(`Funding transfer failed: ${JSON.stringify(status.err)}`);
+    }
+    if (
+      status?.confirmationStatus === "confirmed" ||
+      status?.confirmationStatus === "finalized"
+    ) {
+      const balance = await connection.getBalance(sessionKey, "confirmed");
+      if (balance >= requiredLamports) return;
+      throw new Error(
+        `Funding transfer landed short: ${balance} of ${requiredLamports} lamports.`
+      );
+    }
+    if (Date.now() > deadline) {
+      throw new Error("Timed out waiting for the funding transfer to confirm.");
+    }
+    await new Promise((r) => setTimeout(r, FUNDING_POLL_MS));
+  }
+}
+
+async function sendLocal(
+  connection: Connection,
+  tx: Transaction,
+  signer: Keypair
+): Promise<string> {
+  const { blockhash, lastValidBlockHeight } =
+    await connection.getLatestBlockhash("confirmed");
+  tx.feePayer = signer.publicKey;
+  tx.recentBlockhash = blockhash;
+  tx.sign(signer);
+  const signature = await sendWithRetry(connection, tx.serialize());
+  await confirmTx(connection, signature, blockhash, lastValidBlockHeight);
+  return signature;
+}
+
+/**
+ * Hand the program's upgrade authority to `newAuthority`.
+ *
+ * Retried with backoff: until this lands the learner does not own what they
+ * paid for, and `/api/deploy/save` will refuse the record.
+ */
+export async function transferProgramAuthority(params: {
+  connection: Connection;
+  sessionKeySecret: number[];
+  programId: PublicKey;
+  newAuthority: PublicKey;
+  attempts?: number;
+}): Promise<string> {
+  const { connection, programId, newAuthority } = params;
+  const session = toKeypair(params.sessionKeySecret);
+  const attempts = params.attempts ?? AUTHORITY_ATTEMPTS;
+
+  const [programData] = PublicKey.findProgramAddressSync(
+    [programId.toBuffer()],
+    BPF_LOADER_UPGRADEABLE_ID
+  );
+
+  let lastError: unknown = null;
+  for (let attempt = 0; attempt < attempts; attempt++) {
+    try {
+      const tx = new Transaction().add(
+        priorityFeeIx(),
+        createSetAuthorityInstruction(
+          programData,
+          session.publicKey,
+          newAuthority
+        )
+      );
+      return await sendLocal(connection, tx, session);
+    } catch (err) {
+      lastError = err;
+      if (attempt < attempts - 1) {
+        await new Promise((r) =>
+          setTimeout(r, AUTHORITY_BACKOFF_MS * 2 ** attempt)
+        );
+      }
+    }
+  }
+  throw lastError instanceof Error
+    ? lastError
+    : new Error(String(lastError ?? "SetAuthority failed"));
+}
+
+/**
+ * Return whatever the session key still holds to `destination`, keeping back
+ * only this transaction's own fee. Null when there is nothing worth sending.
+ */
+export async function sweepSessionKey(params: {
+  connection: Connection;
+  sessionKeySecret: number[];
+  destination: PublicKey;
+}): Promise<{ signature: string; lamports: number } | null> {
+  const { connection, destination } = params;
+  const session = toKeypair(params.sessionKeySecret);
+
+  const balance = await connection.getBalance(session.publicKey, "confirmed");
+  const lamports = balance - SWEEP_FEE_LAMPORTS;
+  if (lamports <= 0) return null;
+
+  const tx = new Transaction().add(
+    SystemProgram.transfer({
+      fromPubkey: session.publicKey,
+      toPubkey: destination,
+      lamports,
+    })
+  );
+  const signature = await sendLocal(connection, tx, session);
+  return { signature, lamports };
+}
+
+/**
+ * Abandon a paused session-key deploy: close the buffer (rent refunded to the
+ * session key, which paid it) and sweep the key back to the learner. What is
+ * left after this is a session key worth nothing, safe to discard.
+ */
+export async function startOverSessionKey(params: {
+  connection: Connection;
+  sessionKeySecret: number[];
+  bufferKeypairSecret?: number[] | null;
+  destination: PublicKey;
+}): Promise<{
+  closeSignature: string | null;
+  refund: { signature: string; lamports: number } | null;
+}> {
+  const { connection, destination } = params;
+  const session = toKeypair(params.sessionKeySecret);
+
+  let closeSignature: string | null = null;
+  if (params.bufferKeypairSecret) {
+    const buffer = toKeypair(params.bufferKeypairSecret);
+    const info = await connection.getAccountInfo(buffer.publicKey);
+    if (info) {
+      const tx = new Transaction().add(
+        createCloseBufferInstruction(
+          buffer.publicKey,
+          session.publicKey,
+          session.publicKey
+        )
+      );
+      closeSignature = await sendLocal(connection, tx, session);
+    }
+  }
+
+  const refund = await sweepSessionKey({
+    connection,
+    sessionKeySecret: params.sessionKeySecret,
+    destination,
+  });
+  return { closeSignature, refund };
+}
+
+/**
+ * The whole embedded-wallet deploy: fund a session key with one remote
+ * signature, upload and deploy locally, hand ownership to the learner, sweep.
+ */
+export async function runSessionKeyDeploy(
+  params: SessionKeyDeployParams
+): Promise<SessionKeyDeployResult> {
+  const {
+    connection,
+    learner,
+    buildUuid,
+    fund,
+    callbacks,
+    programKeypairSecret,
+    resumeState = null,
+    events = {},
+  } = params;
+
+  const session = params.persistedSessionKey
+    ? toKeypair(params.persistedSessionKey)
+    : Keypair.generate();
+  const sessionKeySecret = Array.from(session.secretKey);
+  events.onSessionKey?.(sessionKeySecret, session.publicKey);
+
+  const wallet = keypairSigner(session);
+
+  let fundedLamports = 0;
+  if (resumeState) {
+    // A resume is only allowed to continue the buffer this key already owns.
+    await assertSessionOwnsBuffer(
+      connection,
+      toKeypair(resumeState.bufferKeypairSecret).publicKey,
+      session.publicKey
+    );
+  } else {
+    const programLen = getCachedBinaryLength(buildUuid);
+    if (programLen === null) {
+      throw new Error(
+        "The compiled program is no longer available in this session (the build expired). Please rebuild it before deploying."
+      );
+    }
+    const estimate = await estimateSessionKeyDeployCost(connection, programLen);
+    const signature = await fund(estimate.totalLamports, session.publicKey);
+    await waitForFunding(
+      connection,
+      signature,
+      session.publicKey,
+      estimate.totalLamports
+    );
+    fundedLamports = estimate.totalLamports;
+    events.onFunded?.({ lamports: fundedLamports, signature });
+  }
+
+  const deployResult = resumeState
+    ? await resumeDeployment({
+        connection,
+        wallet,
+        buildServerUrl: "",
+        state: resumeState,
+        callbacks,
+      })
+    : await deployProgram({
+        connection,
+        wallet,
+        buildServerUrl: "",
+        buildUuid,
+        callbacks,
+        programKeypairSecret,
+      });
+
+  let authoritySignature: string;
+  try {
+    authoritySignature = await transferProgramAuthority({
+      connection,
+      sessionKeySecret,
+      programId: deployResult.programIdPubkey,
+      newAuthority: learner,
+    });
+  } catch (err) {
+    throw new OwnershipTransferError(
+      err instanceof Error ? err.message : String(err),
+      deployResult,
+      sessionKeySecret
+    );
+  }
+  events.onOwnershipTransferred?.({
+    signature: authoritySignature,
+    newAuthority: learner,
+  });
+
+  // The refund is the one step allowed to fail without failing the deploy: the
+  // program is live and owned by the learner either way.
+  let refundLamports = 0;
+  let refundError: string | null = null;
+  try {
+    const refund = await sweepSessionKey({
+      connection,
+      sessionKeySecret,
+      destination: learner,
+    });
+    if (refund) {
+      refundLamports = refund.lamports;
+      events.onRefunded?.(refund);
+    }
+  } catch (err) {
+    refundError = err instanceof Error ? err.message : String(err);
+    events.onRefundFailed?.({
+      sessionKey: session.publicKey,
+      message: refundError,
+    });
+  }
+
+  return {
+    ...deployResult,
+    sessionKeySecret,
+    fundedLamports,
+    authoritySignature,
+    refundLamports,
+    refundError,
+  };
+}


### PR DESCRIPTION
Implements the session-key addendum of the deploy design (#1227) so an embedded-wallet learner can finish the deployable lesson from #1220: the wallet signs one transaction — a transfer of `estimateSessionKeyDeployCost` into a keypair generated in the tab — and that key is payer and authority for the buffer, the writes and the finalize, all signed locally with no batch ceiling. Immediately after the deploy confirms, a Loader v3 `SetAuthority` (variant 4, new authority non-signing) moves the upgrade authority to the learner, so `verifyProgramDeployment` and `/api/deploy/save` keep attributing the program exactly as today, and the session key then sweeps its balance minus the sweep fee back to the learner. The secret is persisted in the wallet-scoped sessionStorage record under AES-GCM with an HKDF key derived from a per-page-load nonce plus the buildUuid, so resume continues from the saved offset with the same key and no second transfer; the threat model (a storage dump, not code on the page) is documented on the module. Start over closes the buffer to the session key and sweeps before regenerating, a failed `SetAuthority` is retried with backoff and otherwise surfaces a "claim ownership" button that re-runs only that step, and a failed refund is a non-blocking warning with a retry.

Saved state is validated before any resume — build id, offset bounds, chunk count against the cached binary, well-formed keypair secrets, the program keypair matching this build's `declare_id!` injection, and the on-chain buffer's authority being the session key — so a crafted sessionStorage record cannot make a learner pay into a foreign buffer or deploy to someone else's program id. The adapter path is untouched: extension wallets still sign their own batches at the existing batch size.

Tests: 34 in `packages/deploy` (funding amount equals the estimate and the helper is called once, every chunk and finalize tx signed by the session key, SetAuthority accounts and new authority, sweep amount, resume reuses key and offset, start over closes then sweeps, crafted-state rejection) and 128 across `src/hooks src/components/deploy src/lib/dynamic src/lib/deploy` including the encryption round trip and the panel's one-signature funding path. `vitest.setup.ts` restores Node's `Uint8Array` under jsdom, without which every web3.js instruction encode in a component test fails with "b must be a Uint8Array". `tsc --noEmit` and lint are clean; the twelve PGlite suites that time out in a full parallel run pass individually and fail the same way on a clean tree.

Devnet: UNVERIFIED. This machine has no default `solana` keypair and the public devnet faucet refused every airdrop, so the end-to-end run is for the gate. What was verified locally is the artefact it would deploy: the lesson solution built with `cargo build-sbf --tools-version v1.54` against `apps/build-server/programs` is 66,704 bytes — 75 chunks, the size that produced the rate-limit failure this PR removes.

Expect a small conflict with the MPC-backoff/airdrop-RPC branch; this PR touches neither `airdrop.ts` nor the retry logic in `signAllWithDynamicWallet`.
