### PR TITLE
fix(deploy): keep the stranded-key notice across mounts, gate Deploy on the key restore, fail closed on funding checks

### DIFF
--- a/apps/web/src/components/deploy/__tests__/deploy-panel-signer.test.tsx
+++ b/apps/web/src/components/deploy/__tests__/deploy-panel-signer.test.tsx
@@ -14,6 +14,7 @@ import {
   PublicKey,
   SystemInstruction,
 } from "@solana/web3.js";
+import { FundingCheckError } from "@superteam-lms/deploy";
 import { EMBEDDED_BATCH_SIZE } from "@/hooks/use-deploy-signer";
 import messages from "@/messages/en.json";
 import { encryptSessionKey } from "@/lib/deploy/session-key-storage";
@@ -44,6 +45,7 @@ const h = vi.hoisted(() => ({
   balanceLamports: 0,
   trackEvent: vi.fn(),
   isSessionExpired: vi.fn(() => false),
+  holdDecrypt: null as Promise<void> | null,
 }));
 
 vi.mock("@/hooks/use-deploy-signer", async (importOriginal) => ({
@@ -97,6 +99,22 @@ vi.mock("@superteam-lms/deploy", async (importOriginal) => ({
   estimateSessionKeyDeployCost: h.estimateDeployCost,
   createAirdropRequest: vi.fn(async () => ({ success: false, error: "no" })),
 }));
+
+// The decrypt is what Deploy waits on. `h.holdDecrypt` lets a test park it
+// mid-flight and click the button while the saved key is still unread.
+vi.mock("@/lib/deploy/session-key-storage", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/lib/deploy/session-key-storage")>();
+  return {
+    ...actual,
+    decryptSessionKey: async (
+      ...args: Parameters<typeof actual.decryptSessionKey>
+    ) => {
+      if (h.holdDecrypt) await h.holdDecrypt;
+      return actual.decryptSessionKey(...args);
+    },
+  };
+});
 
 vi.mock("@/lib/gamification/celebration", () => ({ celebrate: vi.fn() }));
 vi.mock("@/lib/analytics", () => ({ trackEvent: h.trackEvent }));
@@ -161,6 +179,7 @@ beforeEach(() => {
   h.trackEvent.mockReset();
   h.isSessionExpired.mockReset();
   h.isSessionExpired.mockReturnValue(false);
+  h.holdDecrypt = null;
   localStorage.clear();
   sessionStorage.clear();
   vi.stubGlobal(
@@ -322,21 +341,76 @@ describe("DeployPanel — signer resolution", () => {
       refundError: null,
     });
     renderPanel();
-    // The panel keeps the key and drops the (absent) offset — that rewrite is
-    // how we know the restore has run.
-    await waitFor(() =>
-      expect(
-        sessionStorage.getItem(`deploy-state-${EMBEDDED.slice(0, 8)}-${BUILD}`)
-      ).toContain('"deployment":null')
-    );
-    fireEvent.click(
-      await screen.findByRole("button", { name: "Deploy to Devnet" })
-    );
+    // Deploy stays disabled until the saved key has been decrypted back into
+    // the panel — clicking before that would generate a fresh key over the one
+    // holding the learner's SOL. Waiting for the enabled button is the barrier.
+    const deploy = await screen.findByRole("button", {
+      name: "Deploy to Devnet",
+    });
+    await waitFor(() => expect(deploy).toBeEnabled());
+    expect(
+      sessionStorage.getItem(`deploy-state-${EMBEDDED.slice(0, 8)}-${BUILD}`)
+    ).toContain('"deployment":null');
+    fireEvent.click(deploy);
 
     await waitFor(() => expect(h.runSessionKeyDeploy).toHaveBeenCalledTimes(1));
     const retry = h.runSessionKeyDeploy.mock.calls[0]![0];
     expect(retry.persistedSessionKey).toEqual(secret);
     expect(retry.pendingFundingSignature).toBe("first-fund-sig");
+  });
+
+  it("will not deploy while the saved key is still being read back", async () => {
+    const secret = Array.from(Keypair.generate().secretKey);
+    sessionStorage.setItem(
+      `deploy-state-${EMBEDDED.slice(0, 8)}-${BUILD}`,
+      JSON.stringify({
+        deployment: null,
+        session: await encryptSessionKey(secret, BUILD),
+        sessionAddress: "SessionKeyAddress",
+        fundingSignature: "first-fund-sig",
+      })
+    );
+    let release = () => {};
+    h.holdDecrypt = new Promise<void>((resolve) => {
+      release = () => resolve();
+    });
+    renderPanel();
+
+    // Clicking here would fund a SECOND key over the one that already holds
+    // the learner's SOL, so the button refuses until the decrypt lands.
+    const button = await screen.findByRole("button", {
+      name: "Checking your wallet…",
+    });
+    expect(button).toBeDisabled();
+    fireEvent.click(button);
+    expect(h.runSessionKeyDeploy).not.toHaveBeenCalled();
+
+    release();
+    const deploy = await screen.findByRole("button", {
+      name: "Deploy to Devnet",
+    });
+    fireEvent.click(deploy);
+    await waitFor(() => expect(h.runSessionKeyDeploy).toHaveBeenCalledTimes(1));
+    expect(h.runSessionKeyDeploy.mock.calls[0]![0].persistedSessionKey).toEqual(
+      secret
+    );
+  });
+
+  it("offers a retry, not a second transfer, when the funding check can't answer", async () => {
+    h.runSessionKeyDeploy.mockRejectedValueOnce(
+      new FundingCheckError("rpc-error")
+    );
+    renderPanel();
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Deploy to Devnet" })
+    );
+
+    expect(
+      await screen.findByText(/didn't send another one/i)
+    ).toBeInTheDocument();
+    fireEvent.click(await screen.findByRole("button", { name: "Try again" }));
+    await waitFor(() => expect(h.runSessionKeyDeploy).toHaveBeenCalledTimes(2));
   });
 
   it("takes the mismatch check from the signer's key, not the adapter's", async () => {
@@ -498,6 +572,51 @@ describe("DeployPanel — session-key resume and start over", () => {
       session: null,
       sessionAddress: "StrandedSessionKeyAddress",
     });
+
+    // Every reload after that, too: the pruned record has no session left to
+    // decrypt, and the restore must keep reading it as a stranded key rather
+    // than as junk to delete.
+    for (let reload = 0; reload < 2; reload++) {
+      cleanup();
+      renderPanel();
+      expect(await screen.findByRole("alert")).toHaveTextContent(
+        "StrandedSessionKeyAddress"
+      );
+      expect(
+        JSON.parse(
+          sessionStorage.getItem(
+            `deploy-state-${EMBEDDED.slice(0, 8)}-${BUILD}`
+          )!
+        )
+      ).toMatchObject({
+        session: null,
+        sessionAddress: "StrandedSessionKeyAddress",
+      });
+    }
+
+    // It goes when there is a key to replace it with: a new deploy reports its
+    // session key, and the record now names an address that CAN be signed with.
+    h.runSessionKeyDeploy.mockImplementation(
+      async (params: {
+        events: {
+          onSessionKey: (s: number[], k: PublicKey) => Promise<void> | void;
+        };
+      }) => {
+        await params.events.onSessionKey(
+          Array.from(Keypair.generate().secretKey),
+          Keypair.generate().publicKey
+        );
+        throw new Error("stop here");
+      }
+    );
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Deploy to Devnet" })
+    );
+    await waitFor(() =>
+      expect(
+        screen.queryByText(/StrandedSessionKeyAddress/)
+      ).not.toBeInTheDocument()
+    );
   });
 
   it("warns before the transfer that a reload strands the funds", async () => {

--- a/apps/web/src/components/deploy/deploy-panel.tsx
+++ b/apps/web/src/components/deploy/deploy-panel.tsx
@@ -11,6 +11,7 @@ import {
   estimateSessionKeyDeployCost,
   getCachedBinaryLength,
   isResumableDeploymentState,
+  FundingCheckError,
   OwnershipTransferError,
   resumeDeployment,
   runSessionKeyDeploy,
@@ -198,6 +199,16 @@ export function DeployPanel({
   );
   const lostSessionAddressRef = useRef<string | null>(null);
   const [lostCopied, setLostCopied] = useState(false);
+  // Whether the saved session key has been read back yet. Deploy waits for it:
+  // clicking before the decrypt resolves would generate a fresh key over the
+  // one an earlier attempt already funded, and transfer a second time.
+  const [restoreStatus, setRestoreStatus] = useState<"pending" | "done">(
+    "pending"
+  );
+  // The funding check could not tell whether the learner's transfer landed, so
+  // nothing was sent. Offers a retry rather than a start over — the carried-over
+  // key is the whole point.
+  const [fundingCheckFailed, setFundingCheckFailed] = useState(false);
   // A start-over sweep that rejected. Held so "retry refund" has a key to
   // sweep WITH — `resetSession` runs before the sweep settles.
   const strandedSweepRef = useRef<{
@@ -503,8 +514,14 @@ export function DeployPanel({
   // is offered — and dropped, not repaired, when it fails.
   useEffect(() => {
     let cancelled = false;
+    const settle = () => {
+      if (!cancelled) setRestoreStatus("done");
+    };
     const stored = readDeployState(buildUuid, walletPrefix);
-    if (!stored) return;
+    if (!stored) {
+      settle();
+      return;
+    }
 
     const deployment = stored.deployment;
     const resumable =
@@ -516,59 +533,80 @@ export function DeployPanel({
       });
 
     // Dropped without waiting on the decrypt: a state that is neither
-    // resumable nor attached to a funded key has nothing worth reading.
+    // resumable nor attached to a funded key has nothing worth reading — with
+    // one exception. A record already pruned down to a stranded key's address
+    // (session null, address kept) is the only surviving record of where the
+    // learner's SOL went, and it has to outlive every later reload, not just
+    // the one that created it.
     if (!resumable && !(stored.session && stored.fundingSignature)) {
-      clearDeployState(buildUuid, walletPrefix);
-      return;
-    }
-
-    (async () => {
-      // No session key means the adapter path (or a reload that took the
-      // wrapping nonce with it): a session-key deploy cannot resume without it.
-      const secret = stored.session
-        ? await decryptSessionKey(stored.session, buildUuid)
-        : null;
-      if (cancelled) return;
-
-      // A reload. The key is unrecoverable, but it is where the learner's SOL
-      // went — so the record is kept down to its address, and shown, rather
-      // than deleted along with the only way to find the funds again.
-      if (stored.session && !secret) {
-        if (!stored.sessionAddress) {
-          clearDeployState(buildUuid, walletPrefix);
-          return;
-        }
+      if (!stored.session && stored.sessionAddress) {
         storedRef.current = {
           deployment: null,
           session: null,
           sessionAddress: stored.sessionAddress,
           fundingSignature: stored.fundingSignature,
         };
-        writeDeployState(buildUuid, walletPrefix, storedRef.current);
         rememberLostAddress(stored.sessionAddress);
+        settle();
         return;
       }
-      // Nothing to resume from — but a key with a funding signature against it
-      // is a key an earlier attempt may have paid into, and the offset is not
-      // what makes it worth keeping. Keep it (and only it, never the state that
-      // failed validation) so the next Deploy carries it over instead of
-      // transferring a second time.
-      if (!resumable) {
-        if (!secret) {
-          clearDeployState(buildUuid, walletPrefix);
+      clearDeployState(buildUuid, walletPrefix);
+      settle();
+      return;
+    }
+
+    // Deploy is gated on `settle`, so every branch below has to reach it.
+    void (async () => {
+      try {
+        // No session key means the adapter path (or a reload that took the
+        // wrapping nonce with it): a session-key deploy cannot resume without it.
+        const secret = stored.session
+          ? await decryptSessionKey(stored.session, buildUuid)
+          : null;
+        if (cancelled) return;
+
+        // A reload. The key is unrecoverable, but it is where the learner's SOL
+        // went — so the record is kept down to its address, and shown, rather
+        // than deleted along with the only way to find the funds again.
+        if (stored.session && !secret) {
+          if (!stored.sessionAddress) {
+            clearDeployState(buildUuid, walletPrefix);
+            return;
+          }
+          storedRef.current = {
+            deployment: null,
+            session: null,
+            sessionAddress: stored.sessionAddress,
+            fundingSignature: stored.fundingSignature,
+          };
+          writeDeployState(buildUuid, walletPrefix, storedRef.current);
+          rememberLostAddress(stored.sessionAddress);
+          return;
+        }
+        // Nothing to resume from — but a key with a funding signature against it
+        // is a key an earlier attempt may have paid into, and the offset is not
+        // what makes it worth keeping. Keep it (and only it, never the state that
+        // failed validation) so the next Deploy carries it over instead of
+        // transferring a second time.
+        if (!resumable) {
+          if (!secret) {
+            clearDeployState(buildUuid, walletPrefix);
+            return;
+          }
+          sessionSecretRef.current = secret;
+          setSessionAddress(stored.sessionAddress);
+          storedRef.current = { ...stored, deployment: null };
+          writeDeployState(buildUuid, walletPrefix, storedRef.current);
           return;
         }
         sessionSecretRef.current = secret;
         setSessionAddress(stored.sessionAddress);
-        storedRef.current = { ...stored, deployment: null };
-        writeDeployState(buildUuid, walletPrefix, storedRef.current);
-        return;
+        storedRef.current = stored;
+        setSavedState(deployment);
+        setPanelState("paused");
+      } finally {
+        settle();
       }
-      sessionSecretRef.current = secret;
-      setSessionAddress(stored.sessionAddress);
-      storedRef.current = stored;
-      setSavedState(deployment);
-      setPanelState("paused");
     })();
 
     return () => {
@@ -757,6 +795,7 @@ export function DeployPanel({
       setBatchInfo(null);
       setSessionExpired(false);
       setRefundFailed(false);
+      setFundingCheckFailed(false);
       setClaim(null);
       startTimeRef.current = Date.now();
       if (resume) {
@@ -858,6 +897,15 @@ export function DeployPanel({
           setSessionAddress(err.sessionKeyAddress.toBase58());
           setClaim(err.deployResult);
           setErrorMessage(t("ownershipFailed"));
+          setPanelState("paused");
+          return;
+        }
+        // The funding check could not say whether the earlier transfer landed,
+        // so nothing was sent and nothing is lost — the same key, and its
+        // pending signature, are still saved. This is a retry, not a failure.
+        if (err instanceof FundingCheckError) {
+          setFundingCheckFailed(true);
+          setErrorMessage(t("fundingCheckFailed"));
           setPanelState("paused");
           return;
         }
@@ -1005,6 +1053,9 @@ export function DeployPanel({
   // Deploy handler
   const handleDeploy = useCallback(async () => {
     if (!signer || needsFunding) return;
+    // The saved key is still being read back. Deploying now would generate a
+    // fresh one over a key an earlier attempt may have already funded.
+    if (restoreStatus === "pending") return;
     if (isEmbedded) {
       await runEmbedded(null);
       return;
@@ -1082,6 +1133,7 @@ export function DeployPanel({
     buildCallbacks,
     handleSuccess,
     isEmbedded,
+    restoreStatus,
     runEmbedded,
     t,
   ]);
@@ -1674,6 +1726,15 @@ export function DeployPanel({
           )}
 
           <div className="flex gap-2">
+            {fundingCheckFailed && (
+              <Button
+                onClick={handleDeploy}
+                className="flex-1"
+                disabled={!signer || restoreStatus === "pending"}
+              >
+                {t("retryFundingCheck")}
+              </Button>
+            )}
             {!isExpired && !claim && savedState && (
               <Button
                 onClick={handleResume}
@@ -1782,9 +1843,9 @@ export function DeployPanel({
           <Button
             onClick={handleDeploy}
             className="w-full bg-gradient-to-r from-solana-purple to-solana-green font-semibold text-white hover:opacity-90"
-            disabled={!signer || needsFunding}
+            disabled={!signer || needsFunding || restoreStatus === "pending"}
           >
-            {signerStatus === "resolving"
+            {signerStatus === "resolving" || restoreStatus === "pending"
               ? t("resolvingWallet")
               : needsFunding
                 ? t("insufficientSol", {

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -871,6 +871,8 @@
       "claimOwnership": "Claim ownership",
       "refundFailed": "The leftover SOL is still in the temporary key ({address}). The deploy is complete; you can retry the refund.",
       "retryRefund": "Retry refund",
+      "fundingCheckFailed": "We couldn't check whether your earlier transfer went through, so we didn't send another one — you have not been charged twice. Try again in a moment.",
+      "retryFundingCheck": "Try again",
       "sessionKeyLost": "This tab's temporary deploy key was lost when the page reloaded, so the upload can't be resumed and the SOL it still holds is stranded at {address}. Copy that address to recover the funds yourself; deploying again starts with a new key.",
       "copyAddress": "Copy address",
       "rateLimitWaiting": "Wallet service is busy (rate limited) — retrying in {seconds}s",

--- a/apps/web/src/messages/es.json
+++ b/apps/web/src/messages/es.json
@@ -871,6 +871,8 @@
       "claimOwnership": "Reclamar propiedad",
       "refundFailed": "El SOL restante sigue en la clave temporal ({address}). El despliegue está completo; puedes reintentar el reembolso.",
       "retryRefund": "Reintentar reembolso",
+      "fundingCheckFailed": "No pudimos comprobar si tu transferencia anterior se completó, así que no enviamos otra — no se te ha cobrado dos veces. Inténtalo de nuevo en un momento.",
+      "retryFundingCheck": "Intentar de nuevo",
       "sessionKeyLost": "La clave temporal de despliegue de esta pestaña se perdió al recargar la página, así que la subida no puede reanudarse y el SOL que aún tiene quedó atrapado en {address}. Copia esa dirección para recuperar los fondos por tu cuenta; un nuevo despliegue empieza con otra clave.",
       "copyAddress": "Copiar dirección",
       "rateLimitWaiting": "El servicio de la billetera está ocupado (límite de solicitudes) — reintentando en {seconds}s",

--- a/apps/web/src/messages/pt-BR.json
+++ b/apps/web/src/messages/pt-BR.json
@@ -871,6 +871,8 @@
       "claimOwnership": "Reivindicar propriedade",
       "refundFailed": "O SOL restante ainda está na chave temporária ({address}). O deploy está completo; você pode tentar o reembolso de novo.",
       "retryRefund": "Tentar reembolso de novo",
+      "fundingCheckFailed": "Não conseguimos verificar se a sua transferência anterior foi concluída, então não enviamos outra — você não pagou duas vezes. Tente de novo em instantes.",
+      "retryFundingCheck": "Tentar de novo",
       "sessionKeyLost": "A chave temporária de deploy desta aba se perdeu quando a página recarregou, então o envio não pode ser retomado e o SOL que ela ainda tem ficou preso em {address}. Copie esse endereço para recuperar os fundos por conta própria; um novo deploy começa com outra chave.",
       "copyAddress": "Copiar endereço",
       "rateLimitWaiting": "O serviço da carteira está ocupado (limite de requisições) — tentando de novo em {seconds}s",

--- a/packages/deploy/src/__tests__/session-key.test.ts
+++ b/packages/deploy/src/__tests__/session-key.test.ts
@@ -11,6 +11,7 @@ import { estimateSessionKeyDeployCost } from "../cost";
 import { setCachedBinary } from "../deploy";
 import {
   createFundingTransfer,
+  FundingCheckError,
   isResumableDeploymentState,
   OwnershipTransferError,
   runSessionKeyDeploy,
@@ -341,6 +342,63 @@ describe("runSessionKeyDeploy", () => {
 
     expect(fund).toHaveBeenCalledTimes(1);
     expect(result.fundedLamports).toBeGreaterThan(0);
+  });
+
+  it("does not re-fund when the status read itself fails", async () => {
+    setCachedBinary("uuid-status-error", BINARY);
+    const session = Keypair.generate();
+    const h = harness();
+    h.setBalance(0);
+    (
+      h.connection.getSignatureStatuses as ReturnType<typeof vi.fn>
+    ).mockRejectedValue(new Error("503 rate limited"));
+
+    const fund = vi.fn(async () => "second-fund-sig");
+    const error = await runSessionKeyDeploy({
+      connection: h.connection,
+      learner: Keypair.generate().publicKey,
+      buildUuid: "uuid-status-error",
+      fund,
+      callbacks: callbacks(),
+      persistedSessionKey: Array.from(session.secretKey),
+      pendingFundingSignature: "unreadable-sig",
+    }).catch((err: unknown) => err);
+
+    // A failed READ is not proof the transfer failed: it may have landed.
+    expect(error).toBeInstanceOf(FundingCheckError);
+    expect((error as FundingCheckError).reason).toBe("rpc-error");
+    expect(fund).not.toHaveBeenCalled();
+  });
+
+  it("does not re-fund a transfer still pending past the blockhash window", async () => {
+    setCachedBinary("uuid-status-pending", BINARY);
+    const session = Keypair.generate();
+    const h = harness();
+    h.setBalance(0);
+    (
+      h.connection.getSignatureStatuses as ReturnType<typeof vi.fn>
+    ).mockResolvedValue({ value: [null] });
+
+    const fund = vi.fn(async () => "second-fund-sig");
+    vi.useFakeTimers();
+    const pending = runSessionKeyDeploy({
+      connection: h.connection,
+      learner: Keypair.generate().publicKey,
+      buildUuid: "uuid-status-pending",
+      fund,
+      callbacks: callbacks(),
+      persistedSessionKey: Array.from(session.secretKey),
+      pendingFundingSignature: "slow-sig",
+    }).catch((err: unknown) => err);
+    // Past the ~90 s a blockhash stays valid for; the poll gives up, the
+    // learner does not pay twice.
+    await vi.advanceTimersByTimeAsync(95_000);
+    const error = await pending;
+    vi.useRealTimers();
+
+    expect(error).toBeInstanceOf(FundingCheckError);
+    expect((error as FundingCheckError).reason).toBe("still-pending");
+    expect(fund).not.toHaveBeenCalled();
   });
 
   it("reports a failed handover with the session ADDRESS, never its secret", async () => {

--- a/packages/deploy/src/index.ts
+++ b/packages/deploy/src/index.ts
@@ -21,6 +21,7 @@ export {
   assertSessionOwnsBuffer,
   keypairSigner,
   OwnershipTransferError,
+  FundingCheckError,
   type SessionKeyDeployParams,
   type SessionKeyDeployResult,
   type SessionKeyEvents,

--- a/packages/deploy/src/session-key.ts
+++ b/packages/deploy/src/session-key.ts
@@ -2,6 +2,7 @@ import {
   Connection,
   Keypair,
   PublicKey,
+  type SignatureStatus,
   SystemProgram,
   Transaction,
 } from "@solana/web3.js";
@@ -58,10 +59,11 @@ const FUNDING_POLL_MS = 1_500;
 
 /**
  * How long to wait on a funding signature left over from an attempt that threw.
- * Shorter than a fresh transfer: the point is to find out whether it landed, and
- * a signature the cluster has never heard of should not stall a retry.
+ * Long enough to outlive the blockhash it was signed with (~90 s): a transfer
+ * that is merely slow must not be declared lost while it can still land.
  */
-const PENDING_FUNDING_TIMEOUT_MS = 20_000;
+const PENDING_FUNDING_TIMEOUT_MS = 90_000;
+const PENDING_FUNDING_POLL_MS = 3_000;
 
 /** Attempts for `SetAuthority`, which must succeed or the deploy is unowned. */
 const AUTHORITY_ATTEMPTS = 4;
@@ -370,33 +372,73 @@ async function waitForFunding(
 /**
  * Does this session key already hold the deploy's cost?
  *
- * Two ways it can, both from an attempt that threw after the transfer was on
- * the wire: the balance is simply there, or a signature was persisted before
- * broadcast and the cluster confirms it landed. Either answer means the retry
- * must NOT transfer again. Anything else — no balance, an unknown or failed
- * signature — falls through to a fresh transfer.
+ * Three answers, not two. `"funded"` — the balance is there, or the persisted
+ * transfer confirmed — and `"failed"` — the transfer is on chain and errored —
+ * are both definitive, so the caller can transfer again on the second one. The
+ * third is the one that matters: when the check itself cannot answer (the RPC
+ * read failed, or the signature is still pending past the blockhash it was
+ * signed with) the transfer MIGHT have landed, and sending a second one would
+ * double the learner's bill. That fails closed into a retry.
  */
-async function isAlreadyFunded(
+type FundingCheck = "funded" | "failed";
+
+/** Thrown when the funding check could not tell whether the learner paid. */
+export class FundingCheckError extends Error {
+  readonly reason: "rpc-error" | "still-pending";
+
+  constructor(reason: "rpc-error" | "still-pending") {
+    super(
+      "Could not confirm the previous funding transfer, so no second transfer was sent."
+    );
+    this.name = "FundingCheckError";
+    this.reason = reason;
+  }
+}
+
+async function checkPendingFunding(
+  connection: Connection,
+  signature: string,
+  sessionKey: PublicKey,
+  requiredLamports: number
+): Promise<FundingCheck> {
+  const deadline = Date.now() + PENDING_FUNDING_TIMEOUT_MS;
+  for (;;) {
+    let status: SignatureStatus | null;
+    try {
+      const { value } = await connection.getSignatureStatuses([signature]);
+      status = value[0] ?? null;
+    } catch {
+      // The read failed, not the transfer.
+      throw new FundingCheckError("rpc-error");
+    }
+    if (status?.err) return "failed";
+    if (
+      status?.confirmationStatus === "confirmed" ||
+      status?.confirmationStatus === "finalized"
+    ) {
+      const balance = await connection.getBalance(sessionKey, "confirmed");
+      return balance >= requiredLamports ? "funded" : "failed";
+    }
+    if (Date.now() > deadline) throw new FundingCheckError("still-pending");
+    await new Promise((r) => setTimeout(r, PENDING_FUNDING_POLL_MS));
+  }
+}
+
+async function checkExistingFunding(
   connection: Connection,
   sessionKey: PublicKey,
   requiredLamports: number,
   pendingSignature: string | null
-): Promise<boolean> {
+): Promise<FundingCheck> {
   const balance = await connection.getBalance(sessionKey, "confirmed");
-  if (balance >= requiredLamports) return true;
-  if (!pendingSignature) return false;
-  try {
-    await waitForFunding(
-      connection,
-      pendingSignature,
-      sessionKey,
-      requiredLamports,
-      PENDING_FUNDING_TIMEOUT_MS
-    );
-    return true;
-  } catch {
-    return false;
-  }
+  if (balance >= requiredLamports) return "funded";
+  if (!pendingSignature) return "failed";
+  return checkPendingFunding(
+    connection,
+    pendingSignature,
+    sessionKey,
+    requiredLamports
+  );
 }
 
 async function sendLocal(
@@ -579,15 +621,15 @@ export async function runSessionKeyDeploy(
     // deploy they have already paid for. A key generated a line ago cannot be,
     // so it is not asked.
     const funded = params.persistedSessionKey
-      ? await isAlreadyFunded(
+      ? await checkExistingFunding(
           connection,
           session.publicKey,
           estimate.totalLamports,
           params.pendingFundingSignature ?? null
         )
-      : false;
+      : "failed";
 
-    if (!funded) {
+    if (funded === "failed") {
       const signature = await fund(
         estimate.totalLamports,
         session.publicKey,


### PR DESCRIPTION
Post-merge review of #1230's last commit found four holes in the session-key funds safety, all fixed here. The pruned reload record (session null, address kept) was wiped by the next mount's restore gate, so the only record of where a learner's SOL went survived exactly one reload; the restore now re-reads that shape as a stranded key. Deploy is gated on the restore completing — the panel test that was supposed to prove the carry-over waited on a storage string the first attempt had already written, and failed 5 runs in 6 because the click could beat the decrypt and fund a second key. The funding check now fails closed: an RPC error or a signature still pending past the blockhash window raises `FundingCheckError` instead of transferring again, and the panel offers a retry with the same key (pending ceiling 20s → 90s, polling every 3s).

packages/deploy 47/47; `vitest run src/components/deploy src/hooks src/lib/deploy` 102/102, five runs in a row, all green; tsc clean in both packages; lint leaves only the three pre-existing warnings.